### PR TITLE
fix: improve cron follow mode and reminder scheduling

### DIFF
--- a/aworld-cli/src/aworld_cli/commands/cron_cmd.py
+++ b/aworld-cli/src/aworld_cli/commands/cron_cmd.py
@@ -3,8 +3,10 @@
 """
 Cron slash command - /cron for quick task management.
 """
+import asyncio
 from typing import List, Optional
 
+from rich.markup import escape
 from aworld.tools.cron_tool import cron_tool
 
 from aworld_cli.core.command_system import Command, CommandContext, register_command
@@ -72,6 +74,15 @@ class CronCommand(Command):
             if not job_id:
                 return "请提供要查看的任务 ID。用法：/cron show <job_id>"
             result = await cron_tool(action="show", job_id=job_id)
+            job = result.get("job") if result.get("success") else None
+            runtime = getattr(context, "runtime", None)
+            if (
+                job
+                and job.get("running")
+                and runtime is not None
+                and hasattr(runtime, "_get_cron_progress_logs")
+            ):
+                return await self._follow_running_job(context, job_id, job)
             return self._format_result("show", result)
 
         elif action == "inbox":
@@ -163,6 +174,7 @@ class CronCommand(Command):
                 f"- name: {job.get('name')}\n"
                 f"- schedule: {job.get('schedule')}\n"
                 f"- enabled: {job.get('enabled')}\n"
+                f"- running: {job.get('running')}\n"
                 f"- next_run: {job.get('next_run')}\n"
                 f"- last_run: {job.get('last_run')}\n"
                 f"- max_runs: {job.get('max_runs')}\n"
@@ -173,10 +185,18 @@ class CronCommand(Command):
             )
 
         if action == "add":
-            return (
-                f"{result.get('message')}\n"
-                f"next_run: {result.get('next_run')}"
-            )
+            lines = [
+                result.get("message"),
+                f"next_run: {result.get('next_run')}",
+            ]
+            advance_reminder = result.get("advance_reminder")
+            if advance_reminder:
+                lines.append(
+                    "advance_reminder: "
+                    f"{advance_reminder.get('next_run')} "
+                    f"(lead={advance_reminder.get('lead_minutes')}m)"
+                )
+            return "\n".join(lines)
 
         return result.get("message", "操作成功")
 
@@ -216,6 +236,85 @@ class CronCommand(Command):
             if created_at:
                 lines.append(f"  created_at: {created_at}")
         return "\n".join(lines)
+
+    async def _follow_running_job(self, context: CommandContext, job_id: str, initial_job: dict) -> str:
+        """Follow a running cron job and print live execution logs."""
+        from rich.console import Console as RichConsole
+
+        runtime = getattr(context, "runtime", None)
+        runtime_console = getattr(getattr(runtime, "cli", None), "console", None)
+        console = runtime_console or RichConsole()
+
+        console.print(f"\n[bold cyan]🔄 跟踪定时任务执行：{job_id}[/bold cyan]")
+        console.print(f"[dim]任务名称：{initial_job.get('name')}[/dim]")
+        console.print("[yellow]Press Ctrl+C to stop following[/yellow] [dim](任务仍会继续执行)[/dim]\n")
+        console.print(self._format_result("show", {"success": True, "job": initial_job}))
+        console.print("[dim]--- Live Execution Logs ---[/dim]")
+
+        seen_log_ids = set()
+        showed_waiting_hint = False
+
+        try:
+            while True:
+                progress_logs = []
+                if runtime and hasattr(runtime, "_get_cron_progress_logs"):
+                    progress_logs = runtime._get_cron_progress_logs(job_id) or []
+
+                new_logs = [log for log in progress_logs if getattr(log, "id", None) not in seen_log_ids]
+                if new_logs:
+                    for log in new_logs:
+                        seen_log_ids.add(getattr(log, "id", ""))
+                        self._print_progress_log(console, log)
+                    showed_waiting_hint = False
+                elif not showed_waiting_hint:
+                    console.print("[dim]等待执行日志...[/dim]")
+                    showed_waiting_hint = True
+
+                result = await cron_tool(action="show", job_id=job_id)
+                if result.get("success"):
+                    job = result.get("job") or {}
+                    if not job.get("running"):
+                        console.print(
+                            f"\n[bold green]✅ 定时任务执行结束[/bold green] "
+                            f"(status={job.get('last_status')})"
+                        )
+                        if job.get("last_result_summary"):
+                            console.print(f"[bold]结果：[/bold]{job.get('last_result_summary')}")
+                        if job.get("last_error"):
+                            console.print(f"[bold red]错误：[/bold red]{job.get('last_error')}")
+                        return ""
+                else:
+                    latest_log = progress_logs[-1] if progress_logs else None
+                    if latest_log and getattr(latest_log, "terminal", False):
+                        console.print("\n[bold green]✅ 定时任务执行结束[/bold green]")
+                        return ""
+
+                await asyncio.sleep(0.2)
+
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            console.print(f"\n[yellow]⏸ 已停止跟踪 {job_id}[/yellow]")
+            console.print("[dim]任务仍在后台继续执行[/dim]")
+            console.print(f"[cyan]→ /cron show {job_id}[/cyan]  [dim]重新查看状态[/dim]")
+            return ""
+
+    def _print_progress_log(self, console, log) -> None:
+        """Render a progress log entry with multiline-safe formatting."""
+        time_text = str(getattr(log, "created_at", ""))[11:19] or "--:--:--"
+        level = getattr(log, "level", "info")
+        color = {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red",
+            "success": "green",
+        }.get(level, "white")
+        message = str(getattr(log, "message", "") or "")
+        lines = message.splitlines() or [""]
+
+        prefix = f"[{time_text}] "
+        indent = " " * len(prefix)
+        console.print(f"[dim]{escape(prefix)}[/dim][{color}]{escape(lines[0])}[/{color}]")
+        for line in lines[1:]:
+            console.print(f"[dim]{escape(indent)}[/dim][{color}]{escape(line)}[/{color}]")
 
     def get_help(self) -> str:
         """Return help information."""

