### PR TITLE
fix: harden cron reminder scheduling and temp tool modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ examples/gaia/gaia_dataset/
 # Temporary files
 *.tmp
 *.temp
+*__tmp.py
+*__tmp_action.py
 .*.swp
 .*.swo
 *.webm

--- a/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/prompt.txt
+++ b/aworld-cli/src/aworld_cli/inner_plugins/smllc/agents/prompt.txt
@@ -121,6 +121,9 @@ You are equipped with multiple assistants. It is your job to know which to use a
     - **When to invoke:** Use this for future reminders, delayed execution, and recurring reminders instead of shell-based waiting.
     - **Quick summary:** add: Create a new scheduled task
     - **Natural-language usage:** When the schedule is obvious from the user's wording, pass the user's raw reminder request directly to `cron` via the add action instead of trying to simulate the delay with shell commands or manually decomposing the schedule first.
+    - **Do not invent timestamps:** If the user's request already contains relative or natural-language time information such as `一分钟后`, `两分钟后`, `明天`, or `每天早上9点`, do not generate or guess an absolute `schedule_value` yourself. Let `cron` parse the raw request at execution time.
+    - **Do not use shell/python for reminder time math:** Do not call `bash`, write Python, or manually compute the current time just to schedule a reminder when `cron` can parse the raw request directly.
+    - **Use cron output as source of truth:** After calling `cron`, only trust the tool's returned fields such as `success`, `job_id`, `next_run`, and `error`. Never keep using an earlier guessed `schedule_value` once the tool has returned.
     - **Actions:**
       - `add`: Create a new scheduled task
       - `list`: Show all scheduled tasks
@@ -207,6 +210,8 @@ You are equipped with multiple assistants. It is your job to know which to use a
 - **Honest Capability Assessment:** If a user's request is beyond the combined capabilities of your available assistants, you must terminate the task and clearly explain to the user why it cannot be completed.
 - **Scheduled Reminders And Future Triggers:** For future reminders, delayed execution, or recurring reminders, use `cron` to create a scheduled task and reply immediately after the task is created.
 - **Do Not Simulate Reminders With Shell Waiting:** Do not use `bash` with `sleep`, foreground waiting, delayed `echo`, or temp-file polling to implement reminders. If the user wants "X minutes later remind me", "tomorrow remind me", or recurring reminders, create a `cron` task instead.
+- **Do Not Precompute Reminder Timestamps:** For reminder requests, do not invent absolute times in the assistant response or tool arguments when the raw user request already contains natural-language timing. Pass the raw request to `cron` and let the tool determine the actual schedule from the current runtime clock.
+- **Cron Result Wins:** After `cron` returns, use the returned `next_run` as the confirmed reminder time. If `success` is false, or a one-time reminder does not come back with a valid `next_run`, do not tell the user the reminder was successfully created.
 - **Finite Repeating Reminders:** If the user wants a repeating reminder with a fixed total count, create a single cron task with a run limit and pass the raw request to `cron`; do not create a second stop task.
 - **Working Directory:** Always treat the working directory ({{ARTIFACT_DIRECTORY}}) as your working directory for all actions: run shell commands from it, and use it (or paths under it) for any temporary or output files when such operations are permitted (e.g. non-code tasks). You MUST NOT redirect work or temporary files to /tmp; Always use the working directory so outputs stay with the user's context.
 - **Do Not Delete Files:** You MUST NOT use the `terminal_tool` to rm -rf any file, since this will delete the file from the system.

