### PR TITLE
refactor(context): make agent_info optional in add_task_node and get_…

### DIFF
--- a/aworld/core/context/amni/__init__.py
+++ b/aworld/core/context/amni/__init__.py
@@ -755,9 +755,9 @@ class ApplicationContext(AmniContext):
 
         # Record task relationship
         self.add_task_node(
-            caller_agent_info=self.agent_info,
             child_task_id=sub_context.task_id,
             parent_task_id=self.task_id,
+            caller_agent_info=self.agent_info,
             caller_id=self.agent_info.current_agent_id if self.agent_info and hasattr(self.agent_info, 'current_agent_id') else None
         )
 
@@ -1740,7 +1740,7 @@ class ApplicationContext(AmniContext):
         else:
             return await super().get_task_trajectory(task_id)
 
-    def add_task_node(self, caller_agent_info, child_task_id: str, parent_task_id: str, **kwargs):
+    def add_task_node(self, child_task_id: str, parent_task_id: str, caller_agent_info=None, **kwargs):
         """Record the relationship between child task and parent task.
         Delegate to root context.
         """
@@ -1748,6 +1748,6 @@ class ApplicationContext(AmniContext):
         if not agent_info:
             agent_info = self.agent_info
         if self.root != self:
-            self.root.add_task_node(agent_info, child_task_id, parent_task_id, **kwargs)
+            self.root.add_task_node(child_task_id, parent_task_id, caller_agent_info=agent_info, **kwargs)
         else:
-            super().add_task_node(agent_info, child_task_id, parent_task_id, **kwargs)
+            super().add_task_node(child_task_id, parent_task_id, caller_agent_info=agent_info, **kwargs)

--- a/aworld/core/context/base.py
+++ b/aworld/core/context/base.py
@@ -289,7 +289,7 @@ class Context:
         self._deep_copy(new_context)
         new_context.task_id = sub_task_id
         new_context.task_input = sub_task_content
-        self.add_task_node(self.agent_info, sub_task_id, self.task_id, **kwargs)
+        self.add_task_node(sub_task_id, self.task_id, caller_agent_info=self.agent_info, **kwargs)
         return new_context
 
     def merge_sub_context(self, sub_task_context: 'ApplicationContext', **kwargs):
@@ -485,7 +485,7 @@ class Context:
         agent_task_info = self.agent_info[agent_id][self.task_id]
         agent_task_info['step'] = agent_task_info.get('step', 0) + 1
 
-    def get_agent_step(self, agent_info: dict, agent_id: str, task_id: str = None):
+    def get_agent_step(self, agent_id: str, task_id: str = None, agent_info: dict = None):
         if not agent_info:
             agent_info = self.agent_info
         if not task_id:
@@ -806,7 +806,7 @@ class Context:
             trajectory = await self.trajectory_dataset.get_task_trajectory(task_id)
             return trajectory
 
-    def add_task_node(self, caller_agent_info: dict, child_task_id: str, parent_task_id: str, **kwargs):
+    def add_task_node(self, child_task_id: str, parent_task_id: str, caller_agent_info: dict = None, **kwargs):
         """Add a task node and its relationship to the task graph.
 
         Args:
@@ -824,7 +824,7 @@ class Context:
         caller_info = child_task_node.get("caller_info", {})
         caller_info.update({
             "agent_id": caller_id,
-            "agent_step": self.get_agent_step(agent_info, caller_id, parent_task_id)
+            "agent_step": self.get_agent_step(caller_id, task_id=parent_task_id, agent_info=agent_info)
         })
 
         self._task_graph[child_task_id].update({

--- a/aworld/dataset/trajectory_strategy.py
+++ b/aworld/dataset/trajectory_strategy.py
@@ -257,7 +257,7 @@ class DefaultTrajectoryStrategy(TrajectoryStrategy):
             self.task_agent_map[task_agent_id] = 0
         self.task_agent_map[task_agent_id] += 1
 
-        step = self.task_agent_map[task_agent_id]
+        step = message.context.get_agent_step(agent_id=agent_id, task_id=task_id, agent_info=message.context.agent_info)
         meta = ExpMeta(
             session_id=session_id,
             task_id=task_id,

--- a/aworld/utils/run_util.py
+++ b/aworld/utils/run_util.py
@@ -104,12 +104,8 @@ async def exec_agent(question: Any,
     if outputs:
         task.outputs = outputs
     if sub_task and kwargs.get("tool_call_id"):
-        context.add_task_node(context.agent_info, task.id, context.task_id, tool_call_id=kwargs.get("tool_call_id"))
+        context.add_task_node(task.id, context.task_id, caller_agent_info=context.agent_info, tool_call_id=kwargs.get("tool_call_id"))
     runners = await choose_runners([task])
-    async def _exec_agent(task: Task):
-        return await execute_runner(runners, run_conf=run_conf)
-
-    asyncio.create_task
     res = await execute_runner(runners, run_conf=run_conf)
     resp: TaskResponse = res.get(task.id)
     return resp


### PR DESCRIPTION
…agent_step

Both methods now accept None for agent_info parameter and fallback to self.agent_info, improving API flexibility and reducing redundant parameter passing.