### PR TITLE
Fix aworld-cli task lifecycle and persistence

### DIFF
--- a/aworld-cli/src/aworld_cli/commands/history.py
+++ b/aworld-cli/src/aworld_cli/commands/history.py
@@ -160,7 +160,7 @@ class HistoryCommand(Command):
         # Render table to string
         from io import StringIO
         string_buffer = StringIO()
-        temp_console = Console(file=string_buffer, force_terminal=True)
+        temp_console = Console(file=string_buffer, force_terminal=False, color_system=None)
         temp_console.print(table)
 
         output = string_buffer.getvalue()

--- a/aworld-cli/src/aworld_cli/commands/tasks.py
+++ b/aworld-cli/src/aworld_cli/commands/tasks.py
@@ -123,7 +123,9 @@ class TasksCommand(Command):
                 "running": ("▶", "blue"),
                 "completed": ("✓", "green"),
                 "failed": ("✗", "red"),
-                "cancelled": ("◼", "dim")
+                "cancelled": ("◼", "dim"),
+                "interrupted": ("⏸", "yellow"),
+                "timeout": ("⏱", "magenta"),
             }
             icon, color = status_icons.get(task.status, ("?", "white"))
             status_display = f"[{color}]{icon} {task.status}[/{color}]"
@@ -174,6 +176,10 @@ class TasksCommand(Command):
             summary_parts.append(f"[green]✓ {stats['completed']} completed[/green]")
         if stats['failed'] > 0:
             summary_parts.append(f"[red]✗ {stats['failed']} failed[/red]")
+        if stats['timeout'] > 0:
+            summary_parts.append(f"[magenta]⏱ {stats['timeout']} timeout[/magenta]")
+        if stats['interrupted'] > 0:
+            summary_parts.append(f"[yellow]⏸ {stats['interrupted']} interrupted[/yellow]")
         if stats['pending'] > 0:
             summary_parts.append(f"[yellow]⏳ {stats['pending']} pending[/yellow]")
         if stats['cancelled'] > 0:
@@ -183,7 +189,7 @@ class TasksCommand(Command):
 
         # Render table to string
         buffer = StringIO()
-        temp_console = RichConsole(file=buffer, force_terminal=True, width=120)
+        temp_console = RichConsole(file=buffer, force_terminal=False, color_system=None, width=120)
         temp_console.print(table)
         temp_console.print(summary)
 
@@ -220,7 +226,9 @@ class TasksCommand(Command):
             "running": "🔄",
             "completed": "✅",
             "failed": "❌",
-            "cancelled": "🚫"
+            "cancelled": "🚫",
+            "interrupted": "⏸️",
+            "timeout": "⏱️",
         }.get(task.status, "❓")
 
         # Build status display
@@ -259,12 +267,12 @@ class TasksCommand(Command):
             lines.append(f"\n[bold green]Result:[/bold green]\n{result_preview}")
 
         # Add error if failed
-        if task.status == "failed" and task.error:
+        if task.status in {"failed", "cancelled", "interrupted", "timeout"} and task.error:
             lines.append(f"\n[bold red]Error:[/bold red]\n{task.error}")
 
         # Render panel to string
         buffer = StringIO()
-        temp_console = RichConsole(file=buffer, force_terminal=True, width=120)
+        temp_console = RichConsole(file=buffer, force_terminal=False, color_system=None, width=120)
         panel = Panel(
             "\n".join(lines),
             title=f"📊 Task Status: {task_id}",

--- a/aworld-cli/src/aworld_cli/core/background_task_manager.py
+++ b/aworld-cli/src/aworld_cli/core/background_task_manager.py
@@ -360,7 +360,10 @@ class BackgroundTaskManager:
                 )
 
                 # Run with streaming (existing infrastructure)
-                streaming_outputs = Runners.streamed_run_task(task)
+                streaming_outputs = Runners.streamed_run_task(
+                    task,
+                    cancel_run_impl_task_on_cleanup=False,
+                )
                 metadata.streaming_outputs = streaming_outputs
 
                 # Track progress by consuming stream

--- a/aworld-cli/src/aworld_cli/core/background_task_manager.py
+++ b/aworld-cli/src/aworld_cli/core/background_task_manager.py
@@ -2,16 +2,19 @@
 Background task manager for aworld-cli.
 
 Manages session-level background tasks using asyncio and StreamingOutputs.
-All tasks are in-memory and cleared on CLI exit.
-Task outputs are persisted to files in .aworld/tasks/ directory.
+Task outputs and task metadata are persisted to .aworld/tasks/ directory.
 """
 import asyncio
+import json
+import os
+import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 from rich.console import Console
 
-from aworld.core.task import Task
+from aworld.core.common import TaskStatusValue
+from aworld.core.task import Task, TaskResponse
 from aworld.runner import Runners
 from aworld.logs.util import logger
 from aworld_cli.models.task_metadata import TaskMetadata
@@ -51,7 +54,9 @@ class BackgroundTaskManager:
         # Setup output directory for task logs
         self.output_dir = Path(output_dir or ".aworld/tasks")
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.metadata_file = self.output_dir / "tasks.json"
         logger.info(f"[BackgroundTaskManager] Output directory: {self.output_dir}")
+        self._load_persisted_tasks()
 
     def _get_task_output_path(self, task_id: str) -> Path:
         """