--- a/aworld/agents/llm_agent.py
+++ b/aworld/agents/llm_agent.py
@@ -957,9 +957,41 @@ class LLMAgent(BaseAgent[Observation, List[ActionModel]]):
         """
         content = ""
         for res in tool_results:
-            content += f"{res.content}\n"
+            content += f"{self._format_tool_result_for_followup(res)}\n"
         params = {"is_tool_result": True}
         return [ActionModel(agent_name=self.id(), policy_info=content, params=params)]
+
+    def _format_tool_result_for_followup(self, result: ActionResult) -> str:
+        """Format tool results for the next LLM turn.
+
+        Most tools can be forwarded as-is. For cron scheduling, add an explicit
+        source-of-truth note so the model uses the runtime-confirmed schedule
+        instead of reusing an earlier guessed timestamp.
+        """
+        content = result.content
+        if result.tool_name != "cron" or not isinstance(content, dict):
+            return str(content)
+
+        serialized = json.dumps(content, ensure_ascii=False)
+        if not content.get("success"):
+            return (
+                f"{serialized}\n"
+                "Cron returned an error. Do not claim the reminder or scheduled task was created."
+            )
+
+        next_run = content.get("next_run")
+        job_id = content.get("job_id")
+        if next_run:
+            return (
+                f"{serialized}\n"
+                f"Confirmed cron schedule: next_run={next_run}; job_id={job_id}. "
+                "Use this cron result as the source of truth and do not reuse any earlier guessed schedule_value."
+            )
+
+        return (
+            f"{serialized}\n"
+            "Cron did not return a confirmed next_run. Do not say the reminder time is confirmed."
+        )
 
     async def build_llm_input(self,
                               observation: Observation,

--- a/aworld/core/tool/func_to_tool.py
+++ b/aworld/core/tool/func_to_tool.py
@@ -5,7 +5,9 @@ import importlib.util
 import inspect
 import os
 import sys
+import tempfile
 import uuid
+from pathlib import Path
 
 from typing import Callable, Any, get_type_hints, get_origin, get_args
 
@@ -20,6 +22,20 @@ from aworld.core.tool.base import ToolFactory
 from aworld.core.tool.tool_template import TOOL_TEMPLATE
 from aworld.logs.util import logger
 from aworld.tools import LOCAL_TOOLS_ENV_VAR
+
+
+GENERATED_TOOL_DIR_ENV_VAR = "AWORLD_TOOL_TMP_DIR"
+
+
+def _get_generated_tool_dir() -> Path:
+    """Return the directory used for runtime-generated tool modules."""
+    configured_dir = (os.environ.get(GENERATED_TOOL_DIR_ENV_VAR) or "").strip()
+    if configured_dir:
+        output_dir = Path(os.path.expanduser(configured_dir))
+    else:
+        output_dir = Path(tempfile.gettempdir()) / "aworld_local_tools"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
 
 
 def _load_module_from_path(module_name: str, file_path: str):
@@ -110,9 +126,10 @@ def function_to_tool(
     action_name = name or func.__name__
 
     postfix = f"{uuid.uuid4().hex[0:6]}__tmp"
+    output_dir = _get_generated_tool_dir()
 
     action_module_name = f"{action_name}{postfix}_action"
-    action_py_path = os.path.abspath(f"{action_module_name}.py")
+    action_py_path = str((output_dir / f"{action_module_name}.py").resolve())
 
     with open(action_py_path, 'w') as write:
         write.writelines("from __future__ import annotations\n")
@@ -166,7 +183,7 @@ def function_to_tool(
     parameters = func_params(func)
 
     module_name = f'{tool_name}'
-    tool_py_path = os.path.abspath(f"{tool_name}{postfix}.py")
+    tool_py_path = str((output_dir / f"{tool_name}{postfix}.py").resolve())
     expected_action_cls = f"{tool_name}Action"
     existing_module = sys.modules.get(module_name)
     if existing_module is None or not hasattr(existing_module, expected_action_cls):

--- a/aworld/core/tool/func_to_tool.py
+++ b/aworld/core/tool/func_to_tool.py
@@ -7,6 +7,7 @@ import os
 import sys
 import tempfile
 import uuid
+import getpass
 from pathlib import Path
 
 from typing import Callable, Any, get_type_hints, get_origin, get_args
@@ -27,13 +28,25 @@ from aworld.tools import LOCAL_TOOLS_ENV_VAR
 GENERATED_TOOL_DIR_ENV_VAR = "AWORLD_TOOL_TMP_DIR"
 
 
+def _get_generated_tool_dir_name() -> str:
+    """Return a user-scoped directory name for runtime-generated tool modules."""
+    username = (getpass.getuser() or "unknown").strip() or "unknown"
+    safe_username = "".join(
+        ch if ch.isalnum() or ch in {"-", "_", "."} else "_"
+        for ch in username
+    )
+    uid_getter = getattr(os, "getuid", None)
+    uid_suffix = f"_{uid_getter()}" if callable(uid_getter) else ""
+    return f"aworld_local_tools_{safe_username}{uid_suffix}"
+
+
 def _get_generated_tool_dir() -> Path:
     """Return the directory used for runtime-generated tool modules."""
     configured_dir = (os.environ.get(GENERATED_TOOL_DIR_ENV_VAR) or "").strip()
     if configured_dir:
         output_dir = Path(os.path.expanduser(configured_dir))
     else:
-        output_dir = Path(tempfile.gettempdir()) / "aworld_local_tools"
+        output_dir = Path(tempfile.gettempdir()) / _get_generated_tool_dir_name()
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -4,6 +4,7 @@
 Cron tool - manage scheduled tasks through Agent.
 """
 import re
