### PR TITLE
fix: handle root markdown files in docs outline

### DIFF
--- a/docs/outline.py
+++ b/docs/outline.py
@@ -163,8 +163,8 @@ if __name__ == '__main__':
     # standard structure
     for line in outline:
         for k, v in line.items():
-            index_content.append(f"## {k}")
             if isinstance(v, dict):
+                index_content.append(f"## {k}")
                 for s_k, s_v in v.items():
                     index_content.append(f"[{s_k}]({s_v})")
             else:

--- a/docs/outline.py
+++ b/docs/outline.py
@@ -42,6 +42,10 @@ def scan_path(path: str) -> List[dict]:
         # Apply directory name mapping
         display_name = file_mapping.get(k, k)
 
+        if not isinstance(v, dict):
+            res.append({display_name: v})
+            continue
+
         # files in dir
         final_map = OrderedDict()
         for file in file_priority.get(display_name, []):
@@ -160,8 +164,11 @@ if __name__ == '__main__':
     for line in outline:
         for k, v in line.items():
             index_content.append(f"## {k}")
-            for s_k, s_v in v.items():
-                index_content.append(f"[{s_k}]({s_v})")
+            if isinstance(v, dict):
+                for s_k, s_v in v.items():
+                    index_content.append(f"[{s_k}]({s_v})")
+            else:
+                index_content.append(f"[{k}]({v})")
 
     with open("index.md", 'w') as index_file:
         index_file.write("\n\n".join(index_content))


### PR DESCRIPTION
## Summary
- handle root-level markdown files when building the docs outline nav
- avoid treating root file entries as mapping nodes during nav assembly
- keep index generation compatible with both grouped sections and direct file links

## Testing
- python3 docs/outline.py