### PR TITLE
Improve Happy ACP compatibility and browser-task completion

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/bootstrap.py
+++ b/aworld-cli/src/aworld_cli/acp/bootstrap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from aworld_cli.core.plugin_manager import PluginManager
+from aworld_cli.core.plugin_manager import PluginManager, get_builtin_agent_bundle_roots
 
 
 def bootstrap_acp_plugins(base_dir: Path) -> dict[str, Any]:
@@ -15,6 +15,10 @@ def bootstrap_acp_plugins(base_dir: Path) -> dict[str, Any]:
         runtime_plugin_roots = manager.get_runtime_plugin_roots()
     except Exception as exc:
         warnings.append(f"ACP plugin bootstrap degraded: {exc}")
+
+    # Include builtin agent bundles (e.g., smllc) which contain the actual agents
+    agent_bundle_roots = get_builtin_agent_bundle_roots()
+    runtime_plugin_roots.extend(agent_bundle_roots)
 
     return {
         "plugin_roots": runtime_plugin_roots,

--- a/aworld-cli/src/aworld_cli/acp/runtime_adapter.py
+++ b/aworld-cli/src/aworld_cli/acp/runtime_adapter.py
@@ -95,6 +95,9 @@ def adapt_output_to_runtime_events(
     events: list[dict[str, Any]] = []
 
     if output_type == "chunk":
+        reasoning = _extract_reasoning(output)
+        if reasoning:
+            events.append(normalize_thought_delta(state, reasoning))
         text = _extract_text(output)
         if text:
             state["saw_text_delta"] = True
@@ -117,7 +120,7 @@ def adapt_output_to_runtime_events(
             events.append(normalize_thought_delta(state, reasoning))
 
         text = _extract_text(output)
-        if text and not state.get("saw_text_delta"):
+        if text and not state.get("saw_text_delta") and _should_emit_message_text(output):
             events.append(normalize_final_text(state, text))
         return events
 
@@ -171,12 +174,38 @@ def _extract_reasoning(output: Any) -> str:
     if isinstance(reasoning, str) and reasoning:
         return reasoning
 
+    data = getattr(output, "data", None)
+    data_reasoning = getattr(data, "reasoning_content", None)
+    if isinstance(data_reasoning, str) and data_reasoning:
+        return data_reasoning
+
     source = getattr(output, "source", None)
     source_reasoning = getattr(source, "reasoning_content", None)
     if isinstance(source_reasoning, str) and source_reasoning:
         return source_reasoning
 
     return ""
+
+
+def _should_emit_message_text(output: Any) -> bool:
+    metadata = getattr(output, "metadata", None)
+    if not isinstance(metadata, dict):
+        return True
+
+    is_finished = metadata.get("is_finished")
+    if is_finished is True:
+        return True
+    if is_finished is False:
+        return False
+
+    sender = metadata.get("sender")
+    receiver = metadata.get("receiver")
+    # Legacy/self-test bridges emit direct MessageOutput objects without routing metadata.
+    # Routed runtime messages without an explicit completion marker are often intermediate
+    # observations that should not be surfaced as final ACP text.
+    if sender is not None or receiver is not None:
+        return False
+    return True
 
 
 def _extract_tool_calls(output: Any) -> list[Any]:

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -92,14 +92,10 @@ class AcpExecutorOutputBridge:
         try:
             agent = await self._resolve_agent()
             if agent is None:
-                yield MessageOutput(
-                    source=ModelResponse(
-                        id=f"acp-fallback-{record.acp_session_id}",
-                        model="aworld-cli/acp-fallback",
-                        content=prompt_text,
-                    )
+                raise ValueError(
+                    "No ACP-capable agent found. Ensure agent bundles are loaded. "
+                    "Set AWORLD_ACP_AGENT explicitly or check bootstrap configuration."
                 )
-                return
 
             executor, restore_sandbox_state = await self._create_executor(
                 agent=agent,

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import io
+import json
 import os
 import sys
 from pathlib import Path
@@ -394,7 +395,7 @@ class AcpStdioServer:
                         if isinstance(tool_name, str) and isinstance(tool_call_id, str):
                             state[f"tool_closed::{tool_name}"] = tool_call_id
                     update = map_runtime_event_to_session_update(session_id, event)
-                    await self._write_message(self._notification(self._session_update_method, update))
+                    await self._write_session_update(update)
 
         try:
             task = await self._turns.start_turn(session_id, _run_turn())
@@ -599,6 +600,62 @@ class AcpStdioServer:
             sys.stdout.buffer.write(payload)
             sys.stdout.buffer.flush()
 
+    async def _write_session_update(self, params: dict[str, Any]) -> None:
+        if self._session_update_method == "session/update":
+            params = self._to_current_session_update(params)
+        await self._write_message(self._notification(self._session_update_method, params))
+
+    @staticmethod
+    def _to_current_session_update(params: dict[str, Any]) -> dict[str, Any]:
+        converted = dict(params)
+        update = dict(converted.get("update") or {})
+        converted["update"] = update
+        update_type = update.get("sessionUpdate")
+
+        if update_type in {"agent_message_chunk", "agent_thought_chunk", "user_message_chunk"}:
+            content = update.get("content")
+            if isinstance(content, dict) and isinstance(content.get("text"), str) and "type" not in content:
+                update["content"] = {"type": "text", "text": content["text"]}
+            return converted
+
+        if update_type == "tool_call":
+            raw_input = update.get("content")
+            title = str(update.get("kind") or "tool")
+            update["title"] = title
+            update["kind"] = AcpStdioServer._current_tool_kind(update.get("kind"))
+            update["rawInput"] = raw_input
+            update["content"] = AcpStdioServer._current_tool_content(raw_input)
+            return converted
+
+        if update_type == "tool_call_update":
+            raw_output = update.get("content")
+            title = str(update.get("kind") or "tool")
+            update["title"] = title
+            update["kind"] = AcpStdioServer._current_tool_kind(update.get("kind"))
+            update["rawOutput"] = raw_output
+            update["content"] = AcpStdioServer._current_tool_content(raw_output)
+            return converted
+
+        return converted
+
+    @staticmethod
+    def _current_tool_kind(kind: Any) -> str:
+        if kind in {"read", "edit", "delete", "move", "search", "execute", "think", "fetch", "switch_mode", "other"}:
+            return str(kind)
+        if kind in {"shell", "terminal", "bash", "command"}:
+            return "execute"
+        return "other"
+
+    @staticmethod
+    def _current_tool_content(value: Any) -> list[dict[str, Any]] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            text = value
+        else:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return [{"type": "content", "content": {"type": "text", "text": text}}]
+
     @staticmethod
     def _normalize_runtime_events(state: dict[str, Any], output: Any) -> list[dict[str, Any]]:
         if isinstance(output, dict) and isinstance(output.get("event_type"), str):
@@ -652,7 +709,7 @@ class AcpStdioServer:
                     "raw_output": {"code": code, "message": message},
                 },
             )
-            await self._write_message(self._notification(self._session_update_method, update))
+            await self._write_session_update(update)
             state[f"tool_closed::{tool_name}"] = tool_call_id
         if isinstance(open_tool_calls, list):
             open_tool_calls.clear()

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -597,9 +597,19 @@ class AcpStdioServer:
             sys.stdout.buffer.flush()
 
     async def _write_session_update(self, params: dict[str, Any]) -> None:
+        if self._session_update_method == "session/update" and not self._should_emit_current_session_update(params):
+            return
         if self._session_update_method == "session/update":
             params = self._to_current_session_update(params)
         await self._write_message(self._notification(self._session_update_method, params))
+
+    @staticmethod
+    def _should_emit_current_session_update(params: dict[str, Any]) -> bool:
+        update = params.get("update")
+        if not isinstance(update, dict):
+            return True
+        update_type = update.get("sessionUpdate")
+        return update_type not in {"tool_call", "tool_call_update"}
 
     @staticmethod
     def _to_current_session_update(params: dict[str, Any]) -> dict[str, Any]:

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -491,35 +491,46 @@ class AcpStdioServer:
             if text:
                 return text
 
+        if isinstance(prompt, list):
+            text = self._normalize_content_blocks(prompt)
+            if text:
+                return text
+
         if isinstance(prompt, dict):
             if isinstance(prompt.get("text"), str) and prompt["text"].strip():
                 return prompt["text"].strip()
 
             content = prompt.get("content")
             if isinstance(content, list):
-                parts: list[str] = []
-                for block in content:
-                    if not isinstance(block, dict):
-                        continue
-                    if block.get("type") == "text" and isinstance(block.get("text"), str):
-                        text = block["text"].strip()
-                        if text:
-                            parts.append(text)
-                        continue
-
-                    resource_text = self._extract_embedded_resource_text(block)
-                    if resource_text:
-                        parts.append(resource_text)
-                        continue
-
-                    resource_link_text = self._format_resource_link_reference(block)
-                    if resource_link_text:
-                        parts.append(resource_link_text)
-
-                if parts:
-                    return "\n".join(parts)
+                text = self._normalize_content_blocks(content)
+                if text:
+                    return text
 
         raise ValueError(AWORLD_ACP_UNSUPPORTED_PROMPT_CONTENT)
+
+    def _normalize_content_blocks(self, content: list[Any]) -> str | None:
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                text = block["text"].strip()
+                if text:
+                    parts.append(text)
+                continue
+
+            resource_text = self._extract_embedded_resource_text(block)
+            if resource_text:
+                parts.append(resource_text)
+                continue
+
+            resource_link_text = self._format_resource_link_reference(block)
+            if resource_link_text:
+                parts.append(resource_link_text)
+
+        if parts:
+            return "\n".join(parts)
+        return None
 
     @staticmethod
     def _extract_embedded_resource_text(block: dict[str, Any]) -> str | None:

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -270,6 +270,7 @@ class AcpStdioServer:
         self._state_by_session: dict[str, dict[str, Any]] = {}
         self._write_lock = asyncio.Lock()
         self._output_bridge = output_bridge or AcpExecutorOutputBridge()
+        self._session_update_method = "sessionUpdate"
 
     async def run(self) -> int:
         pending_requests: set[asyncio.Task[Any]] = set()
@@ -297,6 +298,9 @@ class AcpStdioServer:
 
         try:
             if method == "initialize":
+                protocol_version = params.get("protocolVersion")
+                if isinstance(protocol_version, int) and protocol_version >= 1:
+                    self._session_update_method = "session/update"
                 response = self._response(
                     request_id,
                     {
@@ -305,11 +309,11 @@ class AcpStdioServer:
                         "agentCapabilities": {"loadSession": False},
                     },
                 )
-            elif method == "newSession":
+            elif method in ("newSession", "session/new"):
                 response = self._response(request_id, self._handle_new_session(params))
-            elif method == "prompt":
+            elif method in ("prompt", "session/prompt"):
                 response = await self._handle_prompt(request_id, params)
-            elif method == "cancel":
+            elif method in ("cancel", "session/cancel"):
                 response = await self._handle_cancel(request_id, params)
             else:
                 response = self._error(request_id, -32601, f"Unsupported method: {method}")
@@ -322,7 +326,8 @@ class AcpStdioServer:
                 data=build_error_data(detail) if detail is not None else None,
             )
 
-        await self._write_message(response)
+        if request_id is not None:
+            await self._write_message(response)
 
     def _handle_new_session(self, params: dict[str, Any]) -> dict[str, Any]:
         cwd = params.get("cwd")
@@ -389,7 +394,7 @@ class AcpStdioServer:
                         if isinstance(tool_name, str) and isinstance(tool_call_id, str):
                             state[f"tool_closed::{tool_name}"] = tool_call_id
                     update = map_runtime_event_to_session_update(session_id, event)
-                    await self._write_message(self._notification("sessionUpdate", update))
+                    await self._write_message(self._notification(self._session_update_method, update))
 
         try:
             task = await self._turns.start_turn(session_id, _run_turn())
@@ -636,7 +641,7 @@ class AcpStdioServer:
                     "raw_output": {"code": code, "message": message},
                 },
             )