+import traceback
 from datetime import datetime, timedelta
 from typing import Dict, Any, List, Optional, Literal
 from pydantic import Field
@@ -481,7 +482,7 @@ async def cron_tool(
             return {"success": False, "error": f"Unknown action: {action}"}
 
     except Exception as e:
-        logger.error(f"Cron tool error: {e}")
+        logger.error(f"Cron tool error: {e}\n{traceback.format_exc()}")
         return {
             "success": False,
             "error": f"Internal error: {str(e)}"

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -101,7 +101,8 @@ async def cron_tool(
 ) -> Dict[str, Any]:
     """Execute cron operations."""
     # Import helpers from the canonical module path so dynamic @be_tool wrappers
-    # can still resolve them after copying only this function's source.
+    # can still resolve them even when this function source is copied before the
+    # helper definitions below are executed.
     from aworld.tools.cron_tool import (
         _parse_natural_language_add_request as parse_request_helper,
         _unwrap_fieldinfo as unwrap_fieldinfo_helper,
@@ -314,19 +315,37 @@ async def cron_tool(
         scheduler = get_scheduler()
 
         if action == "add":
-            if request and not all([name, message, schedule_type, schedule_value]):
+            request_schedule_derived = False
+            if request:
                 try:
                     parsed_request = parse_request_helper(request)
                 except ValueError as e:
-                    return {"success": False, "error": str(e)}
+                    if not all([name, message, schedule_type, schedule_value]):
+                        return {"success": False, "error": str(e)}
+                    parsed_request = None
 
-                name = name or parsed_request["name"]
-                message = message or parsed_request["message"]
-                schedule_type = schedule_type or parsed_request["schedule_type"]
-                schedule_value = schedule_value or parsed_request["schedule_value"]
-                max_runs = max_runs or parsed_request.get("max_runs")
-                if delete_after_run is None:
-                    delete_after_run = parsed_request["delete_after_run"]
+                if parsed_request:
+                    request_schedule_derived = True
+                    if schedule_type and schedule_type != parsed_request["schedule_type"]:
+                        logger.warning(
+                            "cron_tool(add): overriding LLM-provided "
+                            f"schedule_type {schedule_type!r} with request-derived value "
+                            f"{parsed_request['schedule_type']!r} for request {request!r}"
+                        )
+                    if schedule_value and schedule_value != parsed_request["schedule_value"]:
+                        logger.warning(
+                            "cron_tool(add): overriding LLM-provided "
+                            f"schedule_value {schedule_value!r} with request-derived value "
+                            f"{parsed_request['schedule_value']!r} for request {request!r}"
+                        )
+
+                    name = name or parsed_request["name"]
+                    message = message or parsed_request["message"]
+                    schedule_type = parsed_request["schedule_type"]
+                    schedule_value = parsed_request["schedule_value"]
+                    max_runs = max_runs or parsed_request.get("max_runs")
+                    if delete_after_run is None:
+                        delete_after_run = parsed_request["delete_after_run"]
 
             # Validate required parameters
             if not all([name, message, schedule_type, schedule_value]):
@@ -340,6 +359,21 @@ async def cron_tool(
                 schedule = parse_schedule_local(schedule_type, schedule_value)
             except ValueError as e:
                 return {"success": False, "error": f"Invalid schedule: {str(e)}"}
+
+            if schedule_type == "at" and schedule.at and not request_schedule_derived:
+                target_time = datetime.fromisoformat(schedule.at.replace('Z', '+00:00'))
+                current_time = _resolve_schedule_now(None)
+                if target_time.tzinfo is None:
+                    target_time = target_time.replace(tzinfo=current_time.tzinfo)
+                if target_time <= current_time.astimezone(target_time.tzinfo):
+                    return {
+                        "success": False,
+                        "error": (
+                            f"One-time schedule is already in the past: {schedule.at}. "
+                            "Provide a future time or pass a natural-language request such as "
+                            "'一分钟后提醒我喝水'."
+                        ),
+                    }
 
             # Build job
             job = CronJob(
@@ -447,7 +481,7 @@ async def cron_tool(
             return {"success": False, "error": f"Unknown action: {action}"}
 
     except Exception as e:
-        logger.error(f"Cron tool error: {e}", exc_info=True)
+        logger.error(f"Cron tool error: {e}")
         return {
             "success": False,
             "error": f"Internal error: {str(e)}"
@@ -516,6 +550,7 @@ def _parse_natural_language_add_request(request: str, now: Optional[datetime] = 
 
     Supported examples:
     - 一分钟后提醒我喝水
+    - 提醒我一分钟后喝水
     - 30分钟后提醒我提交代码
     - 每天早上9点提醒我运行测试
     - 明天下午3点提醒我开会
@@ -534,6 +569,26 @@ def _parse_natural_language_add_request(request: str, now: Optional[datetime] = 
         quantity = _parse_natural_language_number(relative_match.group("num"))
         unit = relative_match.group("unit")
         body = relative_match.group("body")
+        delta = _natural_language_delta(quantity, unit)
+        target_time = current_time + delta
+        message = _normalize_reminder_message(body)
+        return {
+            "name": _reminder_name_from_message(message),
+            "message": message,
+            "schedule_type": "at",
+            "schedule_value": target_time.isoformat(timespec="seconds"),
+            "delete_after_run": True,
+        }
+
+    leading_relative_match = re.fullmatch(
+        r"提醒我(?P<num>\d+|[零一二两三四五六七八九十]+)\s*"
+        r"(?P<unit>秒钟?|秒|分钟|分|小时|个小时|小时|天|日)后(?P<body>.+)",
+        text,
+    )
+    if leading_relative_match:
+        quantity = _parse_natural_language_number(leading_relative_match.group("num"))
+        unit = leading_relative_match.group("unit")
+        body = leading_relative_match.group("body")
         delta = _natural_language_delta(quantity, unit)
         target_time = current_time + delta
         message = _normalize_reminder_message(body)

--- a/tests/core/agent/test_aworld_prompt_policy.py
+++ b/tests/core/agent/test_aworld_prompt_policy.py
@@ -37,3 +37,17 @@ def test_aworld_prompt_prefers_single_bounded_cron_for_finite_repetition():
     assert "If the user wants a repeating reminder with a fixed total count" in prompt
     assert "single cron task with a run limit" in prompt
     assert "do not create a second stop task" in prompt
+
+
+def test_aworld_prompt_forbids_inventing_absolute_reminder_timestamps():
+    prompt = load_aworld_system_prompt()
+
+    assert "do not generate or guess an absolute `schedule_value` yourself" in prompt
+    assert "Do not call `bash`, write Python, or manually compute the current time" in prompt
+
+
+def test_aworld_prompt_requires_using_cron_result_as_source_of_truth():
+    prompt = load_aworld_system_prompt()
+
+    assert "only trust the tool's returned fields such as `success`, `job_id`, `next_run`, and `error`" in prompt
+    assert "use the returned `next_run` as the confirmed reminder time" in prompt

--- a/tests/core/agent/test_tool_result_followup_format.py
+++ b/tests/core/agent/test_tool_result_followup_format.py
@@ -1,0 +1,60 @@
+import pytest
+
+from aworld.agents.llm_agent import Agent
+from aworld.config.conf import AgentConfig
+from aworld.core.common import ActionResult
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_results_are_reframed_with_confirmed_next_run():
+    agent = Agent(
+        name="Aworld",
+        conf=AgentConfig(
+            llm_provider="openai",
+            llm_model_name="fake-model",
+            llm_api_key="fake-key",
+        ),
+    )
+
+    aggregated = await agent._tools_aggregate_func([
+        ActionResult(
+            tool_name="cron",
+            content={
+                "success": True,
+                "job_id": "job-123",
+                "next_run": "2026-04-14T17:17:00+08:00",
+                "message": "Created task '喝水提醒' (ID: job-123)",
+            },
+        )
+    ])
+
+    policy_info = aggregated[0].policy_info
+    assert "next_run=2026-04-14T17:17:00+08:00" in policy_info
+    assert "source of truth" in policy_info
+    assert "do not reuse any earlier guessed schedule_value" in policy_info
+
+
+@pytest.mark.asyncio
+async def test_failed_cron_tool_results_block_false_success_claims():
+    agent = Agent(
+        name="Aworld",
+        conf=AgentConfig(
+            llm_provider="openai",
+            llm_model_name="fake-model",
+            llm_api_key="fake-key",
+        ),
+    )
+
+    aggregated = await agent._tools_aggregate_func([
+        ActionResult(
+            tool_name="cron",
+            content={
+                "success": False,
+                "error": "One-time schedule is already in the past",
+            },
+        )
+    ])
+
+    policy_info = aggregated[0].policy_info
+    assert "Cron returned an error" in policy_info
+    assert "Do not claim the reminder or scheduled task was created" in policy_info

--- a/tests/core/tool/test_func_to_tool.py
+++ b/tests/core/tool/test_func_to_tool.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import tempfile
+
+from aworld.core.tool.func_to_tool import _get_generated_tool_dir
+
+
+def test_generated_tool_dir_defaults_to_system_temp_dir(monkeypatch):
+    monkeypatch.delenv("AWORLD_TOOL_TMP_DIR", raising=False)
+
+    output_dir = _get_generated_tool_dir()
+
+    assert output_dir.exists()
+    assert output_dir.is_dir()
+    assert output_dir == Path(tempfile.gettempdir()) / "aworld_local_tools"
+
+
+def test_generated_tool_dir_respects_env_override(monkeypatch, tmp_path):
+    custom_dir = tmp_path / "local-tools"
+    monkeypatch.setenv("AWORLD_TOOL_TMP_DIR", str(custom_dir))
+
+    output_dir = _get_generated_tool_dir()
+
+    assert output_dir == custom_dir
+    assert output_dir.exists()
+    assert output_dir.is_dir()

--- a/tests/core/tool/test_func_to_tool.py
+++ b/tests/core/tool/test_func_to_tool.py
@@ -1,17 +1,26 @@
 from pathlib import Path
 import tempfile
 
-from aworld.core.tool.func_to_tool import _get_generated_tool_dir
+from aworld.core.tool.func_to_tool import _get_generated_tool_dir, _get_generated_tool_dir_name
 
 
 def test_generated_tool_dir_defaults_to_system_temp_dir(monkeypatch):
     monkeypatch.delenv("AWORLD_TOOL_TMP_DIR", raising=False)
+    monkeypatch.setattr("aworld.core.tool.func_to_tool.getpass.getuser", lambda: "alice")
+    monkeypatch.setattr("aworld.core.tool.func_to_tool.os.getuid", lambda: 1234)
 
     output_dir = _get_generated_tool_dir()
 
     assert output_dir.exists()
     assert output_dir.is_dir()
-    assert output_dir == Path(tempfile.gettempdir()) / "aworld_local_tools"
+    assert output_dir == Path(tempfile.gettempdir()) / "aworld_local_tools_alice_1234"
+
+
+def test_generated_tool_dir_name_sanitizes_username(monkeypatch):
+    monkeypatch.setattr("aworld.core.tool.func_to_tool.getpass.getuser", lambda: "alice@example.com")
+    monkeypatch.setattr("aworld.core.tool.func_to_tool.os.getuid", lambda: 1234)
+
+    assert _get_generated_tool_dir_name() == "aworld_local_tools_alice_example.com_1234"
 
 
 def test_generated_tool_dir_respects_env_override(monkeypatch, tmp_path):

--- a/tests/tools/test_cron_tool.py
+++ b/tests/tools/test_cron_tool.py
@@ -550,5 +550,27 @@ async def test_cron_tool_show_includes_last_result_summary(monkeypatch):
     assert result["job"]["last_result_summary"] == "BTC 当前价格 68000 USDT，较上一分钟上涨 0.2%"
 
 
+@pytest.mark.asyncio
+async def test_cron_tool_logs_traceback_for_unexpected_internal_errors(monkeypatch):
+    """Unexpected internal errors should still log a traceback for diagnosis."""
+    import aworld.tools.cron_tool as cron_tool_module
+
+    logged_messages = []
+
+    def fake_error(message, *args, **kwargs):
+        logged_messages.append(str(message))
+
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(cron_tool_module.logger, "error", fake_error)
+
+    result = await cron_tool_module.cron_tool(action="status")
+
+    assert result["success"] is False
+    assert result["error"] == "Internal error: boom"
+    assert logged_messages
+    assert "Cron tool error: boom" in logged_messages[0]
+    assert "Traceback" in logged_messages[0]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tools/test_cron_tool.py
+++ b/tests/tools/test_cron_tool.py
@@ -123,6 +123,18 @@ class TestParseScheduleValidation:
         assert parsed["schedule_value"] == "2026-04-11T23:22:00+08:00"
         assert parsed["delete_after_run"] is True
 
+    def test_parse_natural_language_relative_reminder_with_leading_prefix_in_chinese(self):
+        """Test '提醒我X分钟后Y' phrasing is parsed to a one-shot schedule."""
+        now = datetime(2026, 4, 11, 23, 21, 0, tzinfo=timezone(timedelta(hours=8)))
+
+        parsed = self._parse_natural_language_add_request("提醒我两分钟后喝水", now=now)
+
+        assert parsed["name"] == "提醒：喝水"
+        assert parsed["message"] == "提醒我喝水"
+        assert parsed["schedule_type"] == "at"
+        assert parsed["schedule_value"] == "2026-04-11T23:23:00+08:00"
+        assert parsed["delete_after_run"] is True
+
     def test_parse_natural_language_daily_recurring_reminder_in_chinese(self):
         """Test common daily reminder requests are parsed to cron schedules."""
         now = datetime(2026, 4, 11, 23, 21, 0, tzinfo=timezone(timedelta(hours=8)))
@@ -201,6 +213,54 @@ async def test_cron_tool_add_accepts_raw_natural_language_request(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cron_tool_add_prefers_request_derived_schedule_over_llm_supplied_absolute_time(monkeypatch):
+    """Raw request should be authoritative when LLM also supplies a stale absolute schedule."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.last_job = None
+
+        async def add_job(self, job):
+            self.last_job = job
+            job.state = CronJobState(next_run_at=job.schedule.at)
+            return job
+
+    fake_scheduler = FakeScheduler()
+
+    monkeypatch.setattr(
+        cron_tool_module,
+        "_parse_natural_language_add_request",
+        lambda request, now=None: {
+            "name": "提醒：上厕所",
+            "message": "提醒我上厕所",
+            "schedule_type": "at",
+            "schedule_value": "2026-04-14T16:25:02+08:00",
+            "delete_after_run": True,
+        },
+    )
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        request="两分钟后提醒我上厕所",
+        name="上厕所提醒",
+        message="提醒：该去上厕所了！",
+        schedule_type="at",
+        schedule_value="2026-04-14T16:07:45+08:00",
+    )
+
+    assert result["success"] is True
+    assert fake_scheduler.last_job is not None
+    assert fake_scheduler.last_job.name == "上厕所提醒"
+    assert fake_scheduler.last_job.payload.message == "提醒：该去上厕所了！"
+    assert fake_scheduler.last_job.schedule.kind == "at"
+    assert fake_scheduler.last_job.schedule.at == "2026-04-14T16:25:02+08:00"
+    assert result["next_run"] == "2026-04-14T16:25:02+08:00"
+
+
+@pytest.mark.asyncio
 async def test_cron_tool_normalizes_string_max_runs_and_aworld_agent_name(monkeypatch):
     """String max_runs and lowercase aworld agent name should be normalized before persistence."""
     from aworld.core.scheduler.types import CronJobState
@@ -234,6 +294,79 @@ async def test_cron_tool_normalizes_string_max_runs_and_aworld_agent_name(monkey
     assert fake_scheduler.last_job is not None
     assert fake_scheduler.last_job.payload.max_runs == 3
     assert fake_scheduler.last_job.payload.agent_name == "Aworld"
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_prefers_request_derived_schedule_for_leading_relative_phrase(monkeypatch):
+    """Leading '提醒我X分钟后Y' requests should override stale LLM absolute timestamps."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.last_job = None
+
+        async def add_job(self, job):
+            self.last_job = job
+            job.state = CronJobState(next_run_at=job.schedule.at)
+            return job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+    monkeypatch.setattr(
+        cron_tool_module,
+        "_parse_natural_language_add_request",
+        lambda request, now=None: {
+            "name": "喝水提醒",
+            "message": "提醒用户喝水",
+            "schedule_type": "at",
+            "schedule_value": "2026-04-14T17:17:00+08:00",
+            "delete_after_run": True,
+        },
+    )
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        request="提醒我两分钟后喝水",
+        name="喝水提醒",
+        message="提醒用户喝水",
+        schedule_type="at",
+        schedule_value="2026-04-14T16:50:01+08:00",
+    )
+
+    assert result["success"] is True
+    assert fake_scheduler.last_job is not None
+    assert fake_scheduler.last_job.schedule.at == "2026-04-14T17:17:00+08:00"
+    assert result["next_run"] == "2026-04-14T17:17:00+08:00"
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_rejects_past_one_time_schedule(monkeypatch):
+    """Stale absolute one-time timestamps should fail closed instead of creating a dead job."""
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.add_called = False
+
+        async def add_job(self, job):
+            self.add_called = True
+            return job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        name="喝水提醒",
+        message="提醒用户喝水",
+        schedule_type="at",
+        schedule_value="2026-04-14T16:50:01+08:00",
+    )
+
+    assert result["success"] is False
+    assert "already in the past" in result["error"]
+    assert fake_scheduler.add_called is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- harden cron reminder parsing, stale timestamp handling, and past-one-shot validation
- teach Aworld to pass raw reminder requests to cron and treat cron next_run as the source of truth
- move runtime-generated tool modules into a temp directory and ignore legacy generated temp files

## Testing
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest tests/core/agent/test_aworld_prompt_policy.py -q
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest tests/core/agent/test_tool_result_followup_format.py -q
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest tests/core/agent/test_reminder_cron_e2e.py -q
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest tests/core/tool/test_func_to_tool.py -q
- /Users/zhuangchenyi/miniconda3/envs/aworldcli_env/bin/pytest tests/tools/test_cron_tool.py -q