### PR TITLE
fix: include cron result details in inbox notifications

### DIFF
--- a/aworld-cli/src/aworld_cli/commands/cron_cmd.py
+++ b/aworld-cli/src/aworld_cli/commands/cron_cmd.py
@@ -229,7 +229,10 @@ class CronCommand(Command):
             lines.append(f"  summary: {getattr(item, 'summary', '')}")
             detail = getattr(item, "detail", None)
             if detail:
-                lines.append(f"  content: {detail}")
+                detail_lines = str(detail).splitlines() or [""]
+                lines.append(f"  content: {detail_lines[0]}")
+                for extra_line in detail_lines[1:]:
+                    lines.append(f"           {extra_line}")
             if next_run_at:
                 lines.append(f"  next_run: {next_run_at}")
             created_at = getattr(item, "created_at", None)

--- a/aworld/core/scheduler/scheduler.py
+++ b/aworld/core/scheduler/scheduler.py
@@ -404,6 +404,20 @@ class CronScheduler:
             return f"{text[:277]}..."
         return text
 
+    def _stringify_result_detail(self, value: Any, limit: int = 4000) -> Optional[str]:
+        """Best-effort conversion of task output to a richer multiline detail string."""
+        if value is None:
+            return None
+
+        text = value if isinstance(value, str) else str(value)
+        text = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+        if not text:
+            return None
+
+        if len(text) > limit:
+            return f"{text[:limit - 3]}..."
+        return text
+
     def _get_result_summary(self, result: Any) -> Optional[str]:
         """Extract a short execution summary from TaskResponse-like objects."""
         if result is None:
@@ -414,6 +428,32 @@ class CronScheduler:
             return answer_text
 
         return self._stringify_result_value(getattr(result, "msg", None))
+
+    def _get_result_detail(self, result: Any) -> Optional[str]:
+        """Extract a richer notification detail from TaskResponse-like objects."""
+        if result is None:
+            return None
+
+        answer_text = self._stringify_result_detail(getattr(result, "answer", None))
+        msg_text = self._stringify_result_detail(getattr(result, "msg", None), limit=1000)
+        generic_msgs = {"ok", "success", "task completed", "执行完成"}
+
+        if answer_text:
+            normalized_answer = answer_text.strip().lower()
+            normalized_msg = (msg_text or "").strip().lower()
+            if (
+                msg_text
+                and normalized_msg
+                and normalized_msg not in generic_msgs
+                and normalized_msg not in normalized_answer
+            ):
+                return f"最终回答：\n{answer_text}\n\n结果消息：\n{msg_text}"
+            return f"最终回答：\n{answer_text}"
+
+        if msg_text:
+            return msg_text
+
+        return None
 
     async def _execute_job_payload(self, job: CronJob):
         """Execute a job or short-circuit legacy stop-task payloads."""
@@ -479,7 +519,8 @@ class CronScheduler:
         self,
         job: CronJob,
         status: Literal["ok", "error", "timeout"],
-        error: Optional[str] = None
+        error: Optional[str] = None,
+        result: Optional[Any] = None,
     ):
         """
         Publish notification if sink is configured.
@@ -512,7 +553,7 @@ class CronScheduler:
                 # Fixed template - do NOT include raw error text in notification
                 summary = f'Cron task "{job.name}" failed'
 
-            detail = self._build_notification_detail(job, status)
+            detail = self._build_notification_detail(job, status, result=result)
 
             notification_data = {
                 'job_id': job.id,
@@ -534,6 +575,7 @@ class CronScheduler:
         self,
         job: CronJob,
         status: Literal["ok", "error", "timeout"],
+        result: Optional[Any] = None,
     ) -> Optional[str]:
         """
         Build optional user-facing detail for notifications.
@@ -547,6 +589,10 @@ class CronScheduler:
         reminder_detail = self._get_reminder_detail(job)
         if reminder_detail:
             return reminder_detail
+
+        result_detail = self._get_result_detail(result)
+        if result_detail:
+            return result_detail
 
         return job.state.last_result_summary
 
@@ -589,7 +635,7 @@ class CronScheduler:
                         "任务执行完成"
                     )
                     await self._publish_progress(notification_job, "success", success_message, terminal=True)
-                    await self._publish_notification(notification_job, "ok")
+                    await self._publish_notification(notification_job, "ok", result=result)
                     if removed:
                         logger.info(f"Deleted one-time job: {job.id}")
                 else:
@@ -747,7 +793,7 @@ class CronScheduler:
                         "任务执行完成"
                     )
                     await self._publish_progress(notification_job, "success", success_message, terminal=True)