-            await self._write_message(self._notification("sessionUpdate", update))
+            await self._write_message(self._notification(self._session_update_method, update))
             state[f"tool_closed::{tool_name}"] = tool_call_id
         if isinstance(open_tool_calls, list):
             open_tool_calls.clear()

--- a/aworld-cli/src/aworld_cli/builtin_agents/smllc/agents/prompt.txt
+++ b/aworld-cli/src/aworld_cli/builtin_agents/smllc/agents/prompt.txt
@@ -236,6 +236,14 @@ You are equipped with multiple assistants. It is your job to know which to use a
 - **Finite Repeating Reminders:** If the user wants a repeating reminder with a fixed total count, create a single cron task with a run limit and pass the raw request to `cron`; do not create a second stop task.
 - **Working Directory:** Always treat the working directory ({{ARTIFACT_DIRECTORY}}) as your working directory for all actions: run shell commands from it, and use it (or paths under it) for any temporary or output files when such operations are permitted (e.g. non-code tasks). You MUST NOT redirect work or temporary files to /tmp; Always use the working directory so outputs stay with the user's context.
 - **Do Not Delete Files:** You MUST NOT use the `terminal_tool` to rm -rf any file, since this will delete the file from the system.
+- **Browser Task Completion Policy:** Browser automation tasks must be treated as bounded investigations, not open-ended browsing.
+  - Before browsing deeply, define the immediate success target in your own reasoning: what page or evidence do you need to answer the user?
+  - Prefer the already-open page or currently visible content over reopening, relogging, or rescanning the same area.
+  - Do not loop on repeated full-page snapshots, waiting, or scrolling without producing a user-facing conclusion.
+  - For feeds, timelines, search results, and following/follower lists, the default scope is the currently visible items plus at most a small bounded extension unless the user explicitly asks for exhaustive coverage.
+  - Once you have enough evidence for a useful answer (for example 3-5 key findings, the visible top items, or the requested specific page), stop browsing and synthesize the answer immediately.
+  - If the page remains slow, unstable, or incomplete, return a partial answer based on what is already visible and clearly state the limitation instead of continuing indefinitely.
+  - If more browsing would help but is not strictly required, provide the best current answer first, then optionally continue only if the user asks for deeper coverage.
 - **Loop (Evaluation & Improvement Cycle):** 
   - **Default Behavior:** When the `developer` completes an apps/code/html/website, return the result directly to the user. Do NOT automatically invoke the `evaluator`.
   - **When to Enable Evaluation Loop:** ONLY when the user **EXPLICITLY** requests evaluation and improvement. Look for these explicit signals:

--- a/tests/acp/test_bootstrap.py
+++ b/tests/acp/test_bootstrap.py
@@ -14,16 +14,23 @@ from aworld_cli.acp.bootstrap import bootstrap_acp_plugins
 def test_bootstrap_acp_plugins_returns_runtime_plugin_roots(monkeypatch, tmp_path: Path) -> None:
     plugin_root = tmp_path / "plugin-alpha"
     plugin_root.mkdir()
+    agent_bundle_root = tmp_path / "agent-bundle"
+    (agent_bundle_root / "agents").mkdir(parents=True)
 
     class FakePluginManager:
         def get_runtime_plugin_roots(self):
             return [plugin_root]
 
     monkeypatch.setattr(bootstrap_module, "PluginManager", FakePluginManager)
+    monkeypatch.setattr(
+        bootstrap_module,
+        "get_builtin_agent_bundle_roots",
+        lambda: [agent_bundle_root],
+    )
 
     payload = bootstrap_acp_plugins(tmp_path)
 
-    assert payload["plugin_roots"] == [plugin_root]
+    assert payload["plugin_roots"] == [plugin_root, agent_bundle_root]
     assert payload["warnings"] == []
     assert payload["command_sync_enabled"] is False
     assert payload["interactive_refresh_enabled"] is False