--- a/aworld-cli/src/aworld_cli/main.py
+++ b/aworld-cli/src/aworld_cli/main.py
@@ -1117,6 +1117,9 @@ async def _run_direct_mode(
         return
     
     # Create agent executor using CliRuntime (session_id is already passed to runtime)
+    from aworld.core.scheduler import get_scheduler
+    runtime._scheduler = get_scheduler()
+    runtime._bind_scheduler_default_agent(selected_agent.name)
     agent_executor = await runtime._create_executor(selected_agent)
 
     if not agent_executor:

--- a/aworld-cli/src/aworld_cli/runtime/base.py
+++ b/aworld-cli/src/aworld_cli/runtime/base.py
@@ -48,6 +48,7 @@ class BaseCliRuntime:
         self.cli = AWorldCLI()
         self._scheduler = None  # Cron scheduler instance
         self._notification_center = None  # Cron notification center
+        self._current_root_agent_name: Optional[str] = None
     
     async def start(self) -> None:
         """Start the CLI interaction loop."""
@@ -71,6 +72,8 @@ class BaseCliRuntime:
                 selected_agent = await self._select_agent(agents)
                 if not selected_agent:
                     return
+
+                self._bind_scheduler_default_agent(selected_agent.name)
                 
                 # Start chat session
                 executor = await self._create_executor(selected_agent)
@@ -137,6 +140,7 @@ class BaseCliRuntime:
             # Get scheduler and wire notification sink
             self._scheduler = get_scheduler()
             self._scheduler.notification_sink = self._notification_center.publish
+            self._scheduler.progress_sink = self._notification_center.publish_progress
             if hasattr(self._scheduler.executor, "set_swarm_resolver"):
                 self._scheduler.executor.set_swarm_resolver(resolve_swarm)
 
@@ -155,6 +159,14 @@ class BaseCliRuntime:
             except Exception as e:
                 from aworld.logs.util import logger
                 logger.warning(f"Failed to stop cron scheduler: {e}")
+
+    def _bind_scheduler_default_agent(self, agent_name: Optional[str]) -> None:
+        """Bind cron task creation to the currently selected CLI root agent."""
+        self._current_root_agent_name = agent_name
+        if not self._scheduler or not getattr(self._scheduler, "executor", None):
+            return
+        if hasattr(self._scheduler.executor, "set_default_agent_name"):
+            self._scheduler.executor.set_default_agent_name(agent_name)
 
     async def _drain_notifications(self, job_id: Optional[str] = None) -> List[Any]:
         """
@@ -178,6 +190,17 @@ class BaseCliRuntime:
         except Exception as e:
             from aworld.logs.util import logger
             logger.warning(f"Failed to drain notifications: {e}")
+            return []
+
+    def _get_cron_progress_logs(self, job_id: str) -> List[Any]:
+        """Return in-memory live execution logs for a cron job."""
+        if not self._notification_center or not hasattr(self._notification_center, "get_progress_logs"):
+            return []
+        try:
+            return self._notification_center.get_progress_logs(job_id)
+        except Exception as e:
+            from aworld.logs.util import logger
+            logger.warning(f"Failed to read cron progress logs: {e}")
             return []
 
     async def _load_agents(self) -> List[AgentInfo]:

--- a/aworld-cli/src/aworld_cli/runtime/cron_notifications.py
+++ b/aworld-cli/src/aworld_cli/runtime/cron_notifications.py
@@ -11,7 +11,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Literal, Optional, List
+from typing import Literal, Optional, List, Dict, Any
 import pytz
 
 
@@ -40,6 +40,18 @@ class CronNotification:
     next_run_at: Optional[str] = None
 
 
+@dataclass
+class CronProgressLog:
+    """In-memory live execution log for a running cron job."""
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    job_id: str = ""
+    job_name: str = ""
+    level: Literal["info", "warning", "error", "success"] = "info"
+    message: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now(pytz.UTC).isoformat())
+    terminal: bool = False
+
+
 class CronNotificationCenter:
     """
     In-memory notification center for cron task completions.
@@ -66,6 +78,8 @@ class CronNotificationCenter:
         self._max_size = max_size
         self._queue = asyncio.Queue(maxsize=max_size)
         self._unread_count = 0
+        self._progress_logs: Dict[str, deque[CronProgressLog]] = {}
+        self._progress_limit = 200
 
     async def publish(self, notification_data: dict) -> None:
         """
@@ -148,6 +162,35 @@ class CronNotificationCenter:
         self._unread_count = self._queue.qsize()
 
         return notifications
+
+    async def publish_progress(self, progress_data: Dict[str, Any]) -> None:
+        """Store live cron execution logs for follow-mode inspection."""
+        try:
+            log = CronProgressLog(
+                job_id=progress_data.get("job_id", ""),
+                job_name=progress_data.get("job_name", ""),
+                level=progress_data.get("level", "info"),
+                message=progress_data.get("message", ""),
+                created_at=progress_data.get("created_at", datetime.now(pytz.UTC).isoformat()),
+                terminal=bool(progress_data.get("terminal", False)),
+            )
+            if not log.job_id:
+                return
+
+            buffer = self._progress_logs.setdefault(
+                log.job_id,
+                deque(maxlen=self._progress_limit),
+            )
+            buffer.append(log)
+        except Exception:
+            pass
+
+    def get_progress_logs(self, job_id: str) -> List[CronProgressLog]:
+        """Return a snapshot of the in-memory live log buffer for a cron job."""
+        buffer = self._progress_logs.get(job_id)
+        if not buffer:
+            return []
+        return list(buffer)
 
     def get_unread_count(self) -> int:
         """Return current unread notification count without draining the queue."""

--- a/aworld-cli/src/aworld_cli/runtime/cron_notifications.py
+++ b/aworld-cli/src/aworld_cli/runtime/cron_notifications.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from typing import Literal, Optional, List, Dict, Any
 import pytz
 
+from aworld.logs.util import logger
+
 
 @dataclass
 class CronNotification:
@@ -182,8 +184,8 @@ class CronNotificationCenter:
                 deque(maxlen=self._progress_limit),
             )
             buffer.append(log)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to store cron progress log: {e}")
 
     def get_progress_logs(self, job_id: str) -> List[CronProgressLog]:
         """Return a snapshot of the in-memory live log buffer for a cron job."""

--- a/aworld/agents/llm_agent.py
+++ b/aworld/agents/llm_agent.py
@@ -981,11 +981,13 @@ class LLMAgent(BaseAgent[Observation, List[ActionModel]]):
 
         next_run = content.get("next_run")
         job_id = content.get("job_id")
+        next_run_display = content.get("next_run_display")
         if next_run:
             return (
                 f"{serialized}\n"
                 f"Confirmed cron schedule: next_run={next_run}; job_id={job_id}. "
-                "Use this cron result as the source of truth and do not reuse any earlier guessed schedule_value."
+                f"{'Use next_run_display=' + next_run_display + ' for any user-facing date or weekday wording. ' if next_run_display else ''}"
+                "Use this cron result as the source of truth and do not reuse any earlier guessed schedule_value or infer the weekday yourself."
             )
 
         return (

--- a/aworld/core/scheduler/executor.py
+++ b/aworld/core/scheduler/executor.py
@@ -271,7 +271,7 @@ class CronExecutor:
 
         except Exception as e:
             logger.error(
-                f"Cron job execution error: {job.id} - {e}\n{traceback.format_exc()}"
+                f"Cron job execution error: {job.id}\n{traceback.format_exc()}"
             )
             return TaskResponse(
                 success=False,
@@ -393,7 +393,7 @@ class CronExecutor:
             logger.debug(f"Cached swarm from configured resolver: {agent_name}")
         except Exception as e:
             logger.error(
-                f"Failed to resolve swarm for {agent_name}: {e}\n{traceback.format_exc()}"
+                f"Failed to resolve swarm for {agent_name}\n{traceback.format_exc()}"
             )
             return None
 

--- a/aworld/core/scheduler/executor.py
+++ b/aworld/core/scheduler/executor.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, Callable, Optional, Awaitable
 
 from aworld.core.task import Task, TaskResponse
 from aworld.logs.util import logger
+from .normalization import resolve_effective_tool_names
 from .types import CronJob
 
 
@@ -44,10 +45,8 @@ class CronExecutor:
         return self.default_agent_name
 
     def _resolve_effective_tool_names(self, job: CronJob) -> list[str]:
-        """Aworld/root-agent cron tasks should not be constrained by persisted tool allowlists."""
-        if job.payload.agent_name == "Aworld":
-            return []
-        return job.payload.tool_names
+        """Resolve the effective tool allowlist for execution."""
+        return resolve_effective_tool_names(job.payload.agent_name, job.payload.tool_names)
 
     def _truncate_text(self, value: Any, limit: int = 400) -> Optional[str]:
         """Convert stream payloads to compact, readable progress lines."""

--- a/aworld/core/scheduler/executor.py
+++ b/aworld/core/scheduler/executor.py
@@ -5,9 +5,10 @@ Cron job executor - converts CronJob to Task and executes.
 """
 import asyncio
 import inspect
-from typing import Dict, Any, Callable, Optional
+import traceback
+from typing import Dict, Any, Callable, Optional, Awaitable
 
-from aworld.core.task import TaskResponse
+from aworld.core.task import Task, TaskResponse
 from aworld.logs.util import logger
 from .types import CronJob
 
@@ -26,13 +27,209 @@ class CronExecutor:
         """Initialize executor."""
         self._agent_cache: Dict[str, Any] = {}
         self.swarm_resolver = swarm_resolver
+        self.default_agent_name: Optional[str] = None
 
     def set_swarm_resolver(self, swarm_resolver: Optional[Callable[[str], Any]]) -> None:
         """Configure the swarm resolver used by cron jobs."""
         self.swarm_resolver = swarm_resolver
         self._agent_cache.clear()
 
-    async def execute(self, job: CronJob) -> TaskResponse:
+    def set_default_agent_name(self, agent_name: Optional[str]) -> None:
+        """Bind cron jobs created in the current CLI session to the selected root agent."""
+        candidate = (agent_name or "").strip()
+        self.default_agent_name = candidate or None
+
+    def get_default_agent_name(self) -> Optional[str]:
+        """Return the CLI-selected default agent name for newly created cron jobs."""
+        return self.default_agent_name
+
+    def _resolve_effective_tool_names(self, job: CronJob) -> list[str]:
+        """Aworld/root-agent cron tasks should not be constrained by persisted tool allowlists."""
+        if job.payload.agent_name == "Aworld":
+            return []
+        return job.payload.tool_names
+
+    def _truncate_text(self, value: Any, limit: int = 400) -> Optional[str]:
+        """Convert stream payloads to compact, readable progress lines."""
+        if value is None:
+            return None
+
+        text = value if isinstance(value, str) else str(value)
+        text = text.strip()
+        if not text:
+            return None
+
+        if len(text) > limit:
+            return f"{text[:limit - 3]}..."
+        return text
+
+    def _format_stream_output(self, output: Any) -> Optional[tuple[str, str]]:
+        """Translate AWorld streaming outputs into human-readable cron follow logs."""
+        if not hasattr(output, "output_type"):
+            return None
+
+        output_type = output.output_type()
+
+        if output_type == "message":
+            response = self._truncate_text(getattr(output, "response", None), limit=800)
+            if response:
+                return "info", f"Agent 输出：\n{response}"
+
+            reasoning = self._truncate_text(getattr(output, "reasoning", None), limit=500)
+            if reasoning:
+                return "info", f"Agent 思考：\n{reasoning}"
+            return None
+
+        if output_type == "step":
+            display_name = getattr(output, "alias_name", None) or getattr(output, "name", None)
+            status = (getattr(output, "status", None) or "").upper()
+            step_num = getattr(output, "step_num", None)
+            step_prefix = f"步骤 #{step_num}" if step_num is not None else "步骤"
+            display_name = display_name or "unknown"
+            if status == "START":
+                return "info", f"{step_prefix} 开始：{display_name}"
+            if status == "FINISHED":
+                return "success", f"{step_prefix} 完成：{display_name}"
+            if status in {"FAILED", "ERROR"}:
+                return "error", f"{step_prefix} 失败：{display_name}"
+            return "info", f"{step_prefix} 状态更新：{display_name} ({status or 'UNKNOWN'})"
+
+        if output_type == "tool_call":
+            tool_name = None
+            args_text = None
+            tool_call = getattr(output, "data", None)
+
+            if tool_call is not None:
+                function = getattr(tool_call, "function", None)
+                if function is not None:
+                    tool_name = getattr(function, "name", None)
+                    args_text = self._truncate_text(getattr(function, "arguments", None), limit=240)
+                else:
+                    tool_name = getattr(tool_call, "name", None)
+                    args_text = self._truncate_text(getattr(tool_call, "arguments", None), limit=240)
+
+            tool_name = tool_name or getattr(output, "tool_name", None) or "unknown"
+            return "info", f"工具调用：{tool_name}({args_text or ''})"
+
+        if output_type == "tool_call_result":
+            tool_name = getattr(output, "tool_name", None) or "unknown"
+            result_text = (
+                self._truncate_text(getattr(output, "data", None), limit=500)
+                or self._truncate_text(getattr(output, "result", None), limit=500)
+                or self._truncate_text(getattr(output, "content", None), limit=500)
+            )
+            if result_text:
+                return "success", f"工具结果：{tool_name}\n{result_text}"
+            return "success", f"工具结果：{tool_name}"
+
+        return None
+
+    async def _get_definitive_task_response(
+        self,
+        aworld_task_id: str,
+        streaming_outputs: Any,
+    ) -> Optional[TaskResponse]:
+        """Wait for the underlying run coroutine and return the final TaskResponse."""
+        run_impl_task = getattr(streaming_outputs, "_run_impl_task", None)
+
+        if run_impl_task is not None:
+            run_result = await run_impl_task
+            if isinstance(run_result, dict):
+                task_response = run_result.get(aworld_task_id)
+                if task_response is not None:
+                    return task_response
+
+        task_response = streaming_outputs.response()
+        if task_response is not None:
+            return task_response
+
+        for _ in range(10):
+            await asyncio.sleep(0.05)
+            task_response = streaming_outputs.response()
+            if task_response is not None:
+                return task_response
+
+        return None
+
+    async def _execute_with_streaming(
+        self,
+        job: CronJob,
+        swarm: Any,
+        progress_callback: Callable[[str, str], Optional[Awaitable[None]]],
+    ) -> TaskResponse:
+        """Execute cron jobs with stream-aware progress so `/cron show` can follow real steps."""
+        from aworld.runner import Runners
+
+        task = Task(
+            input=job.payload.message,
+            swarm=swarm,
+            tool_names=self._resolve_effective_tool_names(job),
+            event_driven=bool(getattr(swarm, "event_driven", False)),
+            session_id=None,
+        )
+
+        streaming_outputs = Runners.streamed_run_task(
+            task=task,
+            cancel_run_impl_task_on_cleanup=False,
+        )
+
+        async for output in streaming_outputs.stream_events():
+            formatted = self._format_stream_output(output)
+            if formatted:
+                level, message = formatted
+                await self._emit_progress(progress_callback, level, message)
+
+        result = await self._get_definitive_task_response(task.id, streaming_outputs)
+        if result is None:
+            fallback_answer = None
+            try:
+                fallback_answer = self._truncate_text(
+                    streaming_outputs.get_message_output_content(),
+                    limit=1200,
+                )
+            except Exception:
+                fallback_answer = None
+
+            return TaskResponse(
+                success=False,
+                answer=fallback_answer,
+                msg="Execution completed without a final task response",
+            )
+
+        final_answer = self._truncate_text(getattr(result, "answer", None), limit=4000)
+        if final_answer:
+            await self._emit_progress(progress_callback, "success", f"最终回答：\n{final_answer}")
+        elif result.msg:
+            await self._emit_progress(
+                progress_callback,
+                "success" if result.success else "error",
+                f"最终结果：{result.msg}",
+            )
+
+        return result
+
+    async def _emit_progress(
+        self,
+        progress_callback: Optional[Callable[[str, str], Optional[Awaitable[None]]]],
+        level: str,
+        message: str,
+    ) -> None:
+        """Best-effort progress callback for live cron execution logs."""
+        if not progress_callback:
+            return
+
+        try:
+            result = progress_callback(level, message)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as e:
+            logger.debug(f"Failed to emit cron progress log: {e}")
+
+    async def execute(
+        self,
+        job: CronJob,
+        progress_callback: Optional[Callable[[str, str], Optional[Awaitable[None]]]] = None,
+    ) -> TaskResponse:
         """
         Execute job (isolated mode only).
 
@@ -53,14 +250,17 @@ class CronExecutor:
                     msg=f"Agent not found: {job.payload.agent_name}"
                 )
 
-            # Execute using Runners.run()
+            # Execute using Runners.run() or stream-aware mode for richer live logs.
             logger.info(f"Executing cron job: {job.id} ({job.name})")
-            result = await Runners.run(
-                input=job.payload.message,
-                swarm=swarm,
-                tool_names=job.payload.tool_names,
-                session_id=None,  # Isolated mode: always None
-            )
+            if progress_callback:
+                result = await self._execute_with_streaming(job, swarm, progress_callback)
+            else:
+                result = await Runners.run(
+                    input=job.payload.message,
+                    swarm=swarm,
+                    tool_names=self._resolve_effective_tool_names(job),
+                    session_id=None,  # Isolated mode: always None
+                )
 
             if result.success:
                 logger.info(f"Cron job completed: {job.id}")
@@ -70,13 +270,20 @@ class CronExecutor:
             return result
 
         except Exception as e:
-            logger.error(f"Cron job execution error: {job.id} - {e}", exc_info=True)
+            logger.error(
+                f"Cron job execution error: {job.id} - {e}\n{traceback.format_exc()}"
+            )
             return TaskResponse(
                 success=False,
                 msg=f"Execution error: {str(e)}"
             )
 
-    async def execute_with_retry(self, job: CronJob, max_retries: int = 3) -> TaskResponse:
+    async def execute_with_retry(
+        self,
+        job: CronJob,
+        max_retries: int = 3,
+        progress_callback: Optional[Callable[[str, str], Optional[Awaitable[None]]]] = None,
+    ) -> TaskResponse:
         """
         Execute with exponential backoff retry.
 
@@ -91,13 +298,28 @@ class CronExecutor:
 
         for attempt in range(max_retries + 1):
             try:
-                result = await self.execute(job)
+                await self._emit_progress(
+                    progress_callback,
+                    "info",
+                    f"开始第 {attempt + 1}/{max_retries + 1} 次执行，agent={job.payload.agent_name}",
+                )
+                result = await self.execute(job, progress_callback=progress_callback)
 
                 if result.success:
+                    await self._emit_progress(
+                        progress_callback,
+                        "info",
+                        f"第 {attempt + 1} 次执行成功",
+                    )
                     return result
 
                 if attempt >= max_retries:
                     logger.error(f"Job {job.id} failed after {max_retries} retries")
+                    await self._emit_progress(
+                        progress_callback,
+                        "error",
+                        f"第 {attempt + 1} 次执行失败：{result.msg}",
+                    )
                     return result
 
                 # Exponential backoff
@@ -106,10 +328,20 @@ class CronExecutor:
                     f"Job {job.id} failed (attempt {attempt+1}/{max_retries+1}), "
                     f"retrying in {wait_seconds}s..."
                 )