-                    await self._publish_notification(notification_job, "ok")
+                    await self._publish_notification(notification_job, "ok", result=result)
                 else:
                     await self._publish_progress(
                         notification_job,

--- a/aworld/core/scheduler/scheduler.py
+++ b/aworld/core/scheduler/scheduler.py
@@ -519,7 +519,6 @@ class CronScheduler:
         self,
         job: CronJob,
         status: Literal["ok", "error", "timeout"],
-        error: Optional[str] = None,
         result: Optional[Any] = None,
     ):
         """
@@ -528,7 +527,6 @@ class CronScheduler:
         Args:
             job: Job that reached terminal state
             status: Terminal status (ok/error/timeout)
-            error: Optional error message (for persistence, not notification display)
 
         Note:
             Per design doc Section 8.4, notification summary uses fixed templates
@@ -645,7 +643,7 @@ class CronScheduler:
                         f"任务执行失败：{result.msg}",
                         terminal=True,
                     )
-                    await self._publish_notification(notification_job, "error", result.msg)
+                    await self._publish_notification(notification_job, "error")
 
             except asyncio.TimeoutError:
                 logger.error(f"Job {job.id} execution timeout")
@@ -689,7 +687,7 @@ class CronScheduler:
                 )
 
                 # Publish error notification
-                await self._publish_notification(job, "error", str(e))
+                await self._publish_notification(job, "error")
 
     # Public API
 
@@ -801,7 +799,7 @@ class CronScheduler:
                         f"任务执行失败：{result.msg}",
                         terminal=True,
                     )
-                    await self._publish_notification(notification_job, "error", result.msg)
+                    await self._publish_notification(notification_job, "error")
 
                 return result
 
@@ -851,7 +849,7 @@ class CronScheduler:
                 )
 
                 # Publish error notification for manual run
-                await self._publish_notification(job, "error", str(e))
+                await self._publish_notification(job, "error")
 
                 return TaskResponse(success=False, msg=f"Execution error: {str(e)}")
 

--- a/tests/core/scheduler/test_notifications.py
+++ b/tests/core/scheduler/test_notifications.py
@@ -216,6 +216,52 @@ async def test_scheduler_publishes_reminder_detail_on_success():
 
 
 @pytest.mark.asyncio
+async def test_scheduler_publishes_full_result_detail_for_deleted_one_time_job():
+    """One-time jobs should still publish full result detail even after deletion."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store_path = Path(tmpdir) / "cron.json"
+        store = FileBasedCronStore(str(store_path))
+
+        executor = AsyncMock(spec=CronExecutor)
+        executor.execute_with_retry = AsyncMock(
+            return_value=TaskResponse(
+                success=True,
+                msg="Task completed",
+                answer="已保存 200 条内容\n输出文件：twitter_for_you_posts_200.md\n日志：twitter_scraper_200.log",
+            )
+        )
+
+        notification_sink = AsyncMock()
+        scheduler = CronScheduler(store, executor, notification_sink=notification_sink)
+
+        now = datetime.now(pytz.UTC)
+        job = CronJob(
+            name="twitter_scraper_200_posts",
+            delete_after_run=True,
+            schedule=CronSchedule(kind="at", at=now.isoformat()),
+            payload=CronPayload(message="run scraper", tool_names=["bash"]),
+            state=CronJobState(
+                running=True,
+                last_run_at=now.isoformat(),
+                next_run_at=None,
+            ),
+        )
+
+        await store.add_job(job)
+        await scheduler._execute_claimed_job(job)
+
+        notification_sink.assert_called_once()
+        call_args = notification_sink.call_args[0][0]
+        assert call_args["status"] == "ok"
+        assert "最终回答：" in call_args["detail"]
+        assert "twitter_for_you_posts_200.md" in call_args["detail"]
+        assert await store.get_job(job.id) is None
+
+
+@pytest.mark.asyncio
 async def test_scheduler_publishes_live_progress_logs():
     """Scheduler should publish live execution progress for `/cron show` follow mode."""
     import tempfile

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -473,6 +473,36 @@ class TestCronCommand:
         assert runtime._notification_center.get_unread_count() == 0
 
     @pytest.mark.asyncio
+    async def test_cron_inbox_formats_multiline_result_detail(self):
+        """Multiline result detail should remain readable in inbox output."""
+        from aworld_cli.runtime.cron_notifications import CronNotificationCenter
+
+        cmd = CommandRegistry.get('cron')
+
+        class FakeRuntime:
+            def __init__(self):
+                self._notification_center = CronNotificationCenter()
+
+            async def _drain_notifications(self):
+                return await self._notification_center.drain()
+
+        runtime = FakeRuntime()
+        await runtime._notification_center.publish({
+            "job_id": "job-1",
+            "job_name": "twitter_scraper_200_posts",
+            "status": "ok",
+            "summary": 'Cron task "twitter_scraper_200_posts" completed',
+            "detail": "最终回答：\n已保存 200 条内容\n输出文件：twitter_for_you_posts_200.md",
+        })
+
+        context = CommandContext(cwd=os.getcwd(), user_args='inbox', runtime=runtime)
+        result = await cmd.execute(context)
+
+        assert "content: 最终回答：" in result
+        assert "已保存 200 条内容" in result
+        assert "输出文件：twitter_for_you_posts_200.md" in result
+
+    @pytest.mark.asyncio
     async def test_cron_inbox_reads_only_notifications_for_requested_job(self):
         """Test /cron inbox <job_id> drains only matching unread notifications."""
         from aworld_cli.runtime.cron_notifications import CronNotificationCenter


### PR DESCRIPTION
## Summary
- keep successful cron notifications rich enough to show final answers and key outputs in `/cron inbox`
- preserve result detail for one-time jobs even after the persisted job record is removed
- render multiline inbox detail cleanly so output files and final answer lines remain readable

## Testing
- PYTHONPATH=aworld-cli/src:. venv/bin/pytest tests/core/scheduler/test_notifications.py tests/test_slash_commands.py