### PR TITLE
docs(ModelResponse): add warning logs to ModelResponse

### DIFF
--- a/aworld/models/model_response.py
+++ b/aworld/models/model_response.py
@@ -200,11 +200,6 @@ class ModelResponse:
                 response
             )
 
-        message_content = message.content if hasattr(message, 'content') else ""
-        message_tool_calls = message.tool_calls if hasattr(message, 'tool_calls') else None
-        if not message_content and not message_tool_calls:
-            logger.warning(f"No content or tool calls found in response: {response}")
-
         # Extract usage information
         usage = {}
         if hasattr(response, 'usage'):
@@ -239,6 +234,11 @@ class ModelResponse:
         # Process tool calls
         processed_tool_calls = []
         raw_tool_calls = message.tool_calls if hasattr(message, 'tool_calls') else message_dict.get('tool_calls')
+
+        message_content = message.content if hasattr(message, 'content') else message.get('content') or ""
+        if not message_content and not raw_tool_calls:
+            logger.warning(f"No content or tool calls found in response: {response}")
+
         if raw_tool_calls:
             for tool_call in raw_tool_calls:
                 if isinstance(tool_call, dict):


### PR DESCRIPTION
Add warning logs when response.content and response.tool_calls are both empty.