@@ -31,15 +38,24 @@ def test_bootstrap_acp_plugins_returns_runtime_plugin_roots(monkeypatch, tmp_pat
 
 
 def test_bootstrap_acp_plugins_degrades_when_plugin_manager_fails(monkeypatch, tmp_path: Path) -> None:
+    agent_bundle_root = tmp_path / "agent-bundle"
+    (agent_bundle_root / "agents").mkdir(parents=True)
+
     class FakePluginManager:
         def get_runtime_plugin_roots(self):
             raise RuntimeError("plugin manager unavailable")
 
     monkeypatch.setattr(bootstrap_module, "PluginManager", FakePluginManager)
+    monkeypatch.setattr(
+        bootstrap_module,
+        "get_builtin_agent_bundle_roots",
+        lambda: [agent_bundle_root],
+    )
 
     payload = bootstrap_acp_plugins(tmp_path)
 
-    assert payload["plugin_roots"] == []
+    # Agent bundles still included even when PluginManager fails
+    assert payload["plugin_roots"] == [agent_bundle_root]
     assert payload["command_sync_enabled"] is False
     assert payload["interactive_refresh_enabled"] is False
     assert payload["base_dir"] == tmp_path

--- a/tests/acp/test_prompt_normalization.py
+++ b/tests/acp/test_prompt_normalization.py
@@ -12,6 +12,21 @@ from aworld_cli.acp.errors import AWORLD_ACP_UNSUPPORTED_PROMPT_CONTENT
 from aworld_cli.acp.server import AcpStdioServer
 
 
+def test_normalize_prompt_text_supports_current_acp_prompt_array() -> None:
+    server = AcpStdioServer()
+
+    prompt_text = server._normalize_prompt_text(
+        [
+            {
+                "type": "text",
+                "text": "hello from happy",
+            }
+        ]
+    )
+
+    assert prompt_text == "hello from happy"
+
+
 def test_normalize_prompt_text_supports_embedded_resource_text() -> None:
     server = AcpStdioServer()
 

--- a/tests/acp/test_runtime_adapter.py
+++ b/tests/acp/test_runtime_adapter.py
@@ -54,6 +54,26 @@ def test_chunk_output_maps_to_text_delta_event() -> None:
     assert events == [{"event_type": "text_delta", "seq": 1, "text": "hello"}]
 
 
+def test_chunk_output_reasoning_maps_to_thought_delta_before_text() -> None:
+    state: dict[str, object] = {}
+    output = ChunkOutput(
+        data=ModelResponse(
+            id="resp-1",
+            model="demo",
+            content="hello",
+            reasoning_content="need to search first",
+        ),
+        metadata={},
+    )
+
+    events = adapt_output_to_runtime_events(state, output)
+
+    assert events == [
+        {"event_type": "thought_delta", "seq": 1, "text": "need to search first"},
+        {"event_type": "text_delta", "seq": 2, "text": "hello"},
+    ]
+
+
 def test_message_output_tool_calls_become_tool_start_events() -> None:
     state: dict[str, object] = {}
     output = MessageOutput(
@@ -107,3 +127,47 @@ def test_message_output_final_text_is_suppressed_after_chunk_stream() -> None:
     events = adapt_output_to_runtime_events(state, output)
 
     assert events == []
+
+
+def test_message_output_reasoning_maps_to_thought_delta() -> None:
+    state: dict[str, object] = {}
+    output = MessageOutput(
+        source=ModelResponse(
+            id="resp-1",
+            model="demo",
+            content="final answer",
+            reasoning_content="plan before answer",
+        ),
+        metadata={"sender": "Aworld", "is_finished": True},
+    )
+
+    events = adapt_output_to_runtime_events(state, output)
+
+    assert events == [
+        {"event_type": "thought_delta", "seq": 1, "text": "plan before answer"},
+        {"event_type": "final_text", "seq": 2, "text": "final answer"},
+    ]
+
+
+def test_message_output_text_requires_completion_marker_for_routed_runtime_messages() -> None:
+    state: dict[str, object] = {}
+    output = MessageOutput(
+        source=ModelResponse(id="resp-1", model="demo", content="echoed prompt"),
+        metadata={"sender": "Aworld", "receiver": None},
+    )
+
+    events = adapt_output_to_runtime_events(state, output)
+
+    assert events == []
+
+
+def test_message_output_text_emits_when_routed_runtime_message_is_finished() -> None:
+    state: dict[str, object] = {}
+    output = MessageOutput(
+        source=ModelResponse(id="resp-1", model="demo", content="final answer"),
+        metadata={"sender": "Aworld", "receiver": None, "is_finished": True},
+    )
+
+    events = adapt_output_to_runtime_events(state, output)
+
+    assert events == [{"event_type": "final_text", "seq": 1, "text": "final answer"}]

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -1138,7 +1138,7 @@ async def test_executor_output_bridge_applies_and_restores_requested_mcp_servers
 
 
 @pytest.mark.asyncio
-async def test_executor_output_bridge_falls_back_to_message_output_when_no_agent_loaded() -> None:
+async def test_executor_output_bridge_raises_error_when_no_agent_loaded() -> None:
     class EmptyRegistry:
         @staticmethod
         def get_agent(_agent_id: str):
@@ -1160,14 +1160,11 @@ async def test_executor_output_bridge_falls_back_to_message_output_when_no_agent
         init_agents_func=lambda *_args, **_kwargs: None,
     )
 
-    outputs = [
-        output
-        async for output in bridge.stream_outputs(
-            record=record,
-            prompt_text="hello",
-        )
-    ]
-
-    assert len(outputs) == 1
-    assert isinstance(outputs[0], MessageOutput)
-    assert outputs[0].source.content == "hello"
+    with pytest.raises(ValueError, match="No ACP-capable agent found"):
+        _outputs = [
+            output
+            async for output in bridge.stream_outputs(
+                record=record,
+                prompt_text="hello",
+            )
+        ]

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -140,6 +140,168 @@ async def test_prompt_resets_turn_local_runtime_state_between_prompts() -> None:
 
 
 @pytest.mark.asyncio
+async def test_current_acp_protocol_suppresses_shell_tool_notifications() -> None:
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-1",
+                function=Function(name="shell", arguments='{"command":"pwd"}'),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-2",
+                    model="demo",
+                    content="final",
+                    reasoning_content="searching sources",
+                    tool_calls=[tool_call],
+                ),
+                metadata={"sender": "Aworld", "is_finished": True},
+            )
+            yield ToolResultOutput(
+                tool_name="shell",
+                data={"cwd": "/tmp"},
+                origin_tool_call=tool_call,
+            )
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    server._session_update_method = "session/update"
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        3,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "hello"}]},
+        },
+    )
+
+    notifications = [message for message in writes if message.get("method") == "session/update"]
+
+    assert response["result"]["status"] == "completed"
+    assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
+        "agent_thought_chunk",
+        "agent_message_chunk",
+    ]
+    assert notifications[0]["params"]["update"]["content"] == {"type": "text", "text": "searching sources"}
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+
+
+@pytest.mark.asyncio
+async def test_current_acp_protocol_suppresses_other_tool_notifications() -> None:
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-1",
+                function=Function(
+                    name="async_spawn_subagent__spawn",
+                    arguments='{"items":[{"type":"content","content":{"type":"text","text":"search deepseek v4"}},{"type":"text","text":"web_searcher"}]}',
+                ),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-2",
+                    model="demo",
+                    content="final",
+                    reasoning_content="我先尝试搜索一下最新信息",
+                    tool_calls=[tool_call],
+                ),
+                metadata={"sender": "Aworld", "is_finished": True},
+            )
+            yield ToolResultOutput(
+                tool_name="async_spawn_subagent__spawn",
+                data={"error": "subagent unavailable"},
+                origin_tool_call=tool_call,
+            )
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    server._session_update_method = "session/update"
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        4,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "hello"}]},
+        },
+    )
+
+    notifications = [message for message in writes if message.get("method") == "session/update"]
+
+    assert response["result"]["status"] == "completed"
+    assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
+        "agent_thought_chunk",
+        "agent_message_chunk",
+    ]
+    assert notifications[0]["params"]["update"]["content"] == {"type": "text", "text": "我先尝试搜索一下最新信息"}
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+
+
+@pytest.mark.asyncio
+async def test_current_acp_protocol_suppresses_execute_tool_notifications() -> None:
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-1",
+                function=Function(name="execute", arguments='{"command":"curl https://x.com"}'),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-2",
+                    model="demo",
+                    content="final",
+                    reasoning_content="我先检查一下页面",
+                    tool_calls=[tool_call],
+                ),
+                metadata={"sender": "Aworld", "is_finished": True},
+            )
+            yield ToolResultOutput(
+                tool_name="execute",
+                data={"stdout": "ok"},
+                origin_tool_call=tool_call,
+            )
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    server._session_update_method = "session/update"
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        5,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "hello"}]},
+        },
+    )
+
+    notifications = [message for message in writes if message.get("method") == "session/update"]
+
+    assert response["result"]["status"] == "completed"
+    assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
+        "agent_thought_chunk",
+        "agent_message_chunk",
+    ]
+    assert notifications[0]["params"]["update"]["content"] == {"type": "text", "text": "我先检查一下页面"}
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+
+
+@pytest.mark.asyncio
 async def test_prompt_rejects_unsupported_prompt_content_with_structured_error() -> None:
     server = AcpStdioServer(output_bridge=object())
     session = server._handle_new_session({"cwd": ".", "mcpServers": []})

--- a/tests/acp/test_server_stdio.py
+++ b/tests/acp/test_server_stdio.py
@@ -168,6 +168,62 @@ def test_acp_server_new_session_and_prompt_emit_session_update() -> None:
         proc.wait(timeout=5)
 
 
+def test_acp_server_accepts_current_acp_session_methods() -> None:
+    proc = _spawn_acp_server()
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": 1,
+                        "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False}},
+                        "clientInfo": {"name": "happy-cli", "version": "test"},
+                    },
+                }
+            )
+            + "\n"
+        )
+        proc.stdin.write('{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":".","mcpServers":[]}}\n')
+        proc.stdin.flush()
+
+        _ = _read_json_line(proc)
+        new_session = _read_json_line(proc)
+        session_id = new_session["result"]["sessionId"]
+
+        proc.stdin.write(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": session_id,
+                        "prompt": {"content": [{"type": "text", "text": "hello"}]},
+                    },
+                }
+            )
+            + "\n"
+        )
+        proc.stdin.flush()
+
+        notification = _read_json_line(proc)
+        response = _read_json_line(proc)
+
+        assert notification["method"] == "session/update"
+        assert notification["params"]["sessionId"] == session_id
+        assert notification["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+        assert response["id"] == 3
+        assert response["result"]["status"] == "completed"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
 def test_acp_server_cancel_missing_session_returns_error() -> None:
     proc = _spawn_acp_server()
     try:

--- a/tests/acp/test_server_stdio.py
+++ b/tests/acp/test_server_stdio.py
@@ -21,6 +21,7 @@ SELF_TEST_SLOW_PROMPT = "__acp_self_test_slow__"
 def _spawn_acp_server() -> subprocess.Popen[str]:
     env = dict(os.environ)
     env.update(ENV)
+    env["AWORLD_ACP_SELF_TEST_BRIDGE"] = "1"
     return subprocess.Popen(
         [sys.executable, "-m", "aworld_cli.main", "--no-banner", "acp"],
         stdin=subprocess.PIPE,

--- a/tests/acp/test_server_stdio.py
+++ b/tests/acp/test_server_stdio.py
@@ -216,6 +216,7 @@ def test_acp_server_accepts_current_acp_session_methods() -> None:
         assert notification["method"] == "session/update"
         assert notification["params"]["sessionId"] == session_id
         assert notification["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+        assert notification["params"]["update"]["content"] == {"type": "text", "text": "hello"}
         assert response["id"] == 3
         assert response["result"]["status"] == "completed"
     finally:


### PR DESCRIPTION
## Summary

- support current Happy ACP session method names and prompt payloads
- emit current ACP-compatible session update payloads
- replace fallback prompt echo with explicit runtime error
- suppress ACP tool-event cards for current Happy clients so Happy shows thinking/final answer instead of raw tool JSON
- improve browser-task completion behavior to avoid over-browsing and timeout-prone loops

## Included fixes

- Support current ACP methods:
  - `session/new`
  - `session/prompt`
  - `session/cancel`
- Accept current ACP prompt content arrays
- Emit current ACP `session/update` payloads
- Fix ACP agent discovery to include builtin agent bundles
- Replace ACP fallback echo with explicit error
- Filter current Happy client tool-call / tool-call-update events from ACP output
- Add browser task completion guidance for bounded investigation and earlier synthesis
- Extend Happy-side ACP turn timeout handling support through the related integration changes already validated locally

## Validation

- `conda run -n aworld_env aworld-cli acp self-test`
- passed `13/13`

## Commits

- `82e4f5d6` Support current ACP session methods
- `a7d6a47a` Accept ACP prompt content arrays
- `6ad90a39` Emit current ACP session update payloads
- `2656cf16` Fix ACP agent discovery to include builtin agent bundles
- `e91c468b` Replace ACP fallback echo with explicit error
- `60758584` fix acp output
- `62a83e39` Hide ACP tool events for current Happy clients
- `abcb4ae2` fix browser task timeout