@@ -64,6 +69,183 @@ class BackgroundTaskManager:
             Path to output log file
         """
         return self.output_dir / f"{task_id}.log"
+
+    def _persist_tasks(self) -> None:
+        """
+        Persist task metadata to disk.
+        """
+        payload = {
+            "version": 1,
+            "session_id": self.session_id,
+            "task_counter": self._task_counter,
+            "updated_at": datetime.now().isoformat(),
+            "tasks": [task.to_dict() for task in self.list_tasks()],
+        }
+
+        temp_path = self.metadata_file.with_suffix(".json.tmp")
+        with open(temp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        os.replace(temp_path, self.metadata_file)
+
+    def _load_persisted_tasks(self) -> None:
+        """
+        Load persisted task metadata from disk.
+        """
+        if not self.metadata_file.exists():
+            return
+
+        try:
+            with open(self.metadata_file, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+
+            loaded_tasks = {}
+            max_task_index = -1
+            for raw_task in payload.get("tasks", []):
+                task = TaskMetadata.from_dict(raw_task)
+
+                # Background tasks are process-local. If the previous process exited while
+                # a task was pending/running, it cannot still be active after restart.
+                if task.status in {"pending", "running"}:
+                    task.status = "interrupted"
+                    task.error = task.error or "Task interrupted because aworld-cli exited or restarted"
+                    task.completed_at = task.completed_at or datetime.now()
+                    if task.output_file:
+                        self._append_restart_note(task)
+
+                self._load_output_buffer_from_log(task)
+                loaded_tasks[task.task_id] = task
+                max_task_index = max(max_task_index, TaskMetadata.parse_task_index(task.task_id))
+
+            self.tasks = loaded_tasks
+            persisted_counter = int(payload.get("task_counter", -1) or -1)
+            self._task_counter = max(persisted_counter, max_task_index + 1, 0)
+
+            # Save back immediately if we normalized stale statuses.
+            self._persist_tasks()
+            logger.info(f"[BackgroundTaskManager] Loaded {len(self.tasks)} persisted tasks")
+        except Exception as e:
+            logger.warning(
+                f"[BackgroundTaskManager] Failed to load persisted tasks: {e}\n{traceback.format_exc()}"
+            )
+
+    def _append_restart_note(self, task: TaskMetadata) -> None:
+        """
+        Append a note to the task log when a stale running task is recovered after restart.
+        """
+        try:
+            output_path = Path(task.output_file)
+            if not output_path.exists():
+                return
+
+            note = (
+                f"\n{'=' * 80}\n"
+                f"Status: interrupted\n"
+                f"Interrupted at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                f"Error: Task interrupted because aworld-cli exited or restarted\n"
+            )
+
+            with open(output_path, "rb") as f:
+                existing = f.read()
+                if b"Task interrupted because aworld-cli exited or restarted" in existing:
+                    return
+
+            with open(output_path, "a", encoding="utf-8") as f:
+                f.write(note)
+        except Exception as e:
+            logger.warning(f"[BackgroundTaskManager] Failed to append restart note: {e}")
+
+    def _load_output_buffer_from_log(self, task: TaskMetadata) -> None:
+        """
+        Rebuild in-memory output buffer from the persisted task log file.
+        """
+        if task.output_buffer:
+            return
+        if not task.output_file:
+            return
+
+        output_path = Path(task.output_file)
+        if not output_path.exists():
+            return
+
+        try:
+            lines = output_path.read_text(encoding="utf-8", errors="replace").splitlines()
+            relevant_lines = lines[-1000:]
+            base_date = (task.submitted_at or datetime.now()).date()
+            for line in relevant_lines:
+                if len(line) >= 11 and line[0] == "[" and line[9] == "]":
+                    time_part = line[1:9]
+                    try:
+                        timestamp = datetime.combine(base_date, datetime.strptime(time_part, "%H:%M:%S").time())
+                        content = line[11:] if len(line) > 11 else ""
+                        task.output_buffer.append((timestamp, content))
+                    except Exception:
+                        continue
+        except Exception as e:
+            logger.warning(f"[BackgroundTaskManager] Failed to load output buffer from log: {e}")
+
+    def _normalize_final_status(self, task_response) -> str:
+        """
+        Normalize AWorld TaskResponse status to CLI background task status.
+
+        Returns one of:
+        pending/running/completed/failed/cancelled/interrupted/timeout
+        """
+        if task_response is None:
+            return "failed"
+
+        status = getattr(task_response, "status", None)
+        success = getattr(task_response, "success", None)
+
+        if status == TaskStatusValue.CANCELLED:
+            return "cancelled"
+        if status == TaskStatusValue.INTERRUPTED:
+            return "interrupted"
+        if status == TaskStatusValue.TIMEOUT:
+            return "timeout"
+        if status == TaskStatusValue.FAILED:
+            return "failed"
+        if status == TaskStatusValue.RUNNING:
+            return "running"
+        if status in (TaskStatusValue.SUCCESS, "finished", "completed") and success is True:
+            return "completed"
+        if success is False:
+            return "failed"
+
+        return "failed"
+
+    async def _get_definitive_task_response(
+        self,
+        aworld_task_id: str,
+        streaming_outputs,
+    ) -> Optional[TaskResponse]:
+        """
+        Resolve the final AWorld TaskResponse from the underlying run task.
+
+        `StreamingOutputs.stream_events()` only reflects stream lifecycle. A stream can
+        end slightly before the producer coroutine fully returns, so `/dispatch` should
+        treat the underlying run result as source of truth for terminal state.
+        """
+        run_impl_task = getattr(streaming_outputs, "_run_impl_task", None)
+
+        if run_impl_task is not None:
+            run_result = await run_impl_task
+            if isinstance(run_result, dict):
+                task_response = run_result.get(aworld_task_id)
+                if task_response is not None:
+                    return task_response
+
+        task_response = streaming_outputs.response()
+        if task_response is not None:
+            return task_response
+
+        # Give mark_completed a brief chance to publish its final TaskResponse.
+        for _ in range(10):
+            await asyncio.sleep(0.05)
+            task_response = streaming_outputs.response()
+            if task_response is not None:
+                return task_response
+
+        return None
 
     async def submit_task(
         self,
@@ -107,6 +289,7 @@ class BackgroundTaskManager:
                 submitted_at=datetime.now()
             )
             self.tasks[task_id] = metadata
+            self._persist_tasks()
 
             # Submit to background
             asyncio_task = asyncio.create_task(
@@ -152,6 +335,7 @@ class BackgroundTaskManager:
         metadata = self.tasks[task_id]
         metadata.status = "running"
         metadata.started_at = datetime.now()
+        self._persist_tasks()
 
         # Setup output file
         output_path = self._get_task_output_path(task_id)
@@ -210,32 +394,51 @@ class BackgroundTaskManager:
                             if hasattr(output, 'name'):
                                 metadata.current_step = f"Step: {output.name}"
 
-                # Wait for completion and extract result
-                task_response = streaming_outputs.response()
-                if task_response and hasattr(task_response, 'answer'):
-                    metadata.result = task_response.answer
-                else:
-                    # Fallback: Try to get message output content
-                    try:
-                        metadata.result = streaming_outputs.get_message_output_content()
-                    except Exception:
-                        metadata.result = "Task completed (no result available)"
+                # Wait for the real underlying task completion and extract final status/result.
+                # Stream completion alone is not authoritative enough.
+                task_response = await self._get_definitive_task_response(task.id, streaming_outputs)
+                metadata.status = self._normalize_final_status(task_response)
 
-                metadata.status = "completed"
-                metadata.progress_percentage = 100.0
+                result_text = None
+                if task_response and hasattr(task_response, 'answer'):
+                    result_text = task_response.answer
+                if not result_text:
+                    try:
+                        result_text = streaming_outputs.get_message_output_content()
+                    except Exception:
+                        result_text = None
+
+                if metadata.status == "completed":
+                    metadata.result = result_text or "Task completed (no result available)"
+                    metadata.progress_percentage = 100.0
+                elif metadata.status in {"failed", "cancelled", "interrupted", "timeout"}:
+                    metadata.error = (
+                        getattr(task_response, "msg", None)
+                        or getattr(task_response, "answer", None)
+                        or result_text
+                        or f"Task ended with status: {metadata.status}"
+                    )
+                    metadata.result = result_text
+                    metadata.progress_percentage = 100.0
+                else:
+                    metadata.result = result_text
 
                 # Write footer to log file
                 log_file.write(f"\n{'=' * 80}\n")
                 log_file.write(f"Status: {metadata.status}\n")
                 log_file.write(f"Completed: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+                if metadata.error and metadata.status != "completed":
+                    log_file.write(f"\nError:\n{metadata.error}\n")
                 if metadata.result:
                     log_file.write(f"\nResult:\n{metadata.result}\n")
                 log_file.flush()
 
-                logger.info(f"[BackgroundTaskManager] Task {task_id} completed successfully")
+                logger.info(f"[BackgroundTaskManager] Task {task_id} finished with status={metadata.status}")
+                self._persist_tasks()
 
         except asyncio.CancelledError:
             metadata.status = "cancelled"
+            metadata.error = "Task cancelled by user"
             logger.info(f"[BackgroundTaskManager] Task {task_id} was cancelled")
 
             # Write cancellation to log file
@@ -246,6 +449,7 @@ class BackgroundTaskManager:
                     log_file.write(f"Cancelled at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             except Exception as e:
                 logger.error(f"[BackgroundTaskManager] Failed to write cancellation to log: {e}")
+            self._persist_tasks()
 
             raise  # Re-raise to properly cancel the task
 
@@ -263,9 +467,14 @@ class BackgroundTaskManager:
                     log_file.write(f"Failed at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             except Exception as write_error:
                 logger.error(f"[BackgroundTaskManager] Failed to write error to log: {write_error}")
+            self._persist_tasks()
 
         finally:
             metadata.completed_at = datetime.now()
+            try:
+                self._persist_tasks()
+            except Exception as e:
+                logger.warning(f"[BackgroundTaskManager] Failed to persist tasks in finally: {e}")
 
     def list_tasks(self) -> List[TaskMetadata]:
         """
@@ -329,6 +538,7 @@ class BackgroundTaskManager:
             if metadata.asyncio_task and not metadata.asyncio_task.done():
                 metadata.asyncio_task.cancel()
                 logger.info(f"[BackgroundTaskManager] Cancelled task {task_id}")
+                self._persist_tasks()
                 return True
 
             return False
@@ -350,6 +560,8 @@ class BackgroundTaskManager:
             "completed": 0,
             "failed": 0,
             "cancelled": 0,
+            "interrupted": 0,
+            "timeout": 0,
             "pending": 0
         }
 

--- a/aworld-cli/src/aworld_cli/core/background_task_manager.py
+++ b/aworld-cli/src/aworld_cli/core/background_task_manager.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import os
 import traceback
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -70,11 +71,8 @@ class BackgroundTaskManager:
         """
         return self.output_dir / f"{task_id}.log"
 
-    def _persist_tasks(self) -> None:
-        """
-        Persist task metadata to disk.
-        """
-        payload = {
+    def _build_persist_payload(self) -> dict:
+        return {
             "version": 1,
             "session_id": self.session_id,
             "task_counter": self._task_counter,
@@ -82,10 +80,27 @@ class BackgroundTaskManager:
             "tasks": [task.to_dict() for task in self.list_tasks()],
         }
 
+    def _write_persisted_tasks(self, payload: dict) -> None:
         temp_path = self.metadata_file.with_suffix(".json.tmp")
         with open(temp_path, "w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
         os.replace(temp_path, self.metadata_file)
+
+    def _persist_tasks_sync(self) -> None:
+        """
+        Persist task metadata to disk synchronously.
+
+        This is reserved for synchronous startup/shutdown paths where no event loop
+        handoff is available.
+        """
+        self._write_persisted_tasks(self._build_persist_payload())
+
+    async def _persist_tasks(self) -> None:
+        """
+        Persist task metadata to disk without blocking the event loop.
+        """
+        payload = self._build_persist_payload()
+        await asyncio.to_thread(self._write_persisted_tasks, payload)
 
     def _load_persisted_tasks(self) -> None:
         """
@@ -121,7 +136,7 @@ class BackgroundTaskManager:
             self._task_counter = max(persisted_counter, max_task_index + 1, 0)
 
             # Save back immediately if we normalized stale statuses.
-            self._persist_tasks()
+            self._persist_tasks_sync()
             logger.info(f"[BackgroundTaskManager] Loaded {len(self.tasks)} persisted tasks")
         except Exception as e:
             logger.warning(
@@ -168,8 +183,11 @@ class BackgroundTaskManager:
             return
 
         try:
-            lines = output_path.read_text(encoding="utf-8", errors="replace").splitlines()
-            relevant_lines = lines[-1000:]
+            relevant_lines = deque(maxlen=1000)
+            with open(output_path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    relevant_lines.append(line.rstrip("\n"))
+
             base_date = (task.submitted_at or datetime.now()).date()
             for line in relevant_lines:
                 if len(line) >= 11 and line[0] == "[" and line[9] == "]":
@@ -289,7 +307,7 @@ class BackgroundTaskManager:
                 submitted_at=datetime.now()
             )
             self.tasks[task_id] = metadata
-            self._persist_tasks()
+            await self._persist_tasks()
 
             # Submit to background
             asyncio_task = asyncio.create_task(
@@ -335,7 +353,7 @@ class BackgroundTaskManager:
         metadata = self.tasks[task_id]
         metadata.status = "running"
         metadata.started_at = datetime.now()
-        self._persist_tasks()
+        await self._persist_tasks()
 
         # Setup output file
         output_path = self._get_task_output_path(task_id)
@@ -437,7 +455,7 @@ class BackgroundTaskManager:
                 log_file.flush()
 
                 logger.info(f"[BackgroundTaskManager] Task {task_id} finished with status={metadata.status}")
-                self._persist_tasks()
+                await self._persist_tasks()
 
         except asyncio.CancelledError:
             metadata.status = "cancelled"
@@ -452,7 +470,7 @@ class BackgroundTaskManager:
                     log_file.write(f"Cancelled at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             except Exception as e:
                 logger.error(f"[BackgroundTaskManager] Failed to write cancellation to log: {e}")
-            self._persist_tasks()
+            await self._persist_tasks()
 
             raise  # Re-raise to properly cancel the task
 
@@ -470,12 +488,12 @@ class BackgroundTaskManager:
                     log_file.write(f"Failed at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             except Exception as write_error:
                 logger.error(f"[BackgroundTaskManager] Failed to write error to log: {write_error}")
-            self._persist_tasks()
+            await self._persist_tasks()
 
         finally:
             metadata.completed_at = datetime.now()
             try:
-                self._persist_tasks()
+                await self._persist_tasks()
             except Exception as e:
                 logger.warning(f"[BackgroundTaskManager] Failed to persist tasks in finally: {e}")
 
@@ -541,7 +559,7 @@ class BackgroundTaskManager:
             if metadata.asyncio_task and not metadata.asyncio_task.done():
                 metadata.asyncio_task.cancel()
                 logger.info(f"[BackgroundTaskManager] Cancelled task {task_id}")
-                self._persist_tasks()
+                await self._persist_tasks()
                 return True
 
             return False

--- a/aworld-cli/src/aworld_cli/executors/local.py
+++ b/aworld-cli/src/aworld_cli/executors/local.py
@@ -962,8 +962,8 @@ class LocalAgentExecutor(BaseAgentExecutor):
                 # Get updated result from kwargs
                 answer = hook_kwargs.get('result', answer)
 
-                # Try to get final result if task is still running
-                # Note: After stream_events() completes, the task may be cancelled, so we handle CancelledError
+                # Try to get final result if task is still running.
+                # If stream consumption ended early, the producer may already have been cancelled.
                 if hasattr(outputs, '_run_impl_task') and outputs._run_impl_task and not outputs.is_complete:
                     try:
                         # Wait with timeout to avoid hanging
@@ -1239,4 +1239,3 @@ class LocalAgentExecutor(BaseAgentExecutor):
         }
 
 __all__ = ["LocalAgentExecutor"]
-

--- a/aworld-cli/src/aworld_cli/models/task_metadata.py
+++ b/aworld-cli/src/aworld_cli/models/task_metadata.py
@@ -1,6 +1,7 @@
 """
 Task metadata for background task tracking.
 """
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Deque
@@ -15,13 +16,13 @@ class TaskMetadata:
     """
     Metadata for tracking background tasks.
 
-    Lifecycle: pending → running → completed/failed/cancelled
+    Lifecycle: pending → running → completed/failed/cancelled/interrupted/timeout
 
     Attributes:
         task_id: Unique task identifier (e.g., "task-001")
         agent_name: Name of agent executing the task
         task_content: User's task description
-        status: Current status (pending/running/completed/failed/cancelled)
+        status: Current status (pending/running/completed/failed/cancelled/interrupted/timeout)
         submitted_at: When task was submitted
         started_at: When task execution started (None if pending)
         completed_at: When task finished (None if not finished)
@@ -66,6 +67,64 @@ class TaskMetadata:
     # File persistence
     output_file: Optional[str] = None  # Path to output log file
 
+    def to_dict(self) -> dict:
+        """
+        Serialize metadata to a JSON-friendly dictionary.
+        """
+        return {
+            "task_id": self.task_id,
+            "agent_name": self.agent_name,
+            "task_content": self.task_content,
+            "status": self.status,
+            "submitted_at": self.submitted_at.isoformat() if self.submitted_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "current_step": self.current_step,
+            "progress_percentage": self.progress_percentage,
+            "result": self.result,
+            "error": self.error,
+            "output_file": self.output_file,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TaskMetadata":
+        """
+        Deserialize metadata from persisted JSON.
+        """
+        return cls(
+            task_id=data["task_id"],
+            agent_name=data.get("agent_name", "Aworld"),
+            task_content=data.get("task_content", ""),
+            status=data.get("status", "pending"),
+            submitted_at=cls._parse_datetime(data.get("submitted_at")) or datetime.now(),
+            started_at=cls._parse_datetime(data.get("started_at")),
+            completed_at=cls._parse_datetime(data.get("completed_at")),
+            current_step=data.get("current_step", ""),
+            progress_percentage=float(data.get("progress_percentage", 0.0) or 0.0),
+            result=data.get("result"),
+            error=data.get("error"),
+            output_file=data.get("output_file"),
+        )
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def parse_task_index(task_id: str) -> int:
+        """
+        Extract numeric suffix from a task id like `task-001`.
+        """
+        match = re.match(r"task-(\d+)$", task_id or "")
+        if not match:
+            return -1
+        return int(match.group(1))
+
     def elapsed_seconds(self) -> float:
         """
         Calculate elapsed time in seconds.
@@ -83,6 +142,6 @@ class TaskMetadata:
         Check if task is in terminal state.
 
         Returns:
-            True if task is completed/failed/cancelled, False otherwise
+            True if task is completed/failed/cancelled/interrupted/timeout, False otherwise
         """
-        return self.status in ('completed', 'failed', 'cancelled')
+        return self.status in ('completed', 'failed', 'cancelled', 'interrupted', 'timeout')

--- a/aworld/mcp_client/server.py
+++ b/aworld/mcp_client/server.py
@@ -292,7 +292,25 @@ class MCPServerStdio(_MCPServerWithClientSession):
         ]
     ]:
         """Create the streams for the server."""
-        return stdio_client(self.params)
+        # Keep stdio MCP server stderr out of the interactive CLI by default.
+        # Background tasks and `/tasks follow` run in the same terminal process,
+        # so uncaptured MCP stderr would otherwise leak raw tracebacks directly
+        # into the user's console when child servers exit or are cancelled.
+        preserve_mcp_logs = os.environ.get("AWORLD_PRESERVE_MCP_LOGS", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+
+        if preserve_mcp_logs:
+            log_path = os.environ.get("AWORLD_LOG_PATH", f"{os.getcwd()}/logs")
+            os.makedirs(log_path, exist_ok=True)
+            mcp_stderr_log = os.path.join(log_path, "mcp_stderr.log")
+            errlog = open(mcp_stderr_log, "a", encoding="utf-8", buffering=1)
+        else:
+            errlog = open(os.devnull, "w")
+
+        return stdio_client(self.params, errlog=errlog)
 
     @property
     def name(self) -> str:
@@ -462,4 +480,3 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
     def name(self) -> str:
         """A readable name for the server."""
         return self._name
-

--- a/aworld/mcp_client/server.py
+++ b/aworld/mcp_client/server.py
@@ -7,7 +7,7 @@ import os
 import threading
 import traceback
 from datetime import timedelta
-from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal
 
@@ -302,15 +302,25 @@ class MCPServerStdio(_MCPServerWithClientSession):
             "yes",
         )
 
-        if preserve_mcp_logs:
-            log_path = os.environ.get("AWORLD_LOG_PATH", f"{os.getcwd()}/logs")
-            os.makedirs(log_path, exist_ok=True)
-            mcp_stderr_log = os.path.join(log_path, "mcp_stderr.log")
-            errlog = open(mcp_stderr_log, "a", encoding="utf-8", buffering=1)
-        else:
-            errlog = open(os.devnull, "w")
+        @asynccontextmanager
+        async def _managed_stdio_client():
+            async with AsyncExitStack() as stack:
+                if preserve_mcp_logs:
+                    log_path = os.environ.get("AWORLD_LOG_PATH", f"{os.getcwd()}/logs")
+                    os.makedirs(log_path, exist_ok=True)
+                    mcp_stderr_log = os.path.join(log_path, "mcp_stderr.log")
+                    errlog = stack.enter_context(
+                        open(mcp_stderr_log, "a", encoding="utf-8", buffering=1)
+                    )
+                else:
+                    errlog = stack.enter_context(open(os.devnull, "w"))
 
-        return stdio_client(self.params, errlog=errlog)
+                transport = await stack.enter_async_context(
+                    stdio_client(self.params, errlog=errlog)
+                )
+                yield transport
+
+        return _managed_stdio_client()
 
     @property
     def name(self) -> str:

--- a/aworld/output/outputs.py
+++ b/aworld/output/outputs.py
@@ -211,13 +211,19 @@ class StreamingOutputs(AsyncOutputs):
                 self._stored_exception = exc
 
     def _cleanup_tasks(self):
-        """Clean up any running tasks by cancelling them if they're not done."""
-        if self._run_impl_task and not self._run_impl_task.done():
-            self._run_impl_task.cancel()
+        """Clean up stream-side state without aborting the underlying task.
+
+        The output stream is only a consumer view. Finishing or stopping the stream
+        should not implicitly cancel the actual task execution, otherwise callers can
+        observe a completed stream while the producer coroutine is still finalizing,
+        or accidentally turn a successful task into a cancelled one.
+        """
+        return
 
     async def mark_completed(self, task_response: "TaskResponse" = None) -> None:
         """Mark the streaming process as completed by adding a RUN_FINISHED_SIGNAL to the queue."""
         self._task_response = task_response
+        self.is_complete = True
         await self._output_queue.put(RUN_FINISHED_SIGNAL)
 
     def response(self) -> Optional["TaskResponse"]:

--- a/aworld/output/outputs.py
+++ b/aworld/output/outputs.py
@@ -120,6 +120,7 @@ class StreamingOutputs(AsyncOutputs):
 
     # State tracking
     is_complete: bool = field(default=False)  # Flag indicating if streaming is complete
+    cancel_run_impl_task_on_cleanup: bool = field(default=True)  # Cancel producer when stream consumer exits early
 
     # Queue for managing outputs
     _output_queue: asyncio.Queue[Output] = field(
@@ -154,47 +155,48 @@ class StreamingOutputs(AsyncOutputs):
         Raises:
             Exception: Any stored exception that occurred during streaming
         """
-        # First yield any cached outputs
-        for output in self._visited_outputs:
-            if output == RUN_FINISHED_SIGNAL:
-                self._output_queue.task_done()
-                return
-            # if self.task_id != output.task_id:
-            #     logger.warning(f"{self.task_id} unequals {output.task_id}")
-            #     return
-            yield output
+        try:
+            # First yield any cached outputs
+            for output in self._visited_outputs:
+                if output == RUN_FINISHED_SIGNAL:
+                    self._output_queue.task_done()
+                    return
+                # if self.task_id != output.task_id:
+                #     logger.warning(f"{self.task_id} unequals {output.task_id}")
+                #     return
+                yield output
 
-        # Main streaming loop
-        while True:
-            self._check_errors()
-            if self._stored_exception:
-                logger.info("Breaking due to stored exception")
-                self.is_complete = True
-                break
-
-            if self.is_complete and self._output_queue.empty():
-                logger.info(f"StreamingOutputs|stream_events|finished|{self.task_id}")
-                break
-
-            try:
-                output = await self._output_queue.get()
-                logger.info("Outputs got output: {}".format(output.output_type()))
-                self._visited_outputs.append(output)
-
-            except asyncio.CancelledError as err:
-                logger.info(f"StreamingOutputs|stream_events|CancelledError|{self.task_id}|{err}")
-                break
-
-            if output == RUN_FINISHED_SIGNAL:
-                logger.info(f"StreamingOutputs|stream_events|RUN_FINISHED_SIGNAL|{self.task_id}|{output}")
-                self._output_queue.task_done()
+            # Main streaming loop
+            while True:
                 self._check_errors()
-                break
+                if self._stored_exception:
+                    logger.info("Breaking due to stored exception")
+                    self.is_complete = True
+                    break
 
-            yield output
-            self._output_queue.task_done()
+                if self.is_complete and self._output_queue.empty():
+                    logger.info(f"StreamingOutputs|stream_events|finished|{self.task_id}")
+                    break
 
-        self._cleanup_tasks()
+                try:
+                    output = await self._output_queue.get()
+                    logger.info("Outputs got output: {}".format(output.output_type()))
+                    self._visited_outputs.append(output)
+
+                except asyncio.CancelledError as err:
+                    logger.info(f"StreamingOutputs|stream_events|CancelledError|{self.task_id}|{err}")
+                    break
+
+                if output == RUN_FINISHED_SIGNAL:
+                    logger.info(f"StreamingOutputs|stream_events|RUN_FINISHED_SIGNAL|{self.task_id}|{output}")
+                    self._output_queue.task_done()
+                    self._check_errors()
+                    break
+
+                yield output
+                self._output_queue.task_done()
+        finally:
+            self._cleanup_tasks()
 
         if self._stored_exception:
             logger.info(f"StreamingOutputs|stream_events|stored_exception|{self.task_id}|{self._stored_exception}")
@@ -211,14 +213,14 @@ class StreamingOutputs(AsyncOutputs):
                 self._stored_exception = exc
 
     def _cleanup_tasks(self):
-        """Clean up stream-side state without aborting the underlying task.
-
-        The output stream is only a consumer view. Finishing or stopping the stream
-        should not implicitly cancel the actual task execution, otherwise callers can
-        observe a completed stream while the producer coroutine is still finalizing,
-        or accidentally turn a successful task into a cancelled one.
-        """
-        return
+        """Cancel the producer only when the stream consumer exits before completion."""
+        if not self.cancel_run_impl_task_on_cleanup:
+            return
+        if self.is_complete:
+            return
+        if not self._run_impl_task or self._run_impl_task.done():
+            return
+        self._run_impl_task.cancel()
 
     async def mark_completed(self, task_response: "TaskResponse" = None) -> None:
         """Mark the streaming process as completed by adding a RUN_FINISHED_SIGNAL to the queue."""

--- a/aworld/runner.py
+++ b/aworld/runner.py
@@ -30,7 +30,11 @@ class Runners:
     """Unified entrance to the utility class of the runnable task of execution."""
 
     @staticmethod
-    def streamed_run_task(task: Task, run_conf: RunConfig = None) -> StreamingOutputs:
+    def streamed_run_task(
+            task: Task,
+            run_conf: RunConfig = None,
+            cancel_run_impl_task_on_cleanup: bool = True
+    ) -> StreamingOutputs:
         """Run the task in stream output."""
 
         with trace.task_span("streamed_run_task",
@@ -42,7 +46,8 @@ class Runners:
             streamed_result = StreamingOutputs(
                 input=task.input,
                 usage={},
-                is_complete=False
+                is_complete=False,
+                cancel_run_impl_task_on_cleanup=cancel_run_impl_task_on_cleanup,
             )
             task.outputs = streamed_result
             streamed_result.task_id = task.id

--- a/aworld/sandbox/tool_servers/filesystem/src/main.py
+++ b/aworld/sandbox/tool_servers/filesystem/src/main.py
@@ -527,7 +527,10 @@ if __name__ == "__main__":
     
     # Run the server: default streamable-http (compat with start_tool_servers.sh); use stdio when --stdio or MCP_TRANSPORT=stdio
     use_stdio = "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT", "").strip().lower() == "stdio"
-    if use_stdio:
-        mcp.run(transport="stdio")
-    else:
-        mcp.run(transport="streamable-http")
+    try:
+        if use_stdio:
+            mcp.run(transport="stdio")
+        else:
+            mcp.run(transport="streamable-http")
+    except KeyboardInterrupt:
+        logging.info("Filesystem MCP server stopped")

--- a/aworld/sandbox/tool_servers/terminal/src/terminal.py
+++ b/aworld/sandbox/tool_servers/terminal/src/terminal.py
@@ -581,7 +581,10 @@ if __name__ == "__main__":
     logging.info("Starting terminal-server MCP server!")
     # Default streamable-http (compat with start_tool_servers.sh); use stdio when --stdio or MCP_TRANSPORT=stdio
     use_stdio = "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT", "").strip().lower() == "stdio"
-    if use_stdio:
-        mcp.run(transport="stdio")
-    else:
-        mcp.run(transport="streamable-http")
+    try:
+        if use_stdio:
+            mcp.run(transport="stdio")
+        else:
+            mcp.run(transport="streamable-http")
+    except KeyboardInterrupt:
+        logging.info("Terminal MCP server stopped")

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "aworld-cli" / "src"))
+
+from aworld.core.common import TaskStatusValue
+from aworld_cli.commands.tasks import TasksCommand
+from aworld_cli.core.background_task_manager import BackgroundTaskManager
+from aworld_cli.models.task_metadata import TaskMetadata
+
+
+class _StubTaskManager:
+    def __init__(self, task: TaskMetadata):
+        self._task = task
+
+    def get_task(self, task_id: str):
+        if self._task.task_id == task_id:
+            return self._task
+        return None
+
+
+class TestBackgroundTaskManager:
+    def test_normalize_final_status(self):
+        manager = BackgroundTaskManager(session_id="test-session")
+
+        assert manager._normalize_final_status(None) == "failed"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.SUCCESS, success=True)) == "completed"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.FAILED, success=False)) == "failed"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.CANCELLED, success=False)) == "cancelled"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.INTERRUPTED, success=False)) == "interrupted"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.TIMEOUT, success=False)) == "timeout"
+        assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.RUNNING, success=True)) == "running"
+        assert manager._normalize_final_status(SimpleNamespace(status="unknown", success=False)) == "failed"
+
+    @pytest.mark.asyncio
+    async def test_definitive_task_response_prefers_run_result(self):
+        manager = BackgroundTaskManager(session_id="test-session")
+        expected = SimpleNamespace(status=TaskStatusValue.SUCCESS, success=True, answer="ok")
+
+        async def fake_run():
+            await asyncio.sleep(0)
+            return {"aw-task-1": expected}
+
+        class DummyStreamingOutputs:
+            def __init__(self):
+                self._run_impl_task = asyncio.create_task(fake_run())
+            def response(self):
+                return None
+
+        actual = await manager._get_definitive_task_response("aw-task-1", DummyStreamingOutputs())
+        assert actual is expected
+
+
+class TestTasksCommandRendering:
+    @pytest.mark.asyncio
+    async def test_show_status_has_no_ansi_escape_codes(self):
+        cmd = TasksCommand()
+        task = TaskMetadata(
+            task_id="task-001",
+            agent_name="Aworld",
+            task_content="test task",
+            status="failed",
+            submitted_at=datetime.now(),
+            started_at=datetime.now(),
+            completed_at=datetime.now(),
+            result="partial result",
+            error="boom",
+            output_file=".aworld/tasks/task-001.log",
+        )
+
+        result = await cmd._show_status("task-001", _StubTaskManager(task))
+
+        assert "Task ID:" in result
+        assert "Status:" in result
+        assert "\x1b[" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_has_no_ansi_escape_codes(self):
+        cmd = TasksCommand()
+        task = TaskMetadata(
+            task_id="task-001",
+            agent_name="Aworld",
+            task_content="test task",
+            status="timeout",
+            submitted_at=datetime.now(),
+            output_file=".aworld/tasks/task-001.log",
+        )
+
+        class _ListTaskManager:
+            def list_tasks(self):
+                return [task]
+
+            def get_stats(self):
+                return {
+                    "total": 1,
+                    "running": 0,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "interrupted": 0,
+                    "timeout": 1,
+                    "pending": 0,
+                }
+
+        result = await cmd._list_tasks(_ListTaskManager())
+
+        assert "Background Tasks" in result
+        assert "task-001" in result
+        assert "\x1b[" not in result

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -38,7 +38,7 @@ class TestBackgroundTaskManager:
         assert manager._normalize_final_status(SimpleNamespace(status=TaskStatusValue.RUNNING, success=True)) == "running"
         assert manager._normalize_final_status(SimpleNamespace(status="unknown", success=False)) == "failed"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_definitive_task_response_prefers_run_result(self):
         manager = BackgroundTaskManager(session_id="test-session")
         expected = SimpleNamespace(status=TaskStatusValue.SUCCESS, success=True, answer="ok")
@@ -56,9 +56,35 @@ class TestBackgroundTaskManager:
         actual = await manager._get_definitive_task_response("aw-task-1", DummyStreamingOutputs())
         assert actual is expected
 
+    @pytest.mark.anyio
+    async def test_persist_tasks_uses_background_thread(self, monkeypatch, tmp_path):
+        manager = BackgroundTaskManager(session_id="test-session", output_dir=str(tmp_path))
+        manager.tasks["task-001"] = TaskMetadata(
+            task_id="task-001",
+            agent_name="Aworld",
+            task_content="persist me",
+            status="pending",
+            submitted_at=datetime.now(),
+        )
+
+        captured = {}
+
+        async def fake_to_thread(func, *args, **kwargs):
+            captured["func"] = func
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr("aworld_cli.core.background_task_manager.asyncio.to_thread", fake_to_thread)
+
+        await manager._persist_tasks()
+
+        assert captured["func"] == manager._write_persisted_tasks
+        assert manager.metadata_file.exists()
+
 
 class TestTasksCommandRendering:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_show_status_has_no_ansi_escape_codes(self):
         cmd = TasksCommand()
         task = TaskMetadata(
@@ -80,7 +106,7 @@ class TestTasksCommandRendering:
         assert "Status:" in result
         assert "\x1b[" not in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_tasks_has_no_ansi_escape_codes(self):
         cmd = TasksCommand()
         task = TaskMetadata(

--- a/tests/test_mcp_stdio_stderr.py
+++ b/tests/test_mcp_stdio_stderr.py
@@ -1,0 +1,67 @@
+import os
+
+import pytest
+
+from aworld.mcp_client.server import MCPServerStdio
+
+
+class _DummyContextManager:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_stdio_client_redirects_stderr_to_devnull_by_default(monkeypatch):
+    captured = {}
+
+    def fake_stdio_client(params, errlog=None):
+        captured["params"] = params
+        captured["errlog"] = errlog
+        return _DummyContextManager()
+
+    monkeypatch.setattr("aworld.mcp_client.server.stdio_client", fake_stdio_client)
+    monkeypatch.delenv("AWORLD_PRESERVE_MCP_LOGS", raising=False)
+
+    server = MCPServerStdio(
+        name="test-server",
+        params={
+            "command": "python",
+            "args": ["-c", "print('ok')"],
+        },
+    )
+
+    _ = server.create_streams()
+
+    assert captured["errlog"] is not None
+    assert captured["errlog"].name == os.devnull
+    captured["errlog"].close()
+
+
+def test_stdio_client_can_preserve_stderr_to_log_file(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_stdio_client(params, errlog=None):
+        captured["params"] = params
+        captured["errlog"] = errlog
+        return _DummyContextManager()
+
+    monkeypatch.setattr("aworld.mcp_client.server.stdio_client", fake_stdio_client)
+    monkeypatch.setenv("AWORLD_PRESERVE_MCP_LOGS", "true")
+    monkeypatch.setenv("AWORLD_LOG_PATH", str(tmp_path))
+
+    server = MCPServerStdio(
+        name="test-server",
+        params={
+            "command": "python",
+            "args": ["-c", "print('ok')"],
+        },
+    )
+
+    _ = server.create_streams()
+
+    assert captured["errlog"] is not None
+    assert captured["errlog"].name.endswith("mcp_stderr.log")
+    assert os.path.dirname(captured["errlog"].name) == str(tmp_path)
+    captured["errlog"].close()

--- a/tests/test_mcp_stdio_stderr.py
+++ b/tests/test_mcp_stdio_stderr.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -5,11 +6,11 @@ import pytest
 from aworld.mcp_client.server import MCPServerStdio
 
 
-class _DummyContextManager:
-    def __enter__(self):
-        return self
+class _DummyAsyncContextManager:
+    async def __aenter__(self):
+        return ("read", "write", None)
 
-    def __exit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb):
         return False
 
 
@@ -19,7 +20,7 @@ def test_stdio_client_redirects_stderr_to_devnull_by_default(monkeypatch):
     def fake_stdio_client(params, errlog=None):
         captured["params"] = params
         captured["errlog"] = errlog
-        return _DummyContextManager()
+        return _DummyAsyncContextManager()
 
     monkeypatch.setattr("aworld.mcp_client.server.stdio_client", fake_stdio_client)
     monkeypatch.delenv("AWORLD_PRESERVE_MCP_LOGS", raising=False)
@@ -32,11 +33,17 @@ def test_stdio_client_redirects_stderr_to_devnull_by_default(monkeypatch):
         },
     )
 
-    _ = server.create_streams()
+    async def exercise():
+        async with server.create_streams():
+            assert captured["errlog"] is not None
+            assert captured["errlog"].name == os.devnull
+            assert not captured["errlog"].closed
+
+    asyncio.run(exercise())
 
     assert captured["errlog"] is not None
     assert captured["errlog"].name == os.devnull
-    captured["errlog"].close()
+    assert captured["errlog"].closed
 
 
 def test_stdio_client_can_preserve_stderr_to_log_file(monkeypatch, tmp_path):
@@ -45,7 +52,7 @@ def test_stdio_client_can_preserve_stderr_to_log_file(monkeypatch, tmp_path):
     def fake_stdio_client(params, errlog=None):
         captured["params"] = params
         captured["errlog"] = errlog
-        return _DummyContextManager()
+        return _DummyAsyncContextManager()
 
     monkeypatch.setattr("aworld.mcp_client.server.stdio_client", fake_stdio_client)
     monkeypatch.setenv("AWORLD_PRESERVE_MCP_LOGS", "true")
@@ -59,9 +66,16 @@ def test_stdio_client_can_preserve_stderr_to_log_file(monkeypatch, tmp_path):
         },
     )
 
-    _ = server.create_streams()
+    async def exercise():
+        async with server.create_streams():
+            assert captured["errlog"] is not None
+            assert captured["errlog"].name.endswith("mcp_stderr.log")
+            assert os.path.dirname(captured["errlog"].name) == str(tmp_path)
+            assert not captured["errlog"].closed
+
+    asyncio.run(exercise())
 
     assert captured["errlog"] is not None
     assert captured["errlog"].name.endswith("mcp_stderr.log")
     assert os.path.dirname(captured["errlog"].name) == str(tmp_path)
-    captured["errlog"].close()
+    assert captured["errlog"].closed

--- a/tests/test_streaming_outputs.py
+++ b/tests/test_streaming_outputs.py
@@ -1,0 +1,86 @@
+import asyncio
+
+import pytest
+
+from aworld.output.outputs import StreamingOutputs
+
+
+class DummyOutput:
+    def output_type(self):
+        return "dummy"
+
+
+@pytest.mark.asyncio
+async def test_streaming_outputs_cancels_producer_when_consumer_stops_early():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def producer():
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    outputs = StreamingOutputs(cancel_run_impl_task_on_cleanup=True)
+    outputs._run_impl_task = asyncio.create_task(producer())
+    await started.wait()
+    await outputs.add_output(DummyOutput())
+
+    stream = outputs.stream_events()
+    await stream.__anext__()
+    await stream.aclose()
+
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+    with pytest.raises(asyncio.CancelledError):
+        await outputs._run_impl_task
+
+
+@pytest.mark.asyncio
+async def test_streaming_outputs_preserves_producer_when_cleanup_cancellation_disabled():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def producer():
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    outputs = StreamingOutputs(cancel_run_impl_task_on_cleanup=False)
+    outputs._run_impl_task = asyncio.create_task(producer())
+    await started.wait()
+    await outputs.add_output(DummyOutput())
+
+    stream = outputs.stream_events()
+    await stream.__anext__()
+    await stream.aclose()
+    await asyncio.sleep(0)
+
+    assert not cancelled.is_set()
+    assert not outputs._run_impl_task.cancelled()
+
+    outputs._run_impl_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outputs._run_impl_task
+
+
+@pytest.mark.asyncio
+async def test_streaming_outputs_does_not_cancel_finishing_producer_after_mark_completed():
+    async def producer():
+        await asyncio.sleep(0.1)
+        return {"task-1": "ok"}
+
+    outputs = StreamingOutputs(task_id="task-1", cancel_run_impl_task_on_cleanup=True)
+    outputs._run_impl_task = asyncio.create_task(producer())
+    await outputs.mark_completed()
+
+    stream = outputs.stream_events()
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+    await asyncio.wait_for(outputs._run_impl_task, timeout=1.0)
+    assert not outputs._run_impl_task.cancelled()

--- a/tests/test_streaming_outputs.py
+++ b/tests/test_streaming_outputs.py
@@ -10,7 +10,7 @@ class DummyOutput:
         return "dummy"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_streaming_outputs_cancels_producer_when_consumer_stops_early():
     started = asyncio.Event()
     cancelled = asyncio.Event()
@@ -37,7 +37,7 @@ async def test_streaming_outputs_cancels_producer_when_consumer_stops_early():
         await outputs._run_impl_task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_streaming_outputs_preserves_producer_when_cleanup_cancellation_disabled():
     started = asyncio.Event()
     cancelled = asyncio.Event()
@@ -68,7 +68,7 @@ async def test_streaming_outputs_preserves_producer_when_cleanup_cancellation_di
         await outputs._run_impl_task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_streaming_outputs_does_not_cancel_finishing_producer_after_mark_completed():
     async def producer():
         await asyncio.sleep(0.1)

--- a/tests/test_task_persistence.py
+++ b/tests/test_task_persistence.py
@@ -23,7 +23,7 @@ def test_persist_and_reload_tasks(tmp_path):
     )
     manager.tasks[task.task_id] = task
     manager._task_counter = 4
-    manager._persist_tasks()
+    manager._persist_tasks_sync()
 
     restored = BackgroundTaskManager(session_id="session-b", output_dir=str(tmp_path))
 
@@ -50,7 +50,7 @@ def test_restore_marks_running_tasks_interrupted(tmp_path):
     )
     manager.tasks = {task.task_id: task}
     manager._task_counter = 1
-    manager._persist_tasks()
+    manager._persist_tasks_sync()
 
     restored = BackgroundTaskManager(session_id="session-b", output_dir=str(tmp_path))
     loaded = restored.get_task("task-000")
@@ -59,3 +59,26 @@ def test_restore_marks_running_tasks_interrupted(tmp_path):
     assert loaded.status == "interrupted"
     assert "restarted" in (loaded.error or "")
     assert len(loaded.output_buffer) == 1
+
+
+def test_restore_only_keeps_last_1000_log_lines(tmp_path):
+    log_path = tmp_path / "task-100.log"
+    with open(log_path, "w", encoding="utf-8") as f:
+        for i in range(1205):
+            f.write(f"[12:00:{i % 60:02d}] line-{i}\n")
+
+    manager = BackgroundTaskManager(session_id="session-a", output_dir=str(tmp_path))
+    task = TaskMetadata(
+        task_id="task-100",
+        agent_name="Aworld",
+        task_content="large log",
+        status="completed",
+        submitted_at=datetime.now(),
+        output_file=str(log_path),
+    )
+
+    manager._load_output_buffer_from_log(task)
+
+    assert len(task.output_buffer) == 1000
+    assert task.output_buffer[0][1] == "line-205"
+    assert task.output_buffer[-1][1] == "line-1204"

--- a/tests/test_task_persistence.py
+++ b/tests/test_task_persistence.py
@@ -1,0 +1,61 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "aworld-cli" / "src"))
+
+from aworld_cli.core.background_task_manager import BackgroundTaskManager
+from aworld_cli.models.task_metadata import TaskMetadata
+
+
+def test_persist_and_reload_tasks(tmp_path):
+    manager = BackgroundTaskManager(session_id="session-a", output_dir=str(tmp_path))
+    task = TaskMetadata(
+        task_id="task-003",
+        agent_name="Aworld",
+        task_content="persist me",
+        status="completed",
+        submitted_at=datetime.now(),
+        started_at=datetime.now(),
+        completed_at=datetime.now(),
+        result="done",
+        output_file=str(tmp_path / "task-003.log"),
+    )
+    manager.tasks[task.task_id] = task
+    manager._task_counter = 4
+    manager._persist_tasks()
+
+    restored = BackgroundTaskManager(session_id="session-b", output_dir=str(tmp_path))
+
+    loaded = restored.get_task("task-003")
+    assert loaded is not None
+    assert loaded.status == "completed"
+    assert loaded.result == "done"
+    assert restored._task_counter >= 4
+
+
+def test_restore_marks_running_tasks_interrupted(tmp_path):
+    log_path = tmp_path / "task-000.log"
+    log_path.write_text("[12:00:00] hello\n", encoding="utf-8")
+
+    manager = BackgroundTaskManager(session_id="session-a", output_dir=str(tmp_path))
+    task = TaskMetadata(
+        task_id="task-000",
+        agent_name="Aworld",
+        task_content="was running",
+        status="running",
+        submitted_at=datetime.now(),
+        started_at=datetime.now(),
+        output_file=str(log_path),
+    )
+    manager.tasks = {task.task_id: task}
+    manager._task_counter = 1
+    manager._persist_tasks()
+
+    restored = BackgroundTaskManager(session_id="session-b", output_dir=str(tmp_path))
+    loaded = restored.get_task("task-000")
+
+    assert loaded is not None
+    assert loaded.status == "interrupted"
+    assert "restarted" in (loaded.error or "")
+    assert len(loaded.output_buffer) == 1


### PR DESCRIPTION
## Summary
- persist /tasks metadata to disk and reload task history on CLI restart
- use AWorld TaskResponse as the source of truth for dispatch completion and final task status
- clean up /tasks and history rendering, add interrupted/timeout states, and suppress MCP stdio stderr noise

## Testing
- python -m py_compile aworld-cli/src/aworld_cli/commands/history.py aworld-cli/src/aworld_cli/commands/tasks.py aworld-cli/src/aworld_cli/core/background_task_manager.py aworld-cli/src/aworld_cli/models/task_metadata.py aworld/mcp_client/server.py aworld/output/outputs.py aworld/sandbox/tool_servers/filesystem/src/main.py aworld/sandbox/tool_servers/terminal/src/terminal.py tests/test_background_tasks.py tests/test_mcp_stdio_stderr.py tests/test_task_persistence.py
- pytest not run locally because pytest is not installed in the available environments