+                await self._emit_progress(
+                    progress_callback,
+                    "warning",
+                    f"第 {attempt + 1} 次执行失败：{result.msg}；将在 {wait_seconds}s 后重试",
+                )
                 await asyncio.sleep(wait_seconds)
 
             except Exception as e:
                 if attempt >= max_retries:
+                    await self._emit_progress(
+                        progress_callback,
+                        "error",
+                        f"第 {attempt + 1} 次执行异常：{e}",
+                    )
                     return TaskResponse(
                         success=False,
                         msg=f"Execution failed after {max_retries} retries: {str(e)}"
@@ -117,6 +349,11 @@ class CronExecutor:
 
                 wait_seconds = backoff_base ** attempt
                 logger.warning(f"Job {job.id} error, retrying in {wait_seconds}s: {e}")
+                await self._emit_progress(
+                    progress_callback,
+                    "warning",
+                    f"第 {attempt + 1} 次执行异常：{e}；将在 {wait_seconds}s 后重试",
+                )
                 await asyncio.sleep(wait_seconds)
 
         # Should not reach here
@@ -155,7 +392,9 @@ class CronExecutor:
             self._agent_cache[agent_name] = swarm
             logger.debug(f"Cached swarm from configured resolver: {agent_name}")
         except Exception as e:
-            logger.error(f"Failed to resolve swarm for {agent_name}: {e}", exc_info=True)
+            logger.error(
+                f"Failed to resolve swarm for {agent_name}: {e}\n{traceback.format_exc()}"
+            )
             return None
 
         return self._agent_cache.get(agent_name)

--- a/aworld/core/scheduler/normalization.py
+++ b/aworld/core/scheduler/normalization.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+# Copyright (c) 2025 inclusionAI.
+"""Normalization helpers shared by cron scheduler components."""
+
+from typing import Any, List
+
+
+def normalize_tool_names(value: Any) -> List[str]:
+    """Normalize persisted or user-supplied tool names into a clean list."""
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        normalized = []
+        for item in value:
+            text = str(item).strip()
+            if not text:
+                continue
+            if "," in text:
+                normalized.extend(part.strip() for part in text.split(",") if part.strip())
+            else:
+                normalized.append(text)
+        return normalized
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        if "," in stripped:
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+        return [stripped]
+
+    text = str(value).strip()
+    return [text] if text else []

--- a/aworld/core/scheduler/normalization.py
+++ b/aworld/core/scheduler/normalization.py
@@ -32,3 +32,16 @@ def normalize_tool_names(value: Any) -> List[str]:
 
     text = str(value).strip()
     return [text] if text else []
+
+
+def resolve_effective_tool_names(agent_name: str, tool_names: List[str]) -> List[str]:
+    """
+    Return the effective tool allowlist for a cron job.
+
+    Aworld/root-agent cron tasks should not be constrained by persisted tool
+    allowlists because cron-created automation is often open-ended and requires
+    the runtime agent to choose the necessary tools dynamically.
+    """
+    if agent_name == "Aworld":
+        return []
+    return tool_names

--- a/aworld/core/scheduler/scheduler.py
+++ b/aworld/core/scheduler/scheduler.py
@@ -190,7 +190,7 @@ class CronScheduler:
                     await asyncio.sleep(sleep_time)
 
             except Exception as e:
-                logger.error(f"Scheduler loop error: {e}\n{traceback.format_exc()}")
+                logger.error(f"Scheduler loop error\n{traceback.format_exc()}")
                 await asyncio.sleep(5)  # Brief pause before retry
 
     def _find_next_job(self, jobs: List[CronJob]) -> Tuple[Optional[CronJob], float]:
@@ -624,7 +624,7 @@ class CronScheduler:
                 await self._publish_notification(job, "timeout")
 
             except Exception as e:
-                logger.error(f"Job {job.id} trigger error: {e}\n{traceback.format_exc()}")
+                logger.error(f"Job {job.id} trigger error\n{traceback.format_exc()}")
                 await self.store.update_job(
                     job.id,
                     state={
@@ -785,7 +785,7 @@ class CronScheduler:
 
             except Exception as e:
                 logger.error(
-                    f"Manual job {job_id} execution error: {e}\n{traceback.format_exc()}"
+                    f"Manual job {job_id} execution error\n{traceback.format_exc()}"
                 )
                 await self.store.update_job(
                     job_id,

--- a/aworld/core/scheduler/scheduler.py
+++ b/aworld/core/scheduler/scheduler.py
@@ -5,6 +5,7 @@ Cron scheduler - timer loop with startup recovery.
 """
 import asyncio
 import re
+import traceback
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, List, Callable, Any, Awaitable, Literal
 import pytz
@@ -35,7 +36,8 @@ class CronScheduler:
         store: FileBasedCronStore,
         executor: CronExecutor,
         max_concurrent: int = 5,
-        notification_sink: Optional[Callable[[Any], Awaitable[None]]] = None
+        notification_sink: Optional[Callable[[Any], Awaitable[None]]] = None,
+        progress_sink: Optional[Callable[[Any], Awaitable[None]]] = None,
     ):
         """
         Initialize scheduler.
@@ -52,6 +54,30 @@ class CronScheduler:
         self.running = False
         self._timer_task: Optional[asyncio.Task] = None
         self.notification_sink = notification_sink
+        self.progress_sink = progress_sink
+
+    async def _publish_progress(
+        self,
+        job: CronJob,
+        level: Literal["info", "warning", "error", "success"],
+        message: str,
+        terminal: bool = False,
+    ) -> None:
+        """Publish live execution logs for `/cron show` follow mode."""
+        if not self.progress_sink:
+            return
+
+        try:
+            await self.progress_sink({
+                "job_id": job.id,
+                "job_name": job.name,
+                "level": level,
+                "message": message,
+                "terminal": terminal,
+                "created_at": datetime.now(pytz.UTC).isoformat(),
+            })
+        except Exception as e:
+            logger.warning(f"Failed to publish progress for job {job.id}: {e}")
 
     async def start(self):
         """Start scheduler with recovery."""
@@ -164,7 +190,7 @@ class CronScheduler:
                     await asyncio.sleep(sleep_time)
 
             except Exception as e:
-                logger.error(f"Scheduler loop error: {e}", exc_info=True)
+                logger.error(f"Scheduler loop error: {e}\n{traceback.format_exc()}")
                 await asyncio.sleep(5)  # Brief pause before retry
 
     def _find_next_job(self, jobs: List[CronJob]) -> Tuple[Optional[CronJob], float]:
@@ -410,9 +436,13 @@ class CronScheduler:
 
         reminder_detail = self._get_reminder_detail(job)
         if reminder_detail:
+            await self._publish_progress(job, "info", "识别为提醒类任务，直接生成提醒内容")
             return TaskResponse(success=True, msg=reminder_detail, answer=reminder_detail)
 
-        return await self.executor.execute_with_retry(job)
+        return await self.executor.execute_with_retry(
+            job,
+            progress_callback=lambda level, message: self._publish_progress(job, level, message),
+        )
 
     async def _persist_job_result(self, job: CronJob, result) -> tuple[Optional[CronJob], bool]:
         """Persist terminal execution state and return the updated job."""
@@ -533,6 +563,12 @@ class CronScheduler:
         async with self.semaphore:  # Concurrency control
             try:
                 logger.info(f"Executing claimed cron job: {job.id} ({job.name})")
+                tools_text = job.payload.tool_names if job.payload.tool_names else "auto"
+                await self._publish_progress(
+                    job,
+                    "info",
+                    f"任务开始执行，agent={job.payload.agent_name}，tools={tools_text}",
+                )
 
                 # Execute with timeout
                 timeout = job.payload.timeout_seconds or 600
@@ -546,10 +582,23 @@ class CronScheduler:
 
                 # Publish notification (after state persistence and deletion)
                 if result.success:
+                    success_summary = self._get_result_summary(result)
+                    success_message = (
+                        f"任务执行完成：{success_summary}"
+                        if success_summary else
+                        "任务执行完成"
+                    )
+                    await self._publish_progress(notification_job, "success", success_message, terminal=True)
                     await self._publish_notification(notification_job, "ok")
                     if removed:
                         logger.info(f"Deleted one-time job: {job.id}")
                 else:
+                    await self._publish_progress(
+                        notification_job,
+                        "error",
+                        f"任务执行失败：{result.msg}",
+                        terminal=True,
+                    )
                     await self._publish_notification(notification_job, "error", result.msg)
 
             except asyncio.TimeoutError:
@@ -564,12 +613,18 @@ class CronScheduler:
                         "consecutive_errors": job.state.consecutive_errors + 1,
                     }
                 )
+                await self._publish_progress(
+                    job,
+                    "error",
+                    f"任务执行超时：{job.payload.timeout_seconds or 600}s",
+                    terminal=True,
+                )
 
                 # Publish timeout notification
                 await self._publish_notification(job, "timeout")
 
             except Exception as e:
-                logger.error(f"Job {job.id} trigger error: {e}", exc_info=True)
+                logger.error(f"Job {job.id} trigger error: {e}\n{traceback.format_exc()}")
                 await self.store.update_job(
                     job.id,
                     state={
@@ -579,6 +634,12 @@ class CronScheduler:
                         "last_result_summary": None,
                         "consecutive_errors": job.state.consecutive_errors + 1,
                     }
+                )
+                await self._publish_progress(
+                    job,
+                    "error",
+                    f"任务执行异常：{e}",
+                    terminal=True,
                 )
 
                 # Publish error notification
@@ -662,6 +723,12 @@ class CronScheduler:
         async with self.semaphore:
             try:
                 logger.info(f"Manually running job: {job_id}")
+                tools_text = updated_job.payload.tool_names if updated_job.payload.tool_names else "auto"
+                await self._publish_progress(
+                    updated_job,
+                    "info",
+                    f"手动触发执行，agent={updated_job.payload.agent_name}，tools={tools_text}",
+                )
                 timeout = job.payload.timeout_seconds or 600
                 result = await asyncio.wait_for(
                     self._execute_job_payload(updated_job),
@@ -673,8 +740,21 @@ class CronScheduler:
 
                 # Publish notification for manual run
                 if result.success:
+                    success_summary = self._get_result_summary(result)
+                    success_message = (
+                        f"任务执行完成：{success_summary}"
+                        if success_summary else
+                        "任务执行完成"
+                    )
+                    await self._publish_progress(notification_job, "success", success_message, terminal=True)
                     await self._publish_notification(notification_job, "ok")
                 else:
+                    await self._publish_progress(
+                        notification_job,
+                        "error",
+                        f"任务执行失败：{result.msg}",
+                        terminal=True,
+                    )
                     await self._publish_notification(notification_job, "error", result.msg)
 
                 return result
@@ -691,6 +771,12 @@ class CronScheduler:
                         "consecutive_errors": job.state.consecutive_errors + 1,
                     }
                 )
+                await self._publish_progress(
+                    updated_job,
+                    "error",
+                    f"任务执行超时：{job.payload.timeout_seconds or 600}s",
+                    terminal=True,
+                )
 
                 # Publish timeout notification for manual run
                 await self._publish_notification(job, "timeout")
@@ -698,7 +784,9 @@ class CronScheduler:
                 return TaskResponse(success=False, msg="Execution timeout")
 
             except Exception as e:
-                logger.error(f"Manual job {job_id} execution error: {e}", exc_info=True)
+                logger.error(
+                    f"Manual job {job_id} execution error: {e}\n{traceback.format_exc()}"
+                )
                 await self.store.update_job(
                     job_id,
                     state={
@@ -708,6 +796,12 @@ class CronScheduler:
                         "last_result_summary": None,
                         "consecutive_errors": job.state.consecutive_errors + 1,
                     }
+                )
+                await self._publish_progress(
+                    updated_job,
+                    "error",
+                    f"任务执行异常：{e}",
+                    terminal=True,
                 )
 
                 # Publish error notification for manual run

--- a/aworld/core/scheduler/store.py
+++ b/aworld/core/scheduler/store.py
@@ -37,10 +37,23 @@ def _coerce_tool_names(value: Any) -> List[str]:
     if value is None:
         return []
     if isinstance(value, list):
-        return [str(item) for item in value]
+        normalized = []
+        for item in value:
+            text = str(item).strip()
+            if not text:
+                continue
+            if "," in text:
+                normalized.extend(part.strip() for part in text.split(",") if part.strip())
+            else:
+                normalized.append(text)
+        return normalized
     if isinstance(value, str):
         stripped = value.strip()
-        return [stripped] if stripped else []
+        if not stripped:
+            return []
+        if "," in stripped:
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+        return [stripped]
     return [str(value)]
 
 

--- a/aworld/core/scheduler/store.py
+++ b/aworld/core/scheduler/store.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Dict, Any, Iterator
 from datetime import UTC, datetime
 
 from aworld.logs.util import logger
+from .normalization import normalize_tool_names
 from .types import CronJob, CronSchedule, CronPayload, CronJobState
 
 
@@ -34,27 +35,7 @@ def _coerce_bool(value: Any) -> bool:
 
 
 def _coerce_tool_names(value: Any) -> List[str]:
-    if value is None:
-        return []
-    if isinstance(value, list):
-        normalized = []
-        for item in value:
-            text = str(item).strip()
-            if not text:
-                continue
-            if "," in text:
-                normalized.extend(part.strip() for part in text.split(",") if part.strip())
-            else:
-                normalized.append(text)
-        return normalized
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped:
-            return []
-        if "," in stripped:
-            return [part.strip() for part in stripped.split(",") if part.strip()]
-        return [stripped]
-    return [str(value)]
+    return normalize_tool_names(value)
 
 
 def _coerce_optional_int(value: Any) -> Optional[int]:

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -11,9 +11,12 @@ from pydantic import Field
 from pydantic.fields import FieldInfo
 
 from croniter import croniter
+from aworld.core.scheduler.normalization import (
+    normalize_tool_names,
+    resolve_effective_tool_names,
+)
 from aworld.core.tool.func_to_tool import be_tool
 from aworld.logs.util import logger
-from aworld.core.scheduler.normalization import normalize_tool_names
 
 DEFAULT_ADVANCE_REMINDER_MINUTES = 10
 
@@ -254,21 +257,6 @@ async def cron_tool(
             return normalize_agent_name_local(bound_agent_name)
         return normalize_agent_name_local(raw_agent_name)
 
-    def resolve_effective_tool_names_local(
-        resolved_agent_name: str,
-        requested_tools: List[str],
-    ) -> List[str]:
-        """
-        Do not restrict Aworld/root-agent cron tasks unless explicitly designed otherwise.
-
-        Cron-created automation tasks are often open-ended instructions. When the
-        selected runtime root agent is Aworld, constraining tools based on an LLM-
-        invented comma string degrades execution quality and can block required tools.
-        """
-        if resolved_agent_name == "Aworld":
-            return []
-        return requested_tools
-
     def is_reactivatable_local(job: 'CronJob', now: datetime) -> bool:
         if job.schedule.kind in ("every", "cron"):
             return True
@@ -348,7 +336,7 @@ async def cron_tool(
 
         scheduler = get_scheduler()
         agent_name = resolve_bound_agent_name_local(agent_name, scheduler)
-        tools = resolve_effective_tool_names_local(agent_name, tools)
+        tools = resolve_effective_tool_names(agent_name, tools)
 
         if action == "add":
             request_schedule_derived = False

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -13,6 +13,7 @@ from pydantic.fields import FieldInfo
 from croniter import croniter
 from aworld.core.tool.func_to_tool import be_tool
 from aworld.logs.util import logger
+from aworld.core.scheduler.normalization import normalize_tool_names
 
 DEFAULT_ADVANCE_REMINDER_MINUTES = 10
 
@@ -144,32 +145,11 @@ async def cron_tool(
             raise ValueError(f"Invalid max_runs value: {raw_max_runs}. Expected a positive integer.")
         return parsed
 
-    def normalize_tool_names_local(raw_tools: Optional[Any]) -> List[str]:
-        if raw_tools is None or raw_tools == "":
-            return []
-        if isinstance(raw_tools, list):
-            normalized = []
-            for item in raw_tools:
-                text = str(item).strip()
-                if not text:
-                    continue
-                if "," in text:
-                    normalized.extend(part.strip() for part in text.split(",") if part.strip())
-                else:
-                    normalized.append(text)
-            return normalized
-        if isinstance(raw_tools, str):
-            stripped = raw_tools.strip()
-            if not stripped:
-                return []
-            return [part.strip() for part in stripped.split(",") if part.strip()]
-        return [str(raw_tools).strip()]
-
     try:
         max_runs = normalize_max_runs_local(max_runs)
     except ValueError as e:
         return {"success": False, "error": str(e)}
-    tools = normalize_tool_names_local(tools)
+    tools = normalize_tool_names(tools)
 
     def parse_duration_local(duration_str: str) -> int:
         match = re.fullmatch(r'(\d+)([smhd])', duration_str.strip())

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -14,6 +14,8 @@ from croniter import croniter
 from aworld.core.tool.func_to_tool import be_tool
 from aworld.logs.util import logger
 
+DEFAULT_ADVANCE_REMINDER_MINUTES = 10
+
 
 @be_tool(
     tool_name='cron',
@@ -105,6 +107,7 @@ async def cron_tool(
     # can still resolve them even when this function source is copied before the
     # helper definitions below are executed.
     from aworld.tools.cron_tool import (
+        _build_advance_reminder_spec as build_advance_reminder_spec_helper,
         _parse_natural_language_add_request as parse_request_helper,
         _unwrap_fieldinfo as unwrap_fieldinfo_helper,
     )
@@ -141,11 +144,32 @@ async def cron_tool(
             raise ValueError(f"Invalid max_runs value: {raw_max_runs}. Expected a positive integer.")
         return parsed
 
+    def normalize_tool_names_local(raw_tools: Optional[Any]) -> List[str]:
+        if raw_tools is None or raw_tools == "":
+            return []
+        if isinstance(raw_tools, list):
+            normalized = []
+            for item in raw_tools:
+                text = str(item).strip()
+                if not text:
+                    continue
+                if "," in text:
+                    normalized.extend(part.strip() for part in text.split(",") if part.strip())
+                else:
+                    normalized.append(text)
+            return normalized
+        if isinstance(raw_tools, str):
+            stripped = raw_tools.strip()
+            if not stripped:
+                return []
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+        return [str(raw_tools).strip()]
+
     try:
         max_runs = normalize_max_runs_local(max_runs)
     except ValueError as e:
         return {"success": False, "error": str(e)}
-    agent_name = normalize_agent_name_local(agent_name)
+    tools = normalize_tool_names_local(tools)
 
     def parse_duration_local(duration_str: str) -> int:
         match = re.fullmatch(r'(\d+)([smhd])', duration_str.strip())
@@ -222,6 +246,7 @@ async def cron_tool(
             "next_run": job.state.next_run_at,
             "last_run": job.state.last_run_at,
             "enabled": job.enabled,
+            "running": job.state.running,
             "max_runs": job.payload.max_runs,
             "run_count": job.state.run_count,
             "last_status": job.state.last_status,
@@ -235,6 +260,34 @@ async def cron_tool(
         if not value:
             return None
         return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+    def resolve_bound_agent_name_local(raw_agent_name: Optional[str], current_scheduler: Any) -> str:
+        bound_agent_name = None
+        executor = getattr(current_scheduler, "executor", None)
+        if executor and hasattr(executor, "get_default_agent_name"):
+            try:
+                bound_agent_name = executor.get_default_agent_name()
+            except Exception:
+                bound_agent_name = None
+
+        if bound_agent_name:
+            return normalize_agent_name_local(bound_agent_name)
+        return normalize_agent_name_local(raw_agent_name)
+
+    def resolve_effective_tool_names_local(
+        resolved_agent_name: str,
+        requested_tools: List[str],
+    ) -> List[str]:
+        """
+        Do not restrict Aworld/root-agent cron tasks unless explicitly designed otherwise.
+
+        Cron-created automation tasks are often open-ended instructions. When the
+        selected runtime root agent is Aworld, constraining tools based on an LLM-
+        invented comma string degrades execution quality and can block required tools.
+        """
+        if resolved_agent_name == "Aworld":
+            return []
+        return requested_tools
 
     def is_reactivatable_local(job: 'CronJob', now: datetime) -> bool:
         if job.schedule.kind in ("every", "cron"):
@@ -314,9 +367,12 @@ async def cron_tool(
         from aworld.core.scheduler.types import CronJob, CronSchedule, CronPayload
 
         scheduler = get_scheduler()
+        agent_name = resolve_bound_agent_name_local(agent_name, scheduler)
+        tools = resolve_effective_tool_names_local(agent_name, tools)
 
         if action == "add":
             request_schedule_derived = False
+            parsed_request = None
             if request:
                 try:
                     parsed_request = parse_request_helper(request)
@@ -391,12 +447,59 @@ async def cron_tool(
 
             result = await scheduler.add_job(job)
 
-            return {
+            advance_reminder = None
+            try:
+                reminder_body_hint = None
+                if parsed_request:
+                    reminder_body_hint = parsed_request.get("message")
+
+                advance_spec = build_advance_reminder_spec_helper(
+                    name=name,
+                    message=message,
+                    schedule_type=schedule_type,
+                    schedule_value=schedule_value,
+                    request_text=request,
+                    tools=tools,
+                    reminder_body_hint=reminder_body_hint,
+                )
+                if advance_spec:
+                    advance_job = CronJob(
+                        name=advance_spec["name"],
+                        schedule=parse_schedule_local(
+                            advance_spec["schedule_type"],
+                            advance_spec["schedule_value"],
+                        ),
+                        payload=CronPayload(
+                            message=advance_spec["message"],
+                            agent_name=agent_name or "Aworld",
+                            tool_names=[],
+                        ),
+                        delete_after_run=advance_spec["delete_after_run"],
+                    )
+                    advance_result = await scheduler.add_job(advance_job)
+                    advance_reminder = {
+                        "job_id": advance_result.id,
+                        "name": advance_result.name,
+                        "next_run": advance_result.state.next_run_at,
+                        "display": _format_confirmed_time_display(advance_result.state.next_run_at),
+                        "lead_minutes": DEFAULT_ADVANCE_REMINDER_MINUTES,
+                    }
+            except Exception as advance_error:
+                logger.warning(
+                    "cron_tool(add): failed to create advance reminder for "
+                    f"{name!r}: {advance_error}"
+                )
+
+            response = {
                 "success": True,
                 "job_id": result.id,
                 "message": f"Created task '{name}' (ID: {result.id})",
                 "next_run": result.state.next_run_at,
+                "next_run_display": _format_confirmed_time_display(result.state.next_run_at),
             }
+            if advance_reminder:
+                response["advance_reminder"] = advance_reminder
+            return response
 
         elif action == "list":
             jobs = await scheduler.list_jobs(enabled_only=not include_disabled)
@@ -666,11 +769,52 @@ def _parse_natural_language_add_request(request: str, now: Optional[datetime] = 
             "delete_after_run": True,
         }
 
+    weekday_match = _parse_weekday_timed_reminder(text, current_time)
+    if weekday_match:
+        return weekday_match
+
     raise ValueError(
         f"Unsupported natural-language schedule request: {request}. "
         "Use explicit schedule fields or a supported reminder phrase such as "
-        "'一分钟后提醒我喝水' or '每天早上9点提醒我运行测试'."
+        "'一分钟后提醒我喝水', '每天早上9点提醒我运行测试', or '下周三中午12点提醒我开会'."
     )
+
+
+def _parse_weekday_timed_reminder(text: str, current_time: datetime) -> Optional[Dict[str, Any]]:
+    patterns = (
+        r"(?P<week_ref>下周|下星期|本周|这周|本星期|这星期|周|星期)(?P<weekday>[一二三四五六日天])"
+        r"\s*[，,]?\s*(?:(?P<period>早上|上午|中午|下午|晚上))?\s*(?P<hour>\d{1,2})点(?P<half>半)?"
+        r"提醒我(?P<body>.+)",
+        r"(?P<week_ref>下周|下星期|本周|这周|本星期|这星期|周|星期)(?P<weekday>[一二三四五六日天])"
+        r"\s*[，,]?\s*(?:(?P<period>早上|上午|中午|下午|晚上))?\s*(?P<hour>\d{1,2})点(?P<half>半)?"
+        r"(?P<body>.+?)(?:的)?提醒",
+    )
+
+    for pattern in patterns:
+        match = re.fullmatch(pattern, text)
+        if not match:
+            continue
+
+        hour = _normalize_hour(match.group("period"), int(match.group("hour")))
+        minute = 30 if match.group("half") else 0
+        body = match.group("body")
+        target_time = _resolve_weekday_target_time(
+            current_time=current_time,
+            week_ref=match.group("week_ref"),
+            weekday_token=match.group("weekday"),
+            hour=hour,
+            minute=minute,
+        )
+        message = _normalize_reminder_message(body)
+        return {
+            "name": _reminder_name_from_message(message),
+            "message": message,
+            "schedule_type": "at",
+            "schedule_value": target_time.isoformat(timespec="seconds"),
+            "delete_after_run": True,
+        }
+
+    return None
 
 
 def _resolve_schedule_now(now: Optional[datetime]) -> datetime:
@@ -679,6 +823,63 @@ def _resolve_schedule_now(now: Optional[datetime]) -> datetime:
     if now.tzinfo is None:
         return now.replace(tzinfo=datetime.now().astimezone().tzinfo)
     return now
+
+
+def _resolve_weekday_target_time(
+    current_time: datetime,
+    week_ref: str,
+    weekday_token: str,
+    hour: int,
+    minute: int,
+) -> datetime:
+    weekday_index = _weekday_token_to_index(weekday_token)
+    week_scope = _normalize_week_reference(week_ref)
+    current_date = current_time.date()
+
+    if week_scope in {"current", "next"}:
+        start_of_week = current_date - timedelta(days=current_time.weekday())
+        days_offset = weekday_index + (7 if week_scope == "next" else 0)
+        target_date = start_of_week + timedelta(days=days_offset)
+    else:
+        days_ahead = weekday_index - current_time.weekday()
+        target_date = current_date + timedelta(days=days_ahead)
+
+    target_time = current_time.replace(
+        year=target_date.year,
+        month=target_date.month,
+        day=target_date.day,
+        hour=hour,
+        minute=minute,
+        second=0,
+        microsecond=0,
+    )
+    if target_time <= current_time:
+        target_time += timedelta(days=7)
+    return target_time
+
+
+def _normalize_week_reference(value: str) -> str:
+    if value.startswith("下"):
+        return "next"
+    if value.startswith("本") or value.startswith("这"):
+        return "current"
+    return "upcoming"
+
+
+def _weekday_token_to_index(value: str) -> int:
+    weekday_map = {
+        "一": 0,
+        "二": 1,
+        "三": 2,
+        "四": 3,
+        "五": 4,
+        "六": 5,
+        "日": 6,
+        "天": 6,
+    }
+    if value not in weekday_map:
+        raise ValueError(f"Unsupported weekday token in reminder request: {value}")
+    return weekday_map[value]
 
 
 def _natural_language_delta(quantity: int, unit: str) -> timedelta:
@@ -750,6 +951,128 @@ def _reminder_name_from_message(message: str) -> str:
     if body.startswith("提醒我"):
         body = body[len("提醒我"):]
     return f"提醒：{body.strip()}"
+
+
+def _build_advance_reminder_spec(
+    name: str,
+    message: str,
+    schedule_type: str,
+    schedule_value: str,
+    request_text: Optional[str] = None,
+    tools: Optional[List[str]] = None,
+    reminder_body_hint: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> Optional[Dict[str, Any]]:
+    if not _is_notification_reminder(name=name, message=message, tools=tools):
+        return None
+    if _is_relative_reminder_request(request_text):
+        return None
+
+    lead_time = timedelta(minutes=DEFAULT_ADVANCE_REMINDER_MINUTES)
+    reminder_body = _extract_reminder_body(reminder_body_hint) or _extract_reminder_body(message) or _extract_reminder_body(name)
+    if not reminder_body:
+        return None
+
+    if schedule_type != "at":
+        shifted_cron = _shift_simple_daily_cron(schedule_value, lead_time) if schedule_type == "cron" else None
+        if not shifted_cron:
+            return None
+        return {
+            "name": f"{_reminder_name_from_message(f'提醒我{reminder_body}')}（提前{DEFAULT_ADVANCE_REMINDER_MINUTES}分钟）",
+            "message": f"提醒我{reminder_body}，还有{DEFAULT_ADVANCE_REMINDER_MINUTES}分钟",
+            "schedule_type": "cron",
+            "schedule_value": shifted_cron,
+            "delete_after_run": False,
+        }
+
+    target_time = _parse_iso_datetime(schedule_value)
+    current_time = _resolve_schedule_now(now)
+    if target_time.tzinfo is None:
+        target_time = target_time.replace(tzinfo=current_time.tzinfo)
+    current_time = current_time.astimezone(target_time.tzinfo)
+    advance_time = target_time - lead_time
+    if advance_time <= current_time:
+        return None
+
+    return {
+        "name": f"{_reminder_name_from_message(f'提醒我{reminder_body}')}（提前{DEFAULT_ADVANCE_REMINDER_MINUTES}分钟）",
+        "message": f"提醒我{reminder_body}，还有{DEFAULT_ADVANCE_REMINDER_MINUTES}分钟",
+        "schedule_type": "at",
+        "schedule_value": advance_time.isoformat(timespec="seconds"),
+        "delete_after_run": True,
+    }
+
+
+def _is_notification_reminder(name: str, message: str, tools: Optional[List[str]] = None) -> bool:
+    if tools:
+        return False
+
+    name_text = (name or "").strip().lower()
+    message_text = (message or "").strip().lower()
+    if not name_text and not message_text:
+        return False
+
+    keywords = ("提醒", "remind", "reminder")
+    return any(keyword in name_text or keyword in message_text for keyword in keywords)
+
+
+def _extract_reminder_body(text: Optional[str]) -> Optional[str]:
+    value = (text or "").strip()
+    if not value:
+        return None
+
+    value = re.sub(r"^提醒(?:我|用户|您)?[:：]?", "", value).strip()
+    value = re.sub(r"[:：]?提醒$", "", value).strip()
+    value = re.sub(r"^还有\d+\s*分钟[，,]?", "", value).strip()
+    value = re.sub(r"[（(]提前\d+分钟[）)]$", "", value).strip()
+    return value or None
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _format_confirmed_time_display(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+
+    try:
+        dt = _parse_iso_datetime(value)
+    except ValueError:
+        return None
+
+    weekday_map = ("星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日")
+    return (
+        f"{dt.year}年{dt.month}月{dt.day}日"
+        f"（{weekday_map[dt.weekday()]}）"
+        f"{dt.hour:02d}:{dt.minute:02d}"
+    )
+
+
+def _shift_simple_daily_cron(schedule_value: str, lead_time: timedelta) -> Optional[str]:
+    parts = schedule_value.split()
+    if len(parts) != 5 or parts[2:] != ["*", "*", "*"]:
+        return None
+    if not parts[0].isdigit() or not parts[1].isdigit():
+        return None
+
+    base_time = datetime(2000, 1, 2, int(parts[1]), int(parts[0]), 0)
+    shifted_time = base_time - lead_time
+    return f"{shifted_time.minute} {shifted_time.hour} * * *"
+
+
+def _is_relative_reminder_request(text: Optional[str]) -> bool:
+    value = (text or "").strip()
+    if not value:
+        return False
+
+    return bool(
+        re.search(
+            r"(?:\d+|[零一二两三四五六七八九十百]+)\s*(?:秒钟?|秒|分钟|分|小时|个小时|小时|天|日)后提醒我"
+            r"|提醒我(?:\d+|[零一二两三四五六七八九十百]+)\s*(?:秒钟?|秒|分钟|分|小时|个小时|小时|天|日)后",
+            value,
+        )
+    )
 
 
 def _normalize_hour(period: Optional[str], hour: int) -> int:

--- a/tests/core/agent/test_tool_result_followup_format.py
+++ b/tests/core/agent/test_tool_result_followup_format.py
@@ -23,6 +23,7 @@ async def test_cron_tool_results_are_reframed_with_confirmed_next_run():
                 "success": True,
                 "job_id": "job-123",
                 "next_run": "2026-04-14T17:17:00+08:00",
+                "next_run_display": "2026年4月14日（星期二）17:17",
                 "message": "Created task '喝水提醒' (ID: job-123)",
             },
         )
@@ -30,8 +31,10 @@ async def test_cron_tool_results_are_reframed_with_confirmed_next_run():
 
     policy_info = aggregated[0].policy_info
     assert "next_run=2026-04-14T17:17:00+08:00" in policy_info
+    assert "next_run_display=2026年4月14日（星期二）17:17" in policy_info
     assert "source of truth" in policy_info
     assert "do not reuse any earlier guessed schedule_value" in policy_info
+    assert "infer the weekday yourself" in policy_info
 
 
 @pytest.mark.asyncio

--- a/tests/core/scheduler/test_executor.py
+++ b/tests/core/scheduler/test_executor.py
@@ -3,9 +3,11 @@
 """
 Tests for CronExecutor - agent resolution and execution.
 """
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
+from types import SimpleNamespace
 import pytz
 
 from aworld.core.scheduler.executor import CronExecutor
@@ -165,6 +167,39 @@ async def test_execute_success(executor, sample_job):
 
 
 @pytest.mark.asyncio
+async def test_execute_ignores_persisted_tool_restrictions_for_aworld(executor):
+    """Legacy Aworld cron jobs should run without persisted tool allowlists."""
+    aworld_job = CronJob(
+        name="aworld-job",
+        schedule=CronSchedule(kind="every", every_seconds=3600),
+        payload=CronPayload(
+            message="Run aworld task",
+            agent_name="Aworld",
+            tool_names=["CAST_SEARCH", "bash", "SKILL"],
+        ),
+        state=CronJobState(next_run_at=datetime.now(pytz.UTC).isoformat()),
+    )
+
+    mock_swarm = MockSwarm()
+    mock_result = TaskResponse(success=True, msg="Task completed", answer="Result")
+
+    executor._resolve_swarm = AsyncMock(return_value=mock_swarm)
+
+    with patch('aworld.runner.Runners.run', new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = mock_result
+
+        result = await executor.execute(aworld_job)
+
+        mock_run.assert_called_once_with(
+            input="Run aworld task",
+            swarm=mock_swarm,
+            tool_names=[],
+            session_id=None,
+        )
+        assert result.success is True
+
+
+@pytest.mark.asyncio
 async def test_execute_agent_not_found(executor, sample_job):
     """Test execution fails gracefully when agent not found."""
     executor._resolve_swarm = AsyncMock(return_value=None)
@@ -227,6 +262,85 @@ async def test_execute_with_retry_exception_handling(executor, sample_job):
 
     assert result.success is False
     assert "failed after 1 retries" in result.msg
+
+
+@pytest.mark.asyncio
+async def test_execute_with_retry_streams_detailed_progress(executor, sample_job):
+    """Cron execution should surface stream events and final answer to follow mode."""
+    mock_swarm = MockSwarm()
+    executor._resolve_swarm = AsyncMock(return_value=mock_swarm)
+
+    events = [
+        SimpleNamespace(
+            output_type=lambda: "step",
+            alias_name="读取 skill 文档",
+            name="ReadSkill",
+            status="START",
+            step_num=1,
+        ),
+        SimpleNamespace(
+            output_type=lambda: "tool_call",
+            data=SimpleNamespace(
+                function=SimpleNamespace(
+                    name="bash",
+                    arguments='{"cmd":"python twitter_scraper_10_posts.py"}',
+                )
+            ),
+        ),
+        SimpleNamespace(
+            output_type=lambda: "tool_call_result",
+            tool_name="bash",
+            data="saved twitter_latest_10_posts.md",
+        ),
+        SimpleNamespace(
+            output_type=lambda: "message",
+            response="已抓取完成，并保存到当前目录。",
+            reasoning=None,
+        ),
+    ]
+
+    class FakeStreamingOutputs:
+        def __init__(self):
+            self._task_response = TaskResponse(
+                success=True,
+                answer="已抓取完成，并保存到当前目录。",
+                msg="ok",
+            )
+            self._run_impl_task = asyncio.create_task(self._result())
+
+        async def _result(self):
+            return {
+                "task-123": self._task_response
+            }
+
+        async def stream_events(self):
+            for event in events:
+                yield event
+
+        def response(self):
+            return self._task_response
+
+        def get_message_output_content(self):
+            return "Aworld:已抓取完成，并保存到当前目录。"
+
+    progress_messages = []
+
+    async def record_progress(level, message):
+        progress_messages.append((level, message))
+
+    with patch("aworld.runner.Runners.streamed_run_task", return_value=FakeStreamingOutputs()):
+        result = await executor.execute_with_retry(
+            sample_job,
+            max_retries=0,
+            progress_callback=record_progress,
+        )
+
+    assert result.success is True
+    assert any("步骤 #1 开始：读取 skill 文档" in message for _, message in progress_messages)
+    assert any("工具调用：bash" in message for _, message in progress_messages)
+    assert any("工具结果：bash" in message for _, message in progress_messages)
+    assert any("Agent 输出：" in message for _, message in progress_messages)
+    assert any("最终回答：" in message for _, message in progress_messages)
 
 
 @pytest.mark.asyncio

--- a/tests/core/scheduler/test_notifications.py
+++ b/tests/core/scheduler/test_notifications.py
@@ -216,6 +216,50 @@ async def test_scheduler_publishes_reminder_detail_on_success():
 
 
 @pytest.mark.asyncio
+async def test_scheduler_publishes_live_progress_logs():
+    """Scheduler should publish live execution progress for `/cron show` follow mode."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store_path = Path(tmpdir) / "cron.json"
+        store = FileBasedCronStore(str(store_path))
+
+        executor = AsyncMock(spec=CronExecutor)
+
+        async def fake_execute_with_retry(job, progress_callback=None, **kwargs):
+            if progress_callback:
+                await progress_callback("info", "子步骤：准备执行")
+            return TaskResponse(success=True, msg="执行完成")
+
+        executor.execute_with_retry = AsyncMock(side_effect=fake_execute_with_retry)
+
+        progress_sink = AsyncMock()
+        scheduler = CronScheduler(store, executor, progress_sink=progress_sink)
+
+        now = datetime.now(pytz.UTC)
+        job = CronJob(
+            name="live-job",
+            schedule=CronSchedule(kind="at", at=now.isoformat()),
+            payload=CronPayload(message="test"),
+            state=CronJobState(
+                running=True,
+                last_run_at=now.isoformat(),
+                next_run_at=None,
+            ),
+        )
+
+        await store.add_job(job)
+        await scheduler._execute_claimed_job(job)
+
+        assert progress_sink.await_count >= 3
+        messages = [call.args[0]["message"] for call in progress_sink.await_args_list]
+        assert any("任务开始执行" in message for message in messages)
+        assert any("子步骤：准备执行" in message for message in messages)
+        assert any("任务执行完成" in message for message in messages)
+
+
+@pytest.mark.asyncio
 async def test_scheduler_short_circuits_instructional_reminders():
     """Reminder payloads should publish directly instead of re-entering the agent."""
     import tempfile
@@ -319,7 +363,7 @@ async def test_scheduler_publishes_on_timeout():
         store = FileBasedCronStore(str(store_path))
 
         # Mock executor that times out
-        async def timeout_executor(job):
+        async def timeout_executor(job, progress_callback=None):
             await asyncio.sleep(10)  # Will be cancelled by timeout
             return TaskResponse(success=True, msg="Should not reach here")
 

--- a/tests/core/scheduler/test_notifications.py
+++ b/tests/core/scheduler/test_notifications.py
@@ -260,6 +260,28 @@ async def test_scheduler_publishes_live_progress_logs():
 
 
 @pytest.mark.asyncio
+async def test_notification_center_logs_warning_when_progress_store_fails(monkeypatch):
+    """Progress-log buffering failures should be surfaced as warnings."""
+    center = CronNotificationCenter()
+    warnings = []
+
+    monkeypatch.setattr(
+        "aworld_cli.runtime.cron_notifications.logger.warning",
+        lambda message: warnings.append(message),
+    )
+    monkeypatch.setattr(center, "_progress_logs", None)
+
+    await center.publish_progress({
+        "job_id": "job-1",
+        "job_name": "test",
+        "message": "step",
+    })
+
+    assert len(warnings) == 1
+    assert "Failed to store cron progress log" in warnings[0]
+
+
+@pytest.mark.asyncio
 async def test_scheduler_short_circuits_instructional_reminders():
     """Reminder payloads should publish directly instead of re-entering the agent."""
     import tempfile

--- a/tests/core/scheduler/test_store.py
+++ b/tests/core/scheduler/test_store.py
@@ -332,5 +332,31 @@ async def test_store_coerces_legacy_string_max_runs_and_tool_fields(temp_store):
     assert restored.delete_after_run is False
 
 
+@pytest.mark.asyncio
+async def test_store_splits_comma_delimited_tool_names(temp_store):
+    """Comma-delimited legacy tool fields should be split into individual tool names."""
+    job = CronJob(
+        name="legacy-tool-list",
+        schedule=CronSchedule(kind="every", every_seconds=180),
+        payload=CronPayload(
+            message="run task",
+            agent_name="Aworld",
+            tool_names=["bash"],
+        ),
+        state=CronJobState(next_run_at="2026-04-12T10:32:00+00:00"),
+    )
+
+    await temp_store.add_job(job)
+
+    data = temp_store._read_data()
+    data["jobs"][0]["payload"]["tool_names"] = "CAST_SEARCH,bash,SKILL"
+    temp_store._write_data(data)
+
+    restored = await temp_store.get_job(job.id)
+
+    assert restored is not None
+    assert restored.payload.tool_names == ["CAST_SEARCH", "bash", "SKILL"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -7,8 +7,10 @@ import asyncio
 import os
 import sys
 import pytest
+from io import StringIO
 from pathlib import Path
 from prompt_toolkit.document import Document
+from rich.console import Console as RichConsole
 
 # Add aworld-cli to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "aworld-cli" / "src"))
@@ -292,6 +294,98 @@ class TestCronCommand:
         assert "run_count" in result
         assert "last_result_summary" in result
         assert "BTC 当前价格 68000 USDT" in result
+
+    @pytest.mark.asyncio
+    async def test_cron_show_follows_live_logs_for_running_job(self, monkeypatch):
+        """Running jobs should switch `/cron show` into live follow mode."""
+        from aworld_cli.runtime.cron_notifications import CronNotificationCenter
+
+        cmd = CommandRegistry.get('cron')
+        call_count = 0
+
+        async def fake_cron_tool(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return {
+                    "success": True,
+                    "job": {
+                        "id": "job-live",
+                        "name": "爬取 X",
+                        "schedule": "at 2026-04-15T17:37:22+08:00",
+                        "enabled": True,
+                        "running": True,
+                        "next_run": None,
+                        "last_run": "2026-04-15T09:37:22.005051+00:00",
+                        "last_status": None,
+                        "last_error": None,
+                        "max_runs": None,
+                        "run_count": 0,
+                        "last_result_summary": None,
+                    },
+                }
+            return {
+                "success": True,
+                "job": {
+                    "id": "job-live",
+                    "name": "爬取 X",
+                    "schedule": "at 2026-04-15T17:37:22+08:00",
+                    "enabled": True,
+                    "running": False,
+                    "next_run": None,
+                    "last_run": "2026-04-15T09:37:22.005051+00:00",
+                    "last_status": "ok",
+                    "last_error": None,
+                    "max_runs": None,
+                    "run_count": 1,
+                    "last_result_summary": "已保存 10 条内容",
+                },
+            }
+
+        monkeypatch.setattr("aworld_cli.commands.cron_cmd.cron_tool", fake_cron_tool)
+
+        class FakeRuntime:
+            def __init__(self):
+                buffer = StringIO()
+                self._buffer = buffer
+                self.cli = type("FakeCli", (), {"console": RichConsole(file=buffer, force_terminal=False, color_system=None)})()
+                self._notification_center = CronNotificationCenter()
+
+            def _get_cron_progress_logs(self, job_id):
+                return self._notification_center.get_progress_logs(job_id)
+
+        runtime = FakeRuntime()
+        await runtime._notification_center.publish_progress({
+            "job_id": "job-live",
+            "job_name": "爬取 X",
+            "level": "info",
+            "message": "开始第 1/4 次执行",
+        })
+        await runtime._notification_center.publish_progress({
+            "job_id": "job-live",
+            "job_name": "爬取 X",
+            "level": "success",
+            "message": "最终回答：\n已保存 10 条内容\n输出文件：twitter_latest_10_posts.md",
+        })
+        await runtime._notification_center.publish_progress({
+            "job_id": "job-live",
+            "job_name": "爬取 X",
+            "level": "success",
+            "message": "任务执行完成：已保存 10 条内容",
+            "terminal": True,
+        })
+
+        context = CommandContext(cwd=os.getcwd(), user_args="show job-live", runtime=runtime)
+        result = await cmd.execute(context)
+
+        assert result == ""
+        output = runtime._buffer.getvalue()
+        assert "跟踪定时任务执行" in output
+        assert "开始第 1/4 次执行" in output
+        assert "最终回答：" in output
+        assert "输出文件：twitter_latest_10_posts.md" in output
+        assert "任务执行完成：已保存 10 条内容" in output
+        assert "定时任务执行结束" in output
 
     @pytest.mark.asyncio
     async def test_cron_disable_all_executes_tool_directly(self, monkeypatch):

--- a/tests/tools/test_cron_tool.py
+++ b/tests/tools/test_cron_tool.py
@@ -163,6 +163,30 @@ class TestParseScheduleValidation:
         assert parsed["delete_after_run"] is False
         assert parsed["max_runs"] == 3
 
+    def test_parse_natural_language_next_weekday_reminder_in_chinese(self):
+        """Test next-week weekday reminders resolve to the correct calendar date."""
+        now = datetime(2026, 4, 15, 16, 33, 0, tzinfo=timezone(timedelta(hours=8)))
+
+        parsed = self._parse_natural_language_add_request("下周三中午12点提醒我开会", now=now)
+
+        assert parsed["name"] == "提醒：开会"
+        assert parsed["message"] == "提醒我开会"
+        assert parsed["schedule_type"] == "at"
+        assert parsed["schedule_value"] == "2026-04-22T12:00:00+08:00"
+        assert parsed["delete_after_run"] is True
+
+    def test_parse_natural_language_next_weekday_suffix_reminder_in_chinese(self):
+        """Test trailing '...的提醒' phrasing also resolves correctly."""
+        now = datetime(2026, 4, 15, 16, 33, 0, tzinfo=timezone(timedelta(hours=8)))
+
+        parsed = self._parse_natural_language_add_request("下周三，中午12点开会的提醒", now=now)
+
+        assert parsed["name"] == "提醒：开会"
+        assert parsed["message"] == "提醒我开会"
+        assert parsed["schedule_type"] == "at"
+        assert parsed["schedule_value"] == "2026-04-22T12:00:00+08:00"
+        assert parsed["delete_after_run"] is True
+
     def test_parse_natural_language_rejects_unsupported_request(self):
         """Test unsupported natural-language requests fail clearly."""
         now = datetime(2026, 4, 11, 23, 21, 0, tzinfo=timezone(timedelta(hours=8)))
@@ -261,6 +285,95 @@ async def test_cron_tool_add_prefers_request_derived_schedule_over_llm_supplied_
 
 
 @pytest.mark.asyncio
+async def test_cron_tool_add_creates_default_advance_reminder_for_future_calendar_reminder(monkeypatch):
+    """Future point-in-time reminders should get an extra default pre-reminder."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+
+        async def add_job(self, job):
+            self.jobs.append(job)
+            job.state = CronJobState(next_run_at=job.schedule.at)
+            return job
+
+    fake_scheduler = FakeScheduler()
+
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+    monkeypatch.setattr(
+        cron_tool_module,
+        "_resolve_schedule_now",
+        lambda now=None: now or datetime(2026, 4, 15, 10, 0, 0, tzinfo=timezone(timedelta(hours=8))),
+    )
+    monkeypatch.setattr(
+        cron_tool_module,
+        "_parse_natural_language_add_request",
+        lambda request, now=None: {
+            "name": "提醒：开会",
+            "message": "提醒我开会",
+            "schedule_type": "at",
+            "schedule_value": "2026-04-22T12:00:00+08:00",
+            "delete_after_run": True,
+        },
+    )
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        request="下周三中午12点提醒我开会",
+    )
+
+    assert result["success"] is True
+    assert len(fake_scheduler.jobs) == 2
+    assert fake_scheduler.jobs[0].schedule.at == "2026-04-22T12:00:00+08:00"
+    assert fake_scheduler.jobs[1].name == "提醒：开会（提前10分钟）"
+    assert fake_scheduler.jobs[1].payload.message == "提醒我开会，还有10分钟"
+    assert fake_scheduler.jobs[1].schedule.at == "2026-04-22T11:50:00+08:00"
+    assert result["next_run_display"] == "2026年4月22日（星期三）12:00"
+    assert result["advance_reminder"]["display"] == "2026年4月22日（星期三）11:50"
+    assert result["advance_reminder"]["next_run"] == "2026-04-22T11:50:00+08:00"
+    assert result["advance_reminder"]["lead_minutes"] == 10
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_creates_default_advance_reminder_for_daily_reminder(monkeypatch):
+    """Daily fixed-time reminders should also get a shifted pre-reminder cron."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+
+        async def add_job(self, job):
+            self.jobs.append(job)
+            next_run = job.schedule.at
+            if job.schedule.kind == "cron":
+                next_run = job.schedule.cron_expr
+            job.state = CronJobState(next_run_at=next_run)
+            return job
+
+    fake_scheduler = FakeScheduler()
+
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        request="每天早上9点提醒我运行测试",
+    )
+
+    assert result["success"] is True
+    assert len(fake_scheduler.jobs) == 2
+    assert fake_scheduler.jobs[0].schedule.cron_expr == "0 9 * * *"
+    assert fake_scheduler.jobs[1].name == "提醒：运行测试（提前10分钟）"
+    assert fake_scheduler.jobs[1].payload.message == "提醒我运行测试，还有10分钟"
+    assert fake_scheduler.jobs[1].schedule.cron_expr == "50 8 * * *"
+    assert result["advance_reminder"]["next_run"] == "50 8 * * *"
+    assert result["advance_reminder"]["lead_minutes"] == 10
+
+
+@pytest.mark.asyncio
 async def test_cron_tool_normalizes_string_max_runs_and_aworld_agent_name(monkeypatch):
     """String max_runs and lowercase aworld agent name should be normalized before persistence."""
     from aworld.core.scheduler.types import CronJobState
@@ -294,6 +407,80 @@ async def test_cron_tool_normalizes_string_max_runs_and_aworld_agent_name(monkey
     assert fake_scheduler.last_job is not None
     assert fake_scheduler.last_job.payload.max_runs == 3
     assert fake_scheduler.last_job.payload.agent_name == "Aworld"
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_binds_job_to_runtime_default_agent(monkeypatch):
+    """Cron add should bind the persisted job to the CLI-selected root agent."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeExecutor:
+        def get_default_agent_name(self):
+            return "Aworld"
+
+    class FakeScheduler:
+        def __init__(self):
+            self.last_job = None
+            self.executor = FakeExecutor()
+
+        async def add_job(self, job):
+            self.last_job = job
+            job.state = CronJobState(next_run_at="2026-04-16T10:32:00+00:00")
+            return job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        name="爬取X最新10条内容",
+        message="参考当前目录下twitter_scraper_skill.md skill爬取x上面的内容，存到当前目录。注意爬取最新的10条就行",
+        schedule_type="at",
+        schedule_value="2026-04-16T18:32:00+08:00",
+        agent_name="default",
+        tools=["bash", "CAST_SEARCH"],
+        delete_after_run=True,
+    )
+
+    assert result["success"] is True
+    assert fake_scheduler.last_job is not None
+    assert fake_scheduler.last_job.payload.agent_name == "Aworld"
+    assert fake_scheduler.last_job.payload.tool_names == []
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_splits_comma_delimited_tools_for_non_aworld_agent(monkeypatch):
+    """Non-Aworld cron jobs should still normalize comma-delimited tool strings."""
+    from aworld.core.scheduler.types import CronJobState
+    import aworld.tools.cron_tool as cron_tool_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.last_job = None
+
+        async def add_job(self, job):
+            self.last_job = job
+            job.state = CronJobState(next_run_at="2026-04-16T10:32:00+00:00")
+            return job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        name="special-agent-task",
+        message="run with specific tools",
+        schedule_type="at",
+        schedule_value="2026-04-16T18:32:00+08:00",
+        agent_name="SpecialAgent",
+        tools="CAST_SEARCH,bash,SKILL",
+        delete_after_run=True,
+    )
+
+    assert result["success"] is True
+    assert fake_scheduler.last_job is not None
+    assert fake_scheduler.last_job.payload.tool_names == ["CAST_SEARCH", "bash", "SKILL"]
 
 
 @pytest.mark.asyncio
@@ -427,7 +614,7 @@ async def test_cron_tool_enable_all_skips_expired_one_time_history(monkeypatch):
     from aworld.core.scheduler.types import CronJob, CronJobState, CronPayload, CronSchedule
 
     updated_ids = []
-    future_at = "2026-04-14T10:00:00+00:00"
+    future_at = "2026-04-20T10:00:00+00:00"
     past_at = "2026-04-10T10:00:00+00:00"
 
     class FakeScheduler:


### PR DESCRIPTION
## Summary
- add live follow mode and in-memory progress logs for running cron jobs in the CLI
- bind new cron jobs to the selected CLI root agent and normalize legacy tool persistence for Aworld jobs
- improve reminder parsing, confirmed time display, and automatic advance reminders for supported reminder flows
- harden scheduler/executor error logging and refresh cron-related tests for the new behavior

## Testing
- PYTHONPATH=aworld-cli/src:. venv/bin/pytest tests/core/agent/test_tool_result_followup_format.py tests/core/scheduler/test_executor.py tests/core/scheduler/test_notifications.py tests/core/scheduler/test_store.py tests/test_slash_commands.py tests/tools/test_cron_tool.py