### PR TITLE
fix(llm):fix ToolMessage

### DIFF
--- a/aworld/core/agent/llm_agent.py
+++ b/aworld/core/agent/llm_agent.py
@@ -187,13 +187,15 @@ class Agent(BaseAgent[Observation, List[ActionModel]]):
             messages.append({'role': 'system', 'content': sys_prompt if self.use_tools_in_prompt else sys_prompt.format(
                 tool_list=self.tools)})
 
-        if agent_prompt and '{task}' in agent_prompt:
-            content = agent_prompt.format(task=content)
+        histories = self.memory.get_last_n(self.history_messages)
+        user_content = content
+        if not histories and agent_prompt and '{task}' in agent_prompt:
+            user_content = agent_prompt.format(task=content)
 
-        cur_msg = {'role': 'user', 'content': content}
+        cur_msg = {'role': 'user', 'content': user_content}
         # query from memory,
         # histories = self.memory.get_last_n(self.history_messages, filter={"session_id": self.context.session_id})
-        histories = self.memory.get_last_n(self.history_messages)
+
         if histories:
             # default use the first tool call
             for history in histories:

--- a/aworld/core/agent/swarm.py
+++ b/aworld/core/agent/swarm.py
@@ -206,11 +206,9 @@ class Swarm(object):
                 res = Observation(content=policy_info)
             else:
                 res = observation[-1]
-                if res.content is None:
-                    res.content = ''
+                if not res.content:
+                    res.content = policy_info or ""
 
-                if policy_info:
-                    res.content += policy_info
             return res
         else:
             logger.warning(f"{strategy} not supported now.")


### PR DESCRIPTION
fix: optimize message and observation handling logic

- In llm_agent.py, only apply agent_prompt formatting when history is empty
- In swarm.py, only use policy_info when current observation content is empty

These changes prevent unnecessary content overwriting and ensure more predictable 
message transformation behavior.