### PR TITLE
bugfix: agent config defaults to None, reading env vars instead. 

### DIFF
--- a/aworld/agents/llm_agent.py
+++ b/aworld/agents/llm_agent.py
@@ -125,8 +125,8 @@ class Agent(BaseAgent[Observation, List[ActionModel]]):
     """Basic agent for unified protocol within the framework."""
 
     def __init__(self,
-                 conf: Config,
                  name: str,
+                 conf: Config | None = None,
                  desc: str = None,
                  agent_id: str = None,
                  *,

--- a/aworld/core/agent/base.py
+++ b/aworld/core/agent/base.py
@@ -73,7 +73,7 @@ class BaseAgent(Generic[INPUT, OUTPUT]):
     def __init__(
         self,
         name: str,
-        conf: Union[Dict[str, Any], ConfigDict, AgentConfig, None],
+        conf: Union[Dict[str, Any], ConfigDict, AgentConfig, None] = None,
         desc: str = None,
         agent_id: str = None,
         *,


### PR DESCRIPTION
Fix the agent construction bug #389.

The `conf` argument is set to None explicitly. #342 handles the initialization strategy.

It works as expected with environment variables set.
```bash
LLM_BASE_URL=
LLM_API_KEY=
LLM_BASE_URL=
```