### PR TITLE
fix: harden parallel media task execution

### DIFF
--- a/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/diffusion/diffusion.py
+++ b/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/diffusion/diffusion.py
@@ -69,7 +69,7 @@ Cannot process (do NOT delegate to this agent): Document reading/analysis (.pdf,
 - `content`: Required. The video generation prompt (text description of what to create).
 - `info`: Required JSON string. Use when passing image/video params, e.g.:
   {"image_url": "<data_path_or_base64_string>", "reference_images": ["<path1>", "<path2>"], "resolution": "720p", "duration": 5, "fps": 24, "output_dir": "./output", "sound": "on"}
-  Supported keys: image_url, reference_images (list of paths/URLs/base64), resolution, duration (must be ≤ 10 seconds), fps, poll, poll_interval, poll_timeout, download_video, output_dir.
+  Supported keys: image_url, reference_images (list of paths/URLs/base64), resolution, duration (must be ≤ 10 seconds), fps, poll, poll_interval, poll_timeout, submitted_timeout, download_video, output_dir.
 """
 )
 def build_diffusion_swarm():

--- a/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/prompt.txt
+++ b/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/prompt.txt
@@ -157,7 +157,7 @@ You are equipped with multiple assistants. It is your job to know which to use a
     - **When to invoke:** All video creation tasks MUST be routed to `video_diffusion`.
     - **Call params:** `content` (required: prompt text); `info` (optional, JSON string).
     - **Example info:** `{"image_url": "<path>", "image_tail": "<path>", "reference_images": ["<path1>", "<path2>"], "resolution": "720p", "duration": 5, "fps": 24, "output_dir": "({{ARTIFACT_DIRECTORY}})", "sound": "on"}`; `duration` must be ≤ 10 seconds.
-    - **Supported info keys:** image_url, image_tail (last frame for image-to-video), reference_images (list of paths/URLs/base64), resolution, duration, fps, poll, poll_interval, poll_timeout, download_video, output_dir.
+    - **Supported info keys:** image_url, image_tail (last frame for image-to-video), reference_images (list of paths/URLs/base64), resolution, duration, fps, poll, poll_interval, poll_timeout, submitted_timeout, download_video, output_dir.
 *   `audio_generator`: Sub-agent for text-to-speech audio generation.
     - **When to invoke:** All text-to-speech audio generation tasks MUST be routed to `audio_generator`.
     - **Call params:** `content` (required: text to convert to speech); `info` (optional, JSON string).

--- a/aworld/agents/video_agent.py
+++ b/aworld/agents/video_agent.py
@@ -168,6 +168,7 @@ class VideoAgent(LLMAgent):
             observation: Contains the video prompt in ``content`` and
                 optional overrides in ``info`` (image_url, image_tail,
                 resolution, duration, fps, poll, poll_interval, poll_timeout,
+                submitted_timeout,
                 plus any extra kwargs forwarded to the provider).
             info: Supplementary information dict (merged with
                 ``observation.info`` if both are non-empty).

--- a/aworld/core/agent/subagent_manager.py
+++ b/aworld/core/agent/subagent_manager.py
@@ -449,8 +449,12 @@ class SubagentManager:
             f"(source={subagent_info.source}) with directive: {directive[:100]}..."
         )
 
-        # Step 2: Get current context (thread-safe via contextvars)
-        current_context = BaseAgent._get_current_context()
+        # Step 2: Get parent context.
+        # Prefer an explicit context passed by the caller (e.g. tool execution),
+        # then fall back to the current agent's contextvar-based execution context.
+        current_context = kwargs.pop('context', None) or kwargs.pop('parent_context', None)
+        if current_context is None:
+            current_context = BaseAgent._get_current_context()
         if current_context is None:
             raise RuntimeError(
                 f"SubagentManager.spawn: No active context found. "

--- a/aworld/core/tool/base.py
+++ b/aworld/core/tool/base.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 inclusionAI.
 
 import abc
+import inspect
 import time
 import traceback
 from typing import Dict, Tuple, Any, TypeVar, Generic, List, Union
@@ -31,6 +32,48 @@ ToolInput = TypeVar("ToolInput")
 
 # Forward declaration of action_executor to fix NameError
 action_executor = None
+
+
+async def maybe_await(result: Any) -> Any:
+    """Resolve sync or async hook/reset results uniformly.
+
+    Some call sites operate on ``AsyncTool`` instances and expect async lifecycle
+    methods, but a few implementations still return plain values. Accept both so
+    tool initialization is resilient to mixed implementations.
+    """
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+def ensure_action_results(
+    observation: Observation,
+    actions: List["ActionModel"],
+    *,
+    success: bool,
+    default_content: Any = None,
+    error: str = None,
+) -> Observation:
+    """Ensure an observation has one ActionResult per action.
+
+    Some tools return only ``Observation(content=...)`` on error paths. The
+    framework's post-processing expects ``action_result`` entries to exist, so
+    synthesize them when missing to avoid secondary crashes masking the real
+    tool failure.
+    """
+    if observation.action_result is None:
+        observation.action_result = []
+
+    while len(observation.action_result) < len(actions):
+        action_result_kwargs = {
+            "is_done": True,
+            "success": success,
+            "content": default_content if default_content is not None else observation.content,
+        }
+        if error is not None:
+            action_result_kwargs["error"] = error
+        observation.action_result.append(ActionResult(**action_result_kwargs))
+    return observation
 
 
 class BaseTool(Generic[AgentInput, ToolInput]):
@@ -274,6 +317,14 @@ class Tool(BaseTool[Observation, List[ActionModel]]):
             raise Exception(f'{self.name()} no observation has been made.')
 
         context = message.context
+        info = step_res[4] if len(step_res) > 4 and isinstance(step_res[4], dict) else {}
+        ensure_action_results(
+            step_res[0],
+            action,
+            success=step_res[1] > 0,
+            default_content=step_res[0].content,
+            error=info.get('error'),
+        )
 
         step_res[0].from_agent_name = action[0].agent_name
         for idx, act in enumerate(action):
@@ -481,6 +532,14 @@ class AsyncTool(AsyncBaseTool[Observation, List[ActionModel]]):
         if not step_res:
             raise Exception(f'{self.name()} no observation has been made.')
 
+        info = step_res[4] if len(step_res) > 4 and isinstance(step_res[4], dict) else {}
+        ensure_action_results(
+            step_res[0],
+            action,
+            success=step_res[1] > 0,
+            default_content=step_res[0].content,
+            error=info.get('error'),
+        )
         step_res[0].from_agent_name = action[0].agent_name
         for idx, act in enumerate(action):
             step_res[0].action_result[idx].tool_call_id = act.tool_call_id

--- a/aworld/core/tool/builtin/spawn_subagent_tool.py
+++ b/aworld/core/tool/builtin/spawn_subagent_tool.py
@@ -826,6 +826,15 @@ class SpawnSubagentTool(AsyncTool):
             return message.context
         return getattr(self, 'context', None)
 
+    @staticmethod
+    def _get_agent_info_value(agent_info: Any, key: str) -> Any:
+        """Read an agent_info value from either a mapping or an object."""
+        if agent_info is None:
+            return None
+        if isinstance(agent_info, dict):
+            return agent_info.get(key)
+        return getattr(agent_info, key, None)
+
     def _get_subagent_manager(self, action_model: Optional[ActionModel] = None, context=None):
         """
         Get SubagentManager from current agent context.
@@ -854,7 +863,7 @@ class SpawnSubagentTool(AsyncTool):
                 if action_model and getattr(action_model, 'agent_name', None):
                     candidate_agent_ids.append(action_model.agent_name)
                 agent_info = getattr(context, 'agent_info', None)
-                current_agent_id = agent_info.get('current_agent_id') if agent_info else None
+                current_agent_id = self._get_agent_info_value(agent_info, 'current_agent_id')
                 if current_agent_id:
                     candidate_agent_ids.append(current_agent_id)
 

--- a/aworld/core/tool/builtin/spawn_subagent_tool.py
+++ b/aworld/core/tool/builtin/spawn_subagent_tool.py
@@ -18,11 +18,12 @@ Supports multiple execution modes:
 import asyncio
 import json
 import time
+import traceback
 import uuid
 from typing import List, Dict, Any, Tuple, Optional
 from aworld.core.tool.base import AsyncTool, ToolFactory
 from aworld.core.tool.action import ToolAction
-from aworld.core.common import Observation, ActionModel, ToolActionInfo, ParamInfo
+from aworld.core.common import Observation, ActionModel, ToolActionInfo, ParamInfo, ActionResult
 from aworld.logs.util import logger
 
 
@@ -321,13 +322,17 @@ class SpawnSubagentTool(AsyncTool):
         else:
             logger.debug("SpawnSubagentTool initialized (global registration, no agent context)")
 
-    def reset(self, *, seed: int | None = None, options: Dict[str, str] | None = None) -> Tuple[
+    async def reset(self, *, seed: int | None = None, options: Dict[str, str] | None = None) -> Tuple[
             Any, dict[str, Any]]:
         """
         Reset tool state (required by AsyncTool interface).
 
         For spawn_subagent, there's no persistent state to reset.
         """
+        if self.subagent_manager is None:
+            bound_manager = self._get_subagent_manager(context=getattr(self, 'context', None))
+            if bound_manager is not None:
+                self.subagent_manager = bound_manager
         return (Observation(content="SpawnSubagentTool ready"), {})
 
     async def do_step(
@@ -431,10 +436,14 @@ class SpawnSubagentTool(AsyncTool):
             f"spawn_subagent: Delegating to subagent '{name}' "
             f"with directive: {directive[:100]}..."
         )
+        parent_context = self._resolve_context(kwargs)
 
         try:
             # Get SubagentManager
-            subagent_manager = self._get_subagent_manager()
+            subagent_manager = self._get_subagent_manager(
+                action_model=action_model,
+                context=parent_context
+            )
             if not subagent_manager:
                 error_msg = "spawn_subagent: No SubagentManager available"
                 logger.error(error_msg)
@@ -444,6 +453,7 @@ class SpawnSubagentTool(AsyncTool):
             result = await subagent_manager.spawn(
                 name=name,
                 directive=directive,
+                context=parent_context,
                 **spawn_kwargs
             )
 
@@ -468,7 +478,7 @@ class SpawnSubagentTool(AsyncTool):
 
         except Exception as e:
             error_msg = f"spawn_subagent: Failed to spawn '{name}': {str(e)}"
-            logger.error(error_msg, exc_info=True)
+            logger.error(f"{error_msg}\n{traceback.format_exc()}")
             return self._error_response(error_msg, {'error': str(e), 'subagent': name})
 
     async def _spawn_parallel(
@@ -490,6 +500,7 @@ class SpawnSubagentTool(AsyncTool):
         start_time = time.time()
 
         params = action_model.params if hasattr(action_model, 'params') else {}
+        parent_context = self._resolve_context(kwargs)
 
         tasks = params.get('tasks', [])
         max_concurrent = params.get('max_concurrent', 10)
@@ -514,7 +525,10 @@ class SpawnSubagentTool(AsyncTool):
 
         try:
             # Get SubagentManager
-            subagent_manager = self._get_subagent_manager()
+            subagent_manager = self._get_subagent_manager(
+                action_model=action_model,
+                context=parent_context
+            )
             if not subagent_manager:
                 error_msg = "spawn_parallel: No SubagentManager available"
                 logger.error(error_msg)
@@ -524,6 +538,7 @@ class SpawnSubagentTool(AsyncTool):
             results = await self._execute_tasks_parallel(
                 subagent_manager,
                 tasks,
+                parent_context,
                 max_concurrent,
                 fail_fast
             )
@@ -566,13 +581,14 @@ class SpawnSubagentTool(AsyncTool):
         except Exception as e:
             elapsed = time.time() - start_time
             error_msg = f"spawn_parallel: Exception during execution after {elapsed:.2f}s: {str(e)}"
-            logger.error(error_msg, exc_info=True)
+            logger.error(f"{error_msg}\n{traceback.format_exc()}")
             return self._error_response(error_msg, {'error': str(e), 'elapsed_seconds': round(elapsed, 2)})
 
     async def _execute_tasks_parallel(
         self,
         subagent_manager,
         tasks: List[Dict[str, Any]],
+        parent_context,
         max_concurrent: int,
         fail_fast: bool
     ) -> List[Dict[str, Any]]:
@@ -644,6 +660,7 @@ class SpawnSubagentTool(AsyncTool):
                     result = await subagent_manager.spawn(
                         name=name,
                         directive=directive,
+                        context=parent_context,
                         **spawn_kwargs
                     )
 
@@ -803,7 +820,13 @@ class SpawnSubagentTool(AsyncTool):
 
         return json.dumps(output, indent=2, ensure_ascii=False)
 
-    def _get_subagent_manager(self):
+    def _resolve_context(self, kwargs: Dict[str, Any]) -> Any:
+        message = kwargs.get('message')
+        if message is not None and getattr(message, 'context', None) is not None:
+            return message.context
+        return getattr(self, 'context', None)
+
+    def _get_subagent_manager(self, action_model: Optional[ActionModel] = None, context=None):
         """
         Get SubagentManager from current agent context.
 
@@ -817,14 +840,40 @@ class SpawnSubagentTool(AsyncTool):
             from aworld.core.agent.base import BaseAgent
             current_agent = BaseAgent._get_current_agent()
 
-            if current_agent and hasattr(current_agent, 'subagent_manager'):
+            if current_agent and hasattr(current_agent, 'subagent_manager') and current_agent.subagent_manager:
                 subagent_manager = current_agent.subagent_manager
-            else:
-                logger.error(
-                    "spawn_subagent: No SubagentManager available "
-                    "(agent not found or subagent not enabled)"
-                )
-                return None
+
+        if subagent_manager is None and context is not None:
+            try:
+                swarm = context.swarm
+            except Exception:
+                swarm = None
+
+            if swarm and getattr(swarm, 'agents', None):
+                candidate_agent_ids = []
+                if action_model and getattr(action_model, 'agent_name', None):
+                    candidate_agent_ids.append(action_model.agent_name)
+                agent_info = getattr(context, 'agent_info', None)
+                current_agent_id = agent_info.get('current_agent_id') if agent_info else None
+                if current_agent_id:
+                    candidate_agent_ids.append(current_agent_id)
+
+                seen = set()
+                for agent_id in candidate_agent_ids:
+                    if not agent_id or agent_id in seen:
+                        continue
+                    seen.add(agent_id)
+                    agent = swarm.agents.get(agent_id)
+                    if agent and getattr(agent, 'subagent_manager', None):
+                        subagent_manager = agent.subagent_manager
+                        break
+
+        if subagent_manager is None:
+            logger.error(
+                "spawn_subagent: No SubagentManager available "
+                "(agent context missing, current agent not set, or subagent not enabled)"
+            )
+            return None
 
         return subagent_manager
 
@@ -843,8 +892,19 @@ class SpawnSubagentTool(AsyncTool):
         Returns:
             Error response tuple
         """
+        observation = Observation(
+            content=error_msg,
+            action_result=[
+                ActionResult(
+                    is_done=True,
+                    success=False,
+                    content=error_msg,
+                    error=info.get('error', error_msg)
+                )
+            ]
+        )
         return (
-            Observation(content=error_msg),
+            observation,
             0.0,  # Failed reward
             False,  # Not terminated
             False,  # Not truncated
@@ -914,13 +974,19 @@ class SpawnSubagentTool(AsyncTool):
             spawn_kwargs['model'] = model
         if disallowed_tools:
             spawn_kwargs['disallowedTools'] = disallowed_tools
+        parent_context = self._resolve_context(kwargs)
+        if parent_context is not None:
+            spawn_kwargs['context'] = parent_context
 
         # ✅ Pass task_id as sub_task_id to ensure ID consistency between
         # Tool layer (_background_tasks) and Context layer (sub_task_list)
         spawn_kwargs['sub_task_id'] = task_id
 
         # Get SubagentManager
-        subagent_manager = self._get_subagent_manager()
+        subagent_manager = self._get_subagent_manager(
+            action_model=action_model,
+            context=parent_context
+        )
         if not subagent_manager:
             error_msg = "spawn_background: No SubagentManager available"
             logger.error(error_msg)
@@ -1263,7 +1329,7 @@ class SpawnSubagentTool(AsyncTool):
         except Exception as e:
             elapsed = time.time() - start_time
             error_msg = f"wait_task: Exception after {elapsed:.1f}s: {str(e)}"
-            logger.error(error_msg, exc_info=True)
+            logger.error(f"{error_msg}\n{traceback.format_exc()}")
             return self._error_response(error_msg, {'error': str(e), 'elapsed': round(elapsed, 2)})
 
     async def _cancel_task(
@@ -1451,7 +1517,6 @@ class SpawnSubagentTool(AsyncTool):
 
         except Exception as e:
             logger.error(
-                f"_sync_status_to_context: Failed to sync status for task '{task_id}': {e}",
-                exc_info=True
+                f"_sync_status_to_context: Failed to sync status for task '{task_id}': {e}\n"
+                f"{traceback.format_exc()}"
             )
-

--- a/aworld/models/ant_video_provider.py
+++ b/aworld/models/ant_video_provider.py
@@ -120,10 +120,20 @@ def _resolve_submitted_timeout(submitted_timeout: Any, poll_timeout: float) -> O
     ``None`` means "use the default", and any non-positive value disables the
     queued-status timeout guard.
     """
+    default_timeout = min(poll_timeout, _DEFAULT_SUBMITTED_TIMEOUT)
     if submitted_timeout is None:
-        return min(poll_timeout, _DEFAULT_SUBMITTED_TIMEOUT)
+        return default_timeout
 
-    resolved = float(submitted_timeout)
+    try:
+        resolved = float(submitted_timeout)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[AntVideoProvider] Invalid submitted_timeout %r; using default %.1fs",
+            submitted_timeout,
+            default_timeout,
+        )
+        return default_timeout
+
     if resolved <= 0:
         return None
     return resolved
@@ -1960,7 +1970,6 @@ class AntVideoProvider(VideoGenProviderBase):
         deadline = time.monotonic() + poll_timeout
         attempt  = 0
         queued_since: Optional[float] = None
-        last_status_key: Optional[str] = None
 
         while True:
             attempt += 1
@@ -1983,11 +1992,11 @@ class AntVideoProvider(VideoGenProviderBase):
             if adapter.is_terminal_status(status_raw):
                 return adapter.parse_response(data, model, is_image2video)
 
-            if status_key != last_status_key:
-                queued_since = now if status_key in _QUEUED_STATUS_KEYS else None
-                last_status_key = status_key
-            elif status_key in _QUEUED_STATUS_KEYS and queued_since is None:
-                queued_since = now
+            if status_key in _QUEUED_STATUS_KEYS:
+                if queued_since is None:
+                    queued_since = now
+            else:
+                queued_since = None
 
             if submitted_timeout is not None and status_key in _QUEUED_STATUS_KEYS and queued_since is not None:
                 queued_elapsed = now - queued_since
@@ -2049,7 +2058,6 @@ class AntVideoProvider(VideoGenProviderBase):
         deadline = time.monotonic() + poll_timeout
         attempt  = 0
         queued_since: Optional[float] = None
-        last_status_key: Optional[str] = None
 
         while True:
             attempt += 1
@@ -2072,11 +2080,11 @@ class AntVideoProvider(VideoGenProviderBase):
             if adapter.is_terminal_status(status_raw):
                 return adapter.parse_response(data, model, is_image2video)
 
-            if status_key != last_status_key:
-                queued_since = now if status_key in _QUEUED_STATUS_KEYS else None
-                last_status_key = status_key
-            elif status_key in _QUEUED_STATUS_KEYS and queued_since is None:
-                queued_since = now
+            if status_key in _QUEUED_STATUS_KEYS:
+                if queued_since is None:
+                    queued_since = now
+            else:
+                queued_since = None
 
             if submitted_timeout is not None and status_key in _QUEUED_STATUS_KEYS and queued_since is not None:
                 queued_elapsed = now - queued_since

--- a/aworld/models/ant_video_provider.py
+++ b/aworld/models/ant_video_provider.py
@@ -70,6 +70,7 @@ from aworld.trace import base
 
 _DEFAULT_POLL_INTERVAL = 5.0
 _DEFAULT_POLL_TIMEOUT  = 600.0
+_DEFAULT_SUBMITTED_TIMEOUT = 120.0
 
 # The single gateway endpoint shared by all vendors
 _GENERIC_CALL_ENDPOINT = "v1/genericCall"
@@ -81,6 +82,8 @@ _STATUS_MAP = {
     "succeed":    "succeeded",
     "failed":     "failed",
 }
+
+_QUEUED_STATUS_KEYS = frozenset({"submitted", "pending", "queued"})
 
 # Veo accepts only these image MIME types
 _VEO_ALLOWED_IMAGE_MIMES: frozenset = frozenset({"image/jpeg", "image/png", "image/webp"})
@@ -102,6 +105,28 @@ def _infer_image_mime_from_bytes(data: bytes) -> str:
         if sig != b"RIFF" and data.startswith(sig):
             return mime
     return "image/jpeg"  # fallback
+
+
+def _normalize_status_key(status_raw: Any) -> str:
+    """Normalize provider-specific status values for timeout classification."""
+    if status_raw is None:
+        return "unknown"
+    return str(status_raw).strip().lower()
+
+
+def _resolve_submitted_timeout(submitted_timeout: Any, poll_timeout: float) -> Optional[float]:
+    """Resolve the effective queued-status timeout.
+
+    ``None`` means "use the default", and any non-positive value disables the
+    queued-status timeout guard.
+    """
+    if submitted_timeout is None:
+        return min(poll_timeout, _DEFAULT_SUBMITTED_TIMEOUT)
+
+    resolved = float(submitted_timeout)
+    if resolved <= 0:
+        return None
+    return resolved
 
 
 def _parse_image_for_veo_payload(
@@ -1635,6 +1660,9 @@ class AntVideoProvider(VideoGenProviderBase):
         - ``poll`` (bool, default ``True``): Wait for the task to finish.
         - ``poll_interval`` (float, default 5): Seconds between polls.
         - ``poll_timeout`` (float, default 600): Maximum wait in seconds.
+        - ``submitted_timeout`` (float, default ``min(poll_timeout, 120)``):
+          Maximum time a task may remain queued/submitted before failing fast.
+          Set to ``0`` or a negative value to disable this guard.
         - ``model_name`` (str): Override the model for this single call.
 
         Additional vendor-specific keys (e.g. ``mode`` for Kling) are
@@ -1665,6 +1693,7 @@ class AntVideoProvider(VideoGenProviderBase):
         poll            = extra.pop("poll", True)
         poll_interval   = float(extra.pop("poll_interval", _DEFAULT_POLL_INTERVAL))
         poll_timeout    = float(extra.pop("poll_timeout",  _DEFAULT_POLL_TIMEOUT))
+        submitted_timeout = _resolve_submitted_timeout(extra.pop("submitted_timeout", None), poll_timeout)
         expiration_time = int(extra.pop("expiration_time", 7))
 
         adapter                    = _resolve_adapter(model)
@@ -1708,6 +1737,7 @@ class AntVideoProvider(VideoGenProviderBase):
             is_image2video=is_image2video,
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,
+            submitted_timeout=submitted_timeout,
         )
         return adapter.post_process(response, **pp_kwargs)
 
@@ -1743,6 +1773,7 @@ class AntVideoProvider(VideoGenProviderBase):
         poll            = extra.pop("poll", True)
         poll_interval   = float(extra.pop("poll_interval", _DEFAULT_POLL_INTERVAL))
         poll_timeout    = float(extra.pop("poll_timeout",  _DEFAULT_POLL_TIMEOUT))
+        submitted_timeout = _resolve_submitted_timeout(extra.pop("submitted_timeout", None), poll_timeout)
         expiration_time = int(extra.pop("expiration_time", 7))
 
         adapter                 = _resolve_adapter(model)
@@ -1783,6 +1814,7 @@ class AntVideoProvider(VideoGenProviderBase):
             is_image2video=is_image2video,
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,
+            submitted_timeout=submitted_timeout,
         )
         return await adapter.apost_process(response, **pp_kwargs)
 
@@ -1903,7 +1935,8 @@ class AntVideoProvider(VideoGenProviderBase):
                          model: str,
                          is_image2video: bool,
                          poll_interval: float,
-                         poll_timeout: float) -> ModelResponse:
+                         poll_timeout: float,
+                         submitted_timeout: Optional[float] = None) -> ModelResponse:
         """Block and poll until the task reaches a terminal status.
 
         Args:
@@ -1914,6 +1947,8 @@ class AntVideoProvider(VideoGenProviderBase):
             is_image2video: Passed through to the adapter.
             poll_interval: Seconds between polls.
             poll_timeout: Maximum total wait time in seconds.
+            submitted_timeout: Maximum time a task may remain queued/submitted
+                before failing fast. ``None`` disables the queued-state guard.
 
         Returns:
             ModelResponse for the final task state.
@@ -1924,6 +1959,8 @@ class AntVideoProvider(VideoGenProviderBase):
         """
         deadline = time.monotonic() + poll_timeout
         attempt  = 0
+        queued_since: Optional[float] = None
+        last_status_key: Optional[str] = None
 
         while True:
             attempt += 1
@@ -1939,18 +1976,46 @@ class AntVideoProvider(VideoGenProviderBase):
 
             data       = adapter.extract_status_data(body)
             status_raw = adapter.get_status_from_data(data)
+            now = time.monotonic()
+            status_key = _normalize_status_key(status_raw)
             logger.info(f"[AntVideoProvider] Task {task_id} poll #{attempt}: status={status_raw}")
 
             if adapter.is_terminal_status(status_raw):
                 return adapter.parse_response(data, model, is_image2video)
 
-            remaining = deadline - time.monotonic()
+            if status_key != last_status_key:
+                queued_since = now if status_key in _QUEUED_STATUS_KEYS else None
+                last_status_key = status_key
+            elif status_key in _QUEUED_STATUS_KEYS and queued_since is None:
+                queued_since = now
+
+            if submitted_timeout is not None and status_key in _QUEUED_STATUS_KEYS and queued_since is not None:
+                queued_elapsed = now - queued_since
+                queued_remaining = submitted_timeout - queued_elapsed
+                if queued_remaining <= 0:
+                    raise TimeoutError(
+                        f"Task {task_id} remained in queued status '{status_raw}' for "
+                        f"{submitted_timeout}s without starting processing. "
+                        f"This usually indicates backend queue saturation. "
+                        f"Increase submitted_timeout or reduce concurrency. "
+                        f"Total poll_timeout={poll_timeout}s."
+                    )
+            else:
+                queued_remaining = None
+
+            remaining = deadline - now
             if remaining <= 0:
                 raise TimeoutError(
                     f"Task {task_id} did not complete within {poll_timeout}s. "
                     f"Last status: {status_raw}"
                 )
-            time.sleep(min(poll_interval, remaining))
+
+            sleep_for = remaining
+            if poll_interval is not None:
+                sleep_for = min(sleep_for, poll_interval)
+            if queued_remaining is not None:
+                sleep_for = min(sleep_for, queued_remaining)
+            time.sleep(max(sleep_for, 0))
 
     async def _apoll_until_done(self,
                                 adapter: ModelAdapter,
@@ -1958,7 +2023,8 @@ class AntVideoProvider(VideoGenProviderBase):
                                 model: str,
                                 is_image2video: bool,
                                 poll_interval: float,
-                                poll_timeout: float) -> ModelResponse:
+                                poll_timeout: float,
+                                submitted_timeout: Optional[float] = None) -> ModelResponse:
         """Asynchronously poll until the task reaches a terminal status.
 
         Args:
@@ -1968,6 +2034,8 @@ class AntVideoProvider(VideoGenProviderBase):
             is_image2video: Passed through to the adapter.
             poll_interval: Seconds between polls.
             poll_timeout: Maximum total wait time in seconds.
+            submitted_timeout: Maximum time a task may remain queued/submitted
+                before failing fast. ``None`` disables the queued-state guard.
 
         Returns:
             ModelResponse for the final task state.
@@ -1980,6 +2048,8 @@ class AntVideoProvider(VideoGenProviderBase):
 
         deadline = time.monotonic() + poll_timeout
         attempt  = 0
+        queued_since: Optional[float] = None
+        last_status_key: Optional[str] = None
 
         while True:
             attempt += 1
@@ -1995,18 +2065,46 @@ class AntVideoProvider(VideoGenProviderBase):
 
             data       = adapter.extract_status_data(body)
             status_raw = adapter.get_status_from_data(data)
+            now = time.monotonic()
+            status_key = _normalize_status_key(status_raw)
             logger.info(f"[AntVideoProvider] Task {task_id} poll #{attempt} (async): status={status_raw}")
 
             if adapter.is_terminal_status(status_raw):
                 return adapter.parse_response(data, model, is_image2video)
 
-            remaining = deadline - time.monotonic()
+            if status_key != last_status_key:
+                queued_since = now if status_key in _QUEUED_STATUS_KEYS else None
+                last_status_key = status_key
+            elif status_key in _QUEUED_STATUS_KEYS and queued_since is None:
+                queued_since = now
+
+            if submitted_timeout is not None and status_key in _QUEUED_STATUS_KEYS and queued_since is not None:
+                queued_elapsed = now - queued_since
+                queued_remaining = submitted_timeout - queued_elapsed
+                if queued_remaining <= 0:
+                    raise TimeoutError(
+                        f"Task {task_id} remained in queued status '{status_raw}' for "
+                        f"{submitted_timeout}s without starting processing. "
+                        f"This usually indicates backend queue saturation. "
+                        f"Increase submitted_timeout or reduce concurrency. "
+                        f"Total poll_timeout={poll_timeout}s."
+                    )
+            else:
+                queued_remaining = None
+
+            remaining = deadline - now
             if remaining <= 0:
                 raise TimeoutError(
                     f"Task {task_id} did not complete within {poll_timeout}s. "
                     f"Last status: {status_raw}"
                 )
-            await asyncio.sleep(min(poll_interval, remaining))
+
+            sleep_for = remaining
+            if poll_interval is not None:
+                sleep_for = min(sleep_for, poll_interval)
+            if queued_remaining is not None:
+                sleep_for = min(sleep_for, queued_remaining)
+            await asyncio.sleep(max(sleep_for, 0))
 
 
 # ---------------------------------------------------------------------------

--- a/aworld/models/image_provider.py
+++ b/aworld/models/image_provider.py
@@ -32,6 +32,7 @@ Example usage:
     )
 """
 
+import base64
 import mimetypes
 import os
 import traceback

--- a/aworld/runners/handler/tool.py
+++ b/aworld/runners/handler/tool.py
@@ -8,7 +8,7 @@ from aworld.config import ConfigDict
 from aworld.core.agent.base import is_agent
 from aworld.core.common import ActionModel, TaskItem, Observation, ActionResult
 from aworld.core.event.base import Message, Constants, TopicType, AgentMessage, MemoryEventMessage, MemoryEventType
-from aworld.core.tool.base import AsyncTool, Tool, ToolFactory
+from aworld.core.tool.base import AsyncTool, Tool, ToolFactory, maybe_await
 from aworld.events.util import send_message_with_future
 from aworld.logs.util import logger
 from aworld.runners import HandlerFactory
@@ -80,10 +80,11 @@ class DefaultToolHandler(ToolHandler):
                 try:
                     tool = ToolFactory(act.tool_name, conf=conf, asyn=conf.use_async if conf else False)
                     tool.event_driven = True
+                    tool.context = message.context
                     if isinstance(tool, Tool):
                         tool.reset()
                     elif isinstance(tool, AsyncTool):
-                        await tool.reset()
+                        await maybe_await(tool.reset())
                     tool_mapping[act.tool_name] = []
                     self.tools[act.tool_name] = tool
                     new_tools[act.tool_name] = tool
@@ -144,6 +145,7 @@ class DefaultToolHandler(ToolHandler):
             if not (isinstance(self.tools[tool_name], Tool) or isinstance(self.tools[tool_name], AsyncTool)):
                 logger.warning(f"Unsupported tool type: {self.tools[tool_name]}")
                 continue
+            self.tools[tool_name].context = message.context
 
             # send to the tool
             yield Message(

--- a/aworld/runners/task_runner.py
+++ b/aworld/runners/task_runner.py
@@ -18,7 +18,7 @@ from aworld.core.context.amni import AmniConfigFactory
 from aworld.core.context.base import Context
 from aworld.core.context.session import Session
 from aworld.core.task import Task, TaskResponse, Runner
-from aworld.core.tool.base import Tool, AsyncTool
+from aworld.core.tool.base import Tool, AsyncTool, maybe_await
 from aworld.logs.util import logger
 from aworld.runners.hook.hooks import HookPoint
 from aworld.runners.hook.utils import run_hooks
@@ -131,7 +131,8 @@ class TaskRunner(Runner):
                     tool.context = self.context
                     tool_observation, info = tool.reset()
                 elif isinstance(tool, AsyncTool):
-                    tool_observation, info = await tool.reset()
+                    tool.context = self.context
+                    tool_observation, info = await maybe_await(tool.reset())
                 else:
                     logger.warning(f"Unsupported tool type: {tool}, will ignored.")
 

--- a/tests/core/agent/test_subagent_manager.py
+++ b/tests/core/agent/test_subagent_manager.py
@@ -534,6 +534,47 @@ class TestSpawnOrchestration:
             with pytest.raises(RuntimeError, match="No active context found"):
                 await manager.spawn(name="test", directive="Do something")
 
+    @pytest.mark.asyncio
+    async def test_spawn_accepts_explicit_context(self):
+        """Explicit context should bypass the current-context requirement."""
+        agent = Mock(spec=Agent)
+        agent.tool_names = []
+        agent.conf = AgentConfig()
+        manager = SubagentManager(agent=agent)
+
+        subagent = Mock(spec=Agent)
+        subagent.name.return_value = "test"
+        subagent.tool_names = []
+        subagent.handoffs = []
+        subagent.conf = AgentConfig()
+        subagent.desc.return_value = "Test subagent"
+        subagent.feedback_tool_result = True
+        subagent.wait_tool_result = False
+        subagent.sandbox = None
+
+        manager._available_subagents["test"] = SubagentInfo(
+            name="test",
+            description="Test agent",
+            source='team_member',
+            tools=[],
+            agent_instance=subagent
+        )
+
+        context = Context()
+        context.set_task(Mock())
+        context.build_sub_context = AsyncMock(return_value=context)
+        context.merge_sub_context = Mock()
+
+        with patch.object(BaseAgent, '_get_current_context', return_value=None), \
+             patch("aworld.runner.Runners.run_task", AsyncMock(return_value={"task-id": Mock(success=True, answer="done")})), \
+             patch("aworld.core.task.Task", autospec=True) as task_cls:
+            task_cls.return_value.id = "task-id"
+            result = await manager.spawn(name="test", directive="Do something", context=context)
+
+        assert result == "done"
+        context.build_sub_context.assert_awaited_once()
+        context.merge_sub_context.assert_called_once()
+
 
 if __name__ == '__main__':
     """Run tests directly with pytest"""

--- a/tests/core/tool/test_spawn_parallel.py
+++ b/tests/core/tool/test_spawn_parallel.py
@@ -10,6 +10,9 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aworld.config.conf import ConfigDict
+from aworld.core.context.base import Context
+from aworld.core.event.base import Constants, Message
 from aworld.core.tool.builtin.spawn_subagent_tool import SpawnSubagentTool
 from aworld.core.common import ActionModel, Observation
 from aworld.core.agent.subagent_manager import SubagentManager
@@ -217,6 +220,85 @@ async def test_spawn_parallel_concurrency_limit(mock_subagent_manager):
 
     # Verify max concurrent was respected
     assert max_active <= 3
+
+
+@pytest.mark.asyncio
+async def test_spawn_parallel_resolves_manager_from_context_agent():
+    """Tool should resolve the caller agent's SubagentManager from context."""
+    manager = MagicMock(spec=SubagentManager)
+    manager.spawn = AsyncMock(return_value="[image_generator] ok")
+
+    caller_agent = MagicMock()
+    caller_agent.subagent_manager = manager
+
+    swarm = MagicMock()
+    swarm.agents = {"root-agent": caller_agent}
+
+    context = Context()
+    task = MagicMock()
+    task.swarm = swarm
+    context.set_task(task)
+    context.agent_info.current_agent_id = "root-agent"
+
+    tool = SpawnSubagentTool(conf=ConfigDict({}))
+    tool.context = context
+
+    action = ActionModel(
+        agent_name="root-agent",
+        action_name='spawn_parallel',
+        params={
+            'tasks': [
+                {'name': 'image_generator', 'directive': 'Generate one image'}
+            ],
+            'aggregate': True,
+        }
+    )
+
+    observation, reward, _, _, info = await tool.do_step([action])
+
+    assert reward == 1.0
+    assert info['success_count'] == 1
+    assert 'image_generator' in observation.content
+    manager.spawn.assert_awaited_once()
+    assert manager.spawn.await_args.kwargs['context'] is context
+
+
+@pytest.mark.asyncio
+async def test_spawn_parallel_step_returns_error_without_secondary_index_error():
+    """Error responses should not crash AsyncTool.post_step with empty action_result."""
+    swarm = MagicMock()
+    caller_agent = MagicMock(feedback_tool_result=True)
+    caller_agent.subagent_manager = None
+    swarm.agents = {"root-agent": caller_agent}
+
+    context = Context()
+    task = MagicMock()
+    task.swarm = swarm
+    context.set_task(task)
+
+    tool = SpawnSubagentTool(conf=ConfigDict({}))
+    message = Message(
+        category=Constants.TOOL,
+        payload=[
+            ActionModel(
+                tool_name='async_spawn_subagent',
+                tool_call_id='call-1',
+                agent_name='root-agent',
+                action_name='spawn_parallel',
+                params={'tasks': [{'name': 'image_generator', 'directive': 'Generate one image'}]},
+            )
+        ],
+        headers={'context': context},
+    )
+
+    with patch("aworld.core.tool.base.send_message", AsyncMock()), patch(
+        "aworld.core.tool.base.send_message_with_future",
+        AsyncMock(side_effect=RuntimeError("skip callback in unit test"))
+    ):
+        result = await tool.step(message)
+
+    assert result.payload[0].content == "spawn_parallel: No SubagentManager available"
+    assert result.payload[0].action_result[0].error == "No SubagentManager"
 
 
 @pytest.mark.asyncio

--- a/tests/core/tool/test_spawn_parallel.py
+++ b/tests/core/tool/test_spawn_parallel.py
@@ -264,6 +264,46 @@ async def test_spawn_parallel_resolves_manager_from_context_agent():
 
 
 @pytest.mark.asyncio
+async def test_spawn_parallel_resolves_manager_from_object_agent_info_without_action_agent_name():
+    """Tool should support object-like agent_info, not only dict-like access."""
+    manager = MagicMock(spec=SubagentManager)
+    manager.spawn = AsyncMock(return_value="[image_generator] ok")
+
+    caller_agent = MagicMock()
+    caller_agent.subagent_manager = manager
+
+    swarm = MagicMock()
+    swarm.agents = {"root-agent": caller_agent}
+
+    context = Context()
+    task = MagicMock()
+    task.swarm = swarm
+    context.set_task(task)
+    context.agent_info.current_agent_id = "root-agent"
+
+    tool = SpawnSubagentTool(conf=ConfigDict({}))
+    tool.context = context
+
+    action = ActionModel(
+        action_name='spawn_parallel',
+        params={
+            'tasks': [
+                {'name': 'image_generator', 'directive': 'Generate one image'}
+            ],
+            'aggregate': True,
+        }
+    )
+
+    observation, reward, _, _, info = await tool.do_step([action])
+
+    assert reward == 1.0
+    assert info['success_count'] == 1
+    assert 'image_generator' in observation.content
+    manager.spawn.assert_awaited_once()
+    assert manager.spawn.await_args.kwargs['context'] is context
+
+
+@pytest.mark.asyncio
 async def test_spawn_parallel_step_returns_error_without_secondary_index_error():
     """Error responses should not crash AsyncTool.post_step with empty action_result."""
     swarm = MagicMock()

--- a/tests/models/test_ant_video_provider.py
+++ b/tests/models/test_ant_video_provider.py
@@ -136,6 +136,67 @@ def test_generate_video_uses_default_submitted_timeout(monkeypatch, fake_clock):
     assert fake_clock.now == 120.0
 
 
+def test_generate_video_falls_back_when_submitted_timeout_is_invalid(monkeypatch, fake_clock):
+    provider = AntVideoProvider(
+        model_name="dummy-video-model",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+    provider.provider = _SequentialSyncClient(
+        [
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+        ]
+    )
+    monkeypatch.setattr(ant_video_provider_module, "_resolve_adapter", lambda model: _DummyAdapter())
+
+    request = VideoGenerationRequest(
+        prompt="generate a video",
+        extra_params={
+            "poll": True,
+            "poll_interval": 60.0,
+            "poll_timeout": 600.0,
+            "submitted_timeout": "not-a-number",
+        },
+    )
+
+    with pytest.raises(TimeoutError, match="120.0s without starting processing"):
+        provider.generate_video(request)
+
+    assert fake_clock.now == 120.0
+
+
+def test_poll_until_done_counts_cumulative_time_across_queued_status_variants(fake_clock):
+    provider = AntVideoProvider(
+        model_name="dummy-video-model",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+    provider.provider = _SequentialSyncClient(
+        [
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "pending"},
+            {"task_id": "task-1", "task_status": "queued"},
+            {"task_id": "task-1", "task_status": "queued"},
+        ]
+    )
+
+    with pytest.raises(TimeoutError, match="queued status 'queued'"):
+        provider._poll_until_done(
+            adapter=_DummyAdapter(),
+            task_id="task-1",
+            model="dummy-video-model",
+            is_image2video=False,
+            poll_interval=5.0,
+            poll_timeout=600.0,
+            submitted_timeout=15.0,
+        )
+
+    assert fake_clock.now == 15.0
+
+
 def test_poll_until_done_allows_progress_after_submitted(fake_clock):
     provider = AntVideoProvider(
         model_name="dummy-video-model",

--- a/tests/models/test_ant_video_provider.py
+++ b/tests/models/test_ant_video_provider.py
@@ -1,0 +1,167 @@
+import pytest
+
+import aworld.models.ant_video_provider as ant_video_provider_module
+from aworld.core.video_gen_provider import VideoGenerationRequest
+from aworld.models.ant_video_provider import AntVideoProvider, ModelAdapter
+from aworld.models.model_response import ModelResponse, VideoGenerationResult
+
+
+class _DummyAdapter(ModelAdapter):
+    def build_submit_payload(self, request, model, extra):
+        return False, {"prompt": request.prompt}
+
+    def build_status_payload(self, task_id, model, is_image2video):
+        return {"task_id": task_id}
+
+    def parse_response(self, data, model, is_image2video=False):
+        raw_status = data.get("task_status", "unknown")
+        status = {
+            "submitted": "submitted",
+            "processing": "processing",
+            "succeed": "succeeded",
+            "failed": "failed",
+            "PENDING": "submitted",
+        }.get(raw_status, raw_status)
+        return ModelResponse(
+            id=data.get("task_id", "task-1"),
+            model=model,
+            video_result=VideoGenerationResult(
+                task_id=data.get("task_id", "task-1"),
+                status=status,
+                video_url=data.get("video_url"),
+            ),
+            raw_response=data,
+        )
+
+    def check_submit_response(self, body, model):
+        return None
+
+    def extract_submit_data(self, body):
+        return body
+
+    def extract_task_id(self, data):
+        return data.get("task_id", "")
+
+    def check_status_response(self, body, model):
+        return None
+
+    def extract_status_data(self, body):
+        return body
+
+    def get_status_from_data(self, data):
+        return data.get("task_status", "unknown")
+
+
+class _SequentialSyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def sync_call(self, payload, endpoint=None):
+        if not self._responses:
+            raise AssertionError("No more stub responses available")
+        return self._responses.pop(0)
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(ant_video_provider_module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(ant_video_provider_module.time, "sleep", clock.sleep)
+    return clock
+
+
+def test_poll_until_done_times_out_when_task_stays_submitted(fake_clock):
+    provider = AntVideoProvider(
+        model_name="dummy-video-model",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+    provider.provider = _SequentialSyncClient(
+        [{"task_id": "task-1", "task_status": "submitted"} for _ in range(4)]
+    )
+
+    with pytest.raises(TimeoutError, match="queued status 'submitted'"):
+        provider._poll_until_done(
+            adapter=_DummyAdapter(),
+            task_id="task-1",
+            model="dummy-video-model",
+            is_image2video=False,
+            poll_interval=5.0,
+            poll_timeout=600.0,
+            submitted_timeout=15.0,
+        )
+
+    assert fake_clock.now == 15.0
+
+
+def test_generate_video_uses_default_submitted_timeout(monkeypatch, fake_clock):
+    provider = AntVideoProvider(
+        model_name="dummy-video-model",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+    provider.provider = _SequentialSyncClient(
+        [
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "submitted"},
+        ]
+    )
+    monkeypatch.setattr(ant_video_provider_module, "_resolve_adapter", lambda model: _DummyAdapter())
+
+    request = VideoGenerationRequest(
+        prompt="generate a video",
+        extra_params={
+            "poll": True,
+            "poll_interval": 60.0,
+            "poll_timeout": 600.0,
+        },
+    )
+
+    with pytest.raises(TimeoutError, match="120.0s without starting processing"):
+        provider.generate_video(request)
+
+    assert fake_clock.now == 120.0
+
+
+def test_poll_until_done_allows_progress_after_submitted(fake_clock):
+    provider = AntVideoProvider(
+        model_name="dummy-video-model",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+    provider.provider = _SequentialSyncClient(
+        [
+            {"task_id": "task-1", "task_status": "submitted"},
+            {"task_id": "task-1", "task_status": "processing"},
+            {"task_id": "task-1", "task_status": "processing"},
+            {"task_id": "task-1", "task_status": "succeed", "video_url": "https://example.com/video.mp4"},
+        ]
+    )
+
+    response = provider._poll_until_done(
+        adapter=_DummyAdapter(),
+        task_id="task-1",
+        model="dummy-video-model",
+        is_image2video=False,
+        poll_interval=10.0,
+        poll_timeout=60.0,
+        submitted_timeout=15.0,
+    )
+
+    assert response.video_result is not None
+    assert response.video_result.status == "succeeded"
+    assert response.video_result.video_url == "https://example.com/video.mp4"
+    assert fake_clock.now == 30.0

--- a/tests/models/test_image_provider.py
+++ b/tests/models/test_image_provider.py
@@ -198,3 +198,35 @@ def test_edit_request_supports_mixed_local_file_and_data_url_inputs(tmp_path: Pa
     assert len(payload["image[]"]) == 1
     assert payload["image[]"][0]["filename"] == "cat.webp"
     assert payload["url[]"] == ["data:image/png;base64,abc123"]
+
+
+def test_parse_image_response_decodes_b64_json_and_writes_output(tmp_path: Path):
+    provider = ImageProvider(
+        api_key="test-key",
+        base_url="https://antchat.alipay.com",
+        model_name="Qwen-Image-2512-Lightning",
+        sync_enabled=False,
+        async_enabled=False,
+    )
+
+    output_path = tmp_path / "image.png"
+    response = provider._parse_image_response(
+        {
+            "id": "img-test",
+            "model": "image",
+            "data": [
+                {
+                    "b64_json": "aGVsbG8=",
+                    "size": "1024x1024",
+                }
+            ],
+        },
+        output_format="png",
+        output_path=str(output_path),
+    )
+
+    assert response.id == "img-test"
+    assert response.image_data == b"hello"
+    assert response.image_bytes == 5
+    assert response.image_format == "png"
+    assert output_path.read_bytes() == b"hello"

--- a/tests/runners/test_tool_reset_compat.py
+++ b/tests/runners/test_tool_reset_compat.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2025 inclusionAI.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aworld.config import ConfigDict
+from aworld.core.common import ActionModel, Observation
+from aworld.core.context.base import Context
+from aworld.core.event.base import Constants, Message, TopicType
+from aworld.core.task import Task, TaskResponse
+from aworld.core.tool.base import AsyncTool
+from aworld.runners.handler.tool import DefaultToolHandler
+from aworld.runners.task_runner import TaskRunner
+
+
+class SyncResetAsyncTool(AsyncTool):
+    """AsyncTool variant with a synchronous reset to cover mixed implementations."""
+
+    def __init__(self, conf=None, **kwargs):
+        self.reset_calls = 0
+        super().__init__(conf=conf or ConfigDict({}), **kwargs)
+
+    def reset(self, *, seed: int | None = None, options=None):
+        self.reset_calls += 1
+        return Observation(content="tool-ready"), {}
+
+    async def do_step(self, action, **kwargs):
+        return Observation(content="done"), 1.0, False, False, {}
+
+    async def close(self):
+        return None
+
+
+class DummyTaskRunner(TaskRunner):
+    async def do_run(self, context=None) -> TaskResponse:
+        return TaskResponse(success=True, answer="ok")
+
+    async def streaming(self):
+        if False:
+            yield None
+
+
+@pytest.mark.asyncio
+async def test_default_tool_handler_accepts_sync_reset_for_async_tool():
+    runner = MagicMock()
+    runner.tools = {}
+    runner.tools_conf = {}
+    runner.event_mng.get_handlers.return_value = {}
+
+    handler = DefaultToolHandler(runner)
+    tool = SyncResetAsyncTool(name="async_broken_tool")
+
+    message = Message(
+        category=Constants.TOOL,
+        payload=[
+            ActionModel(
+                tool_name="async_broken_tool",
+                tool_call_id="call-1",
+                agent_name="root-agent",
+            )
+        ],
+        session_id="session-1",
+        headers={"context": Context()},
+    )
+
+    with patch("aworld.runners.handler.tool.ToolFactory", return_value=tool):
+        outputs = [msg async for msg in handler._do_handle(message)]
+
+    assert tool.reset_calls == 1
+    assert runner.tools["async_broken_tool"] is tool
+    assert tool.context is message.context
+    assert any(msg.topic == TopicType.SUBSCRIBE_TOOL for msg in outputs)
+    assert any(msg.category == Constants.TOOL and msg.receiver == "async_broken_tool" for msg in outputs)
+
+
+@pytest.mark.asyncio
+async def test_task_runner_accepts_sync_reset_for_async_tool():
+    tool = SyncResetAsyncTool(name="async_broken_tool")
+    swarm = MagicMock()
+    swarm.agents = {}
+    swarm.reset = MagicMock()
+
+    task = Task(
+        input="hello",
+        swarm=swarm,
+        tools=[tool],
+        tool_names=[],
+        context=Context(),
+        conf=ConfigDict(),
+    )
+
+    runner = DummyTaskRunner(task)
+    await runner.pre_run()
+
+    assert tool.reset_calls == 1
+    assert tool.context is runner.context
+    assert runner.observation.content == "tool-ready"


### PR DESCRIPTION
## Summary
- fix async spawn_subagent reset/context handling so parallel subagent execution works reliably in real CLI runs
- fix image generation decoding for b64_json responses and harden tool error propagation
- add queued video task timeout handling so parallel video generation fails fast instead of appearing hung

## Testing
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest -q tests/models/test_ant_video_provider.py
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest -q tests/core/tool/test_spawn_parallel.py tests/core/agent/test_subagent_manager.py tests/models/test_image_provider.py