### PR TITLE
fix: 将llm_temperature转换为float类型修复LLMResponseError

### DIFF
--- a/aworld/agents/llm_agent.py
+++ b/aworld/agents/llm_agent.py
@@ -698,6 +698,7 @@ class Agent(BaseAgent[Observation, List[ActionModel]]):
 
         try:
             stream_mode = kwargs.get("stream", False)
+            float_temperature=float(self.conf.llm_config.llm_temperature)
             if stream_mode:
                 llm_response = ModelResponse(
                     id="", model="", content="", tool_calls=[])
@@ -705,7 +706,7 @@ class Agent(BaseAgent[Observation, List[ActionModel]]):
                     self.llm,
                     messages=messages,
                     model=self.model_name,
-                    temperature=self.conf.llm_config.llm_temperature,
+                    temperature=float_temperature,
                     tools=self.tools if not self.use_tools_in_prompt and self.tools else None,
                     stream=True
                 )
@@ -751,7 +752,7 @@ class Agent(BaseAgent[Observation, List[ActionModel]]):
                     self.llm,
                     messages=messages,
                     model=self.model_name,
-                    temperature=self.conf.llm_config.llm_temperature,
+                    temperature=float_temperature,
                     tools=self.tools if not self.use_tools_in_prompt and self.tools else None,
                     stream=kwargs.get("stream", False)
                 )


### PR DESCRIPTION
## 问题描述
当前代码会导致`LLMResponseError`，错误信息为：

`aworld/models/openai_provider.py", line 126, in postprocess_response
    raise LLMResponseError(
aworld.models.model_response.LLMResponseError: LLM Error (gpt-5): Panic detected, error: runtime error: invalid memory address or nil pointer dereference.. Response: ChatCompletion(id=None, choices=None, created=None, model=None, object=None, service_tier=None, system_fingerprint=None, usage=None, error={'message': 'Panic detected, error: runtime error: invalid memory address or nil pointer dereference.', 'type': 'new_api_panic'})  `


## 根本原因
在`aworld/agents/llm_agent.py`第755行，temperature参数`self.conf.llm_config.llm_temperature`直接传递而没有类型转换，在底层LLM中造成类型不匹配问题。

## 解决方案
在传递给LLM模型调用之前，将temperature值转换为`float()`。

## 更改内容
- 修改`aworld/agents/llm_agent.py`第701行使用`float(self.conf.llm_config.llm_temperature)`转换格式

## 测试
- [x] 验证修复解决了LLMResponseError
- [x] 确认现有功能没有影响


