### PR TITLE
Fix Windows installation and add missing numpy dependency

### DIFF
--- a/aworld/requirements.txt
+++ b/aworld/requirements.txt
@@ -16,3 +16,4 @@ fastapi
 aiohttp~=3.9.5
 click
 packaging
+numpy

--- a/setup.py
+++ b/setup.py
@@ -126,21 +126,26 @@ class AWorldInstaller(install):
 
     @staticmethod
     def _install_reqs(reqs, ignore_error=False, no_deps=False):
-        info = "--no-deps" if no_deps else ""
+        """
+        Install a list of requirements using pip.
+        Use argument lists (no shell) to avoid quoting issues on Windows (single quotes are literal).
+        """
+        base_cmd = [sys.executable, "-m", "pip", "install"]
+        if no_deps:
+            base_cmd.append("--no-deps")
         if ignore_error:
-            # install requirements one by one
+            # install requirements one by one so a failure doesn't stop the rest
             for req in reqs:
                 try:
-                    cmd = f"{sys.executable} -m pip install {info} '{req}'"
+                    cmd = base_cmd + [req]
                     call_process(cmd)
                     logger.info(f"Installing optional package {req} have succeeded.")
-                except:
+                except Exception:
                     logger.warning(
                         f"Installing optional package {req} is failed, Ignored."
                     )  # ignore
         elif reqs:
-            cmd_reqs = "'" + "' '".join(reqs) + "'"
-            cmd = f"{sys.executable} -m pip install {info} {cmd_reqs}"
+            cmd = base_cmd + list(reqs)
             call_process(cmd)
             logger.info(f"Packages {str(reqs)} have been installed.")
 


### PR DESCRIPTION
This PR fixes two issues:

Windows installation failure: Optional dependencies failed to install due to single quote parsing issues
Missing numpy dependency: Runtime import error when using aworld agents

1. Fix Windows Installation (setup.py)
Problem: On Windows, pip commands like pip install 'pydantic' failed with "Invalid requirement: 'pydantic" because Windows treats single quotes literally.

Solution: Changed from shell string commands to argument lists in AWorldInstaller._install_reqs():

```
# Before (problematic on Windows)
cmd = f"{sys.executable} -m pip install {info} '{req}'"
call_process(cmd)

# After (cross-platform safe)
base_cmd = [sys.executable, "-m", "pip", "install"]
if no_deps: base_cmd.append("--no-deps")
call_process(base_cmd + [req])
```


2. Add numpy to Framework Dependencies (aworld/requirements.txt)
Problem: ModuleNotFoundError: No module named 'numpy' when importing aworld agents because  aworld/utils/serialized_util.py imports numpy unconditionally.

Solution: Added numpy to the [framework] section in  aworld/requirements.txt.

Files Changed
 setup.py: Modified AWorldInstaller._install_reqs() method
 aworld/requirements.txt: Added numpy to framework dependencies