### PR TITLE
feat: bridge cron notifications from ACP sessions

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/cron_bridge.py
+++ b/aworld-cli/src/aworld_cli/acp/cron_bridge.py
@@ -33,6 +33,7 @@ class AcpCronBridge:
         session_id: str,
         tool_name: str | None,
         payload: Any,
+        tool_input: Any = None,
     ) -> None:
         if not session_id or session_id not in self._session_ids:
             return
@@ -41,7 +42,11 @@ class AcpCronBridge:
         if not isinstance(payload, dict) or payload.get("success") is not True:
             return
 
-        for job_id in self._extract_job_ids(payload):
+        job_ids = self._extract_job_ids(payload)
+        if not job_ids:
+            job_ids = self._extract_job_ids_from_tool_input(tool_input, payload)
+
+        for job_id in job_ids:
             self._job_bindings[job_id] = session_id
 
     async def publish_notification(self, notification_data: dict[str, Any]) -> None:
@@ -111,6 +116,21 @@ class AcpCronBridge:
                 job_ids.append(advance_job_id.strip())
 
         return job_ids
+
+    @staticmethod
+    def _extract_job_ids_from_tool_input(tool_input: Any, payload: dict[str, Any]) -> list[str]:
+        if not isinstance(tool_input, dict):
+            return []
+
+        action = tool_input.get("action")
+        if action != "run":
+            return []
+
+        job_id = tool_input.get("job_id")
+        if isinstance(job_id, str) and job_id.strip():
+            return [job_id.strip()]
+
+        return []
 
     @staticmethod
     def _render_notification_text(notification_data: dict[str, Any]) -> str:

--- a/aworld-cli/src/aworld_cli/acp/cron_bridge.py
+++ b/aworld-cli/src/aworld_cli/acp/cron_bridge.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from aworld.logs.util import logger
+
+
+class AcpCronBridge:
+    """ACP-local bridge from cron terminal notifications to session updates."""
+
+    def __init__(
+        self,
+        *,
+        write_session_update: Callable[[str, dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        self._write_session_update = write_session_update
+        self._session_ids: set[str] = set()
+        self._job_bindings: dict[str, str] = {}
+
+    def register_session(self, session_id: str) -> None:
+        if session_id:
+            self._session_ids.add(session_id)
+
+    def unregister_session(self, session_id: str) -> None:
+        self._session_ids.discard(session_id)
+        bound_job_ids = [job_id for job_id, bound_session_id in self._job_bindings.items() if bound_session_id == session_id]
+        for job_id in bound_job_ids:
+            self._job_bindings.pop(job_id, None)
+
+    def bind_from_tool_result(
+        self,
+        *,
+        session_id: str,
+        tool_name: str | None,
+        payload: Any,
+    ) -> None:
+        if not session_id or session_id not in self._session_ids:
+            return
+        if not self._is_cron_tool(tool_name):
+            return
+        if not isinstance(payload, dict) or payload.get("success") is not True:
+            return
+
+        for job_id in self._extract_job_ids(payload):
+            self._job_bindings[job_id] = session_id
+
+    async def publish_notification(self, notification_data: dict[str, Any]) -> None:
+        job_id = str(notification_data.get("job_id") or "").strip()
+        if not job_id:
+            return
+
+        session_id = self._job_bindings.get(job_id)
+        if not session_id or session_id not in self._session_ids:
+            if notification_data.get("next_run_at") is None:
+                self._job_bindings.pop(job_id, None)
+            return
+
+        if notification_data.get("user_visible") is False:
+            if notification_data.get("next_run_at") is None:
+                self._job_bindings.pop(job_id, None)
+            return
+
+        text = self._render_notification_text(notification_data)
+        if not text:
+            if notification_data.get("next_run_at") is None:
+                self._job_bindings.pop(job_id, None)
+            return
+
+        update = {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {
+                "text": text,
+                "cron": {
+                    "jobId": job_id,
+                    "jobName": notification_data.get("job_name"),
+                    "status": notification_data.get("status"),
+                    "createdAt": notification_data.get("created_at"),
+                    "nextRunAt": notification_data.get("next_run_at"),
+                    "source": "cron_notification",
+                },
+            },
+        }
+
+        try:
+            await self._write_session_update(session_id, update)
+        except Exception as exc:
+            logger.warning(f"Failed to push ACP cron notification for job {job_id}: {exc}")
+        finally:
+            if notification_data.get("next_run_at") is None:
+                self._job_bindings.pop(job_id, None)
+
+    @staticmethod
+    def _is_cron_tool(tool_name: str | None) -> bool:
+        if not isinstance(tool_name, str):
+            return False
+        normalized = tool_name.strip().lower()
+        return normalized == "cron" or normalized.startswith("cron__")
+
+    @staticmethod
+    def _extract_job_ids(payload: dict[str, Any]) -> list[str]:
+        job_ids: list[str] = []
+
+        primary = payload.get("job_id")
+        if isinstance(primary, str) and primary.strip():
+            job_ids.append(primary.strip())
+
+        advance = payload.get("advance_reminder")
+        if isinstance(advance, dict):
+            advance_job_id = advance.get("job_id")
+            if isinstance(advance_job_id, str) and advance_job_id.strip():
+                job_ids.append(advance_job_id.strip())
+
+        return job_ids
+
+    @staticmethod
+    def _render_notification_text(notification_data: dict[str, Any]) -> str:
+        summary = str(notification_data.get("summary") or "").strip()
+        detail = notification_data.get("detail")
+        detail_text = str(detail).strip() if detail is not None else ""
+
+        if summary and detail_text:
+            return f"{summary}\n{detail_text}"
+        if summary:
+            return summary
+        return detail_text

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -9,12 +9,14 @@ from pathlib import Path
 from typing import Any
 
 from rich.console import Console
+from aworld.logs.util import logger
 
 from aworld.models.model_response import ModelResponse
 from aworld.output.base import MessageOutput
 from aworld.runner import Runners
 
 from .bootstrap import bootstrap_acp_plugins
+from .cron_bridge import AcpCronBridge
 from .errors import (
     AWORLD_ACP_APPROVAL_UNSUPPORTED,
     AWORLD_ACP_INVALID_CWD,
@@ -270,6 +272,11 @@ class AcpStdioServer:
         self._state_by_session: dict[str, dict[str, Any]] = {}
         self._write_lock = asyncio.Lock()
         self._output_bridge = output_bridge or AcpExecutorOutputBridge()
+        self._cron_runtime_lock = asyncio.Lock()
+        self._cron_runtime_started = False
+        self._notification_center = None
+        self._scheduler = None
+        self._cron_bridge = AcpCronBridge(write_session_update=self._write_session_update)
 
     async def run(self) -> int:
         pending_requests: set[asyncio.Task[Any]] = set()
@@ -334,6 +341,7 @@ class AcpStdioServer:
             requested_mcp_servers=params.get("mcpServers") or [],
         )
         self._state_by_session[record.acp_session_id] = {}
+        self._cron_bridge.register_session(record.acp_session_id)
         return {"sessionId": record.acp_session_id}
 
     async def _handle_prompt(self, request_id: Any, params: dict[str, Any]) -> dict[str, Any]:
@@ -363,6 +371,8 @@ class AcpStdioServer:
                 data=build_error_data(detail) if detail is not None else None,
             )
 
+        await self._ensure_cron_runtime_started()
+
         state: dict[str, Any] = {}
         terminal_error: dict[str, Any] | None = None
 
@@ -388,6 +398,11 @@ class AcpStdioServer:
                         tool_call_id = event.get("tool_call_id")
                         if isinstance(tool_name, str) and isinstance(tool_call_id, str):
                             state[f"tool_closed::{tool_name}"] = tool_call_id
+                        self._cron_bridge.bind_from_tool_result(
+                            session_id=session_id,
+                            tool_name=tool_name if isinstance(tool_name, str) else None,
+                            payload=event.get("raw_output"),
+                        )
                     update = map_runtime_event_to_session_update(session_id, event)
                     await self._write_message(self._notification("sessionUpdate", update))
 
@@ -582,6 +597,47 @@ class AcpStdioServer:
         async with self._write_lock:
             sys.stdout.buffer.write(payload)
             sys.stdout.buffer.flush()
+
+    async def _write_session_update(self, session_id: str, update: dict[str, Any]) -> None:
+        await self._write_message(
+            self._notification(
+                "sessionUpdate",
+                {
+                    "sessionId": session_id,
+                    "update": update,
+                },
+            )
+        )
+
+    async def _ensure_cron_runtime_started(self) -> None:
+        if self._cron_runtime_started:
+            return
+
+        async with self._cron_runtime_lock:
+            if self._cron_runtime_started:
+                return
+
+            try:
+                from aworld.core.scheduler import get_scheduler
+                from aworld_cli.runtime.cron_notifications import CronNotificationCenter
+
+                self._notification_center = CronNotificationCenter()
+                self._scheduler = get_scheduler()
+
+                async def _notification_sink(notification_data: dict[str, Any]) -> None:
+                    if self._notification_center is not None:
+                        await self._notification_center.publish(notification_data)
+                    await self._cron_bridge.publish_notification(notification_data)
+
+                self._scheduler.notification_sink = _notification_sink
+                self._scheduler.progress_sink = self._notification_center.publish_progress
+
+                if not getattr(self._scheduler, "running", False):
+                    await self._scheduler.start()
+
+                self._cron_runtime_started = True
+            except Exception as exc:
+                logger.warning(f"Failed to bootstrap ACP cron runtime: {exc}")
 
     @staticmethod
     def _normalize_runtime_events(state: dict[str, Any], output: Any) -> list[dict[str, Any]]:

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -280,22 +280,25 @@ class AcpStdioServer:
 
     async def run(self) -> int:
         pending_requests: set[asyncio.Task[Any]] = set()
-        while True:
-            line = await asyncio.to_thread(sys.stdin.buffer.readline)
-            if not line:
-                break
+        try:
+            while True:
+                line = await asyncio.to_thread(sys.stdin.buffer.readline)
+                if not line:
+                    break
 
-            request = decode_jsonrpc_line(line)
-            if "method" not in request:
-                continue
+                request = decode_jsonrpc_line(line)
+                if "method" not in request:
+                    continue
 
-            task = asyncio.create_task(self._dispatch_request(request))
-            pending_requests.add(task)
-            task.add_done_callback(pending_requests.discard)
+                task = asyncio.create_task(self._dispatch_request(request))
+                pending_requests.add(task)
+                task.add_done_callback(pending_requests.discard)
 
-        if pending_requests:
-            await asyncio.gather(*pending_requests, return_exceptions=True)
-        return 0
+            if pending_requests:
+                await asyncio.gather(*pending_requests, return_exceptions=True)
+            return 0
+        finally:
+            await self._shutdown()
 
     async def _dispatch_request(self, request: dict[str, Any]) -> None:
         method = request["method"]
@@ -393,6 +396,10 @@ class AcpStdioServer:
                             message=str(event["message"]),
                         )
                         return
+                    if event.get("event_type") == "tool_start":
+                        tool_call_id = event.get("tool_call_id")
+                        if isinstance(tool_call_id, str):
+                            state[f"tool_input::{tool_call_id}"] = event.get("raw_input")
                     if event.get("event_type") == "tool_end":
                         tool_name = event.get("tool_name")
                         tool_call_id = event.get("tool_call_id")
@@ -402,6 +409,7 @@ class AcpStdioServer:
                             session_id=session_id,
                             tool_name=tool_name if isinstance(tool_name, str) else None,
                             payload=event.get("raw_output"),
+                            tool_input=state.get(f"tool_input::{tool_call_id}") if isinstance(tool_call_id, str) else None,
                         )
                     update = map_runtime_event_to_session_update(session_id, event)
                     await self._write_message(self._notification("sessionUpdate", update))
@@ -638,6 +646,29 @@ class AcpStdioServer:
                 self._cron_runtime_started = True
             except Exception as exc:
                 logger.warning(f"Failed to bootstrap ACP cron runtime: {exc}")
+
+    async def _shutdown(self) -> None:
+        session_ids = list(self._state_by_session.keys())
+        for session_id in session_ids:
+            self._cron_bridge.unregister_session(session_id)
+
+        scheduler = self._scheduler
+        self._state_by_session.clear()
+        self._cron_runtime_started = False
+        self._scheduler = None
+        self._notification_center = None
+
+        if scheduler is None:
+            return
+
+        stop = getattr(scheduler, "stop", None)
+        if callable(stop) and getattr(scheduler, "running", False):
+            try:
+                stop_result = stop()
+                if asyncio.iscoroutine(stop_result):
+                    await stop_result
+            except Exception as exc:
+                logger.warning(f"Failed to stop ACP cron runtime: {exc}")
 
     @staticmethod
     def _normalize_runtime_events(state: dict[str, Any], output: Any) -> list[dict[str, Any]]:

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -277,6 +277,10 @@ class AcpStdioServer:
         self._notification_center = None
         self._scheduler = None
         self._cron_bridge = AcpCronBridge(write_session_update=self._write_session_update)
+        self._previous_notification_sink = None
+        self._previous_progress_sink = None
+        self._installed_notification_sink = None
+        self._installed_progress_sink = None
 
     async def run(self) -> int:
         pending_requests: set[asyncio.Task[Any]] = set()
@@ -631,14 +635,32 @@ class AcpStdioServer:
 
                 self._notification_center = CronNotificationCenter()
                 self._scheduler = get_scheduler()
+                self._previous_notification_sink = getattr(self._scheduler, "notification_sink", None)
+                self._previous_progress_sink = getattr(self._scheduler, "progress_sink", None)
 
                 async def _notification_sink(notification_data: dict[str, Any]) -> None:
+                    previous_sink = self._previous_notification_sink
+                    if previous_sink is not None:
+                        previous_result = previous_sink(notification_data)
+                        if asyncio.iscoroutine(previous_result):
+                            await previous_result
                     if self._notification_center is not None:
                         await self._notification_center.publish(notification_data)
                     await self._cron_bridge.publish_notification(notification_data)
 
+                async def _progress_sink(progress_data: dict[str, Any]) -> None:
+                    previous_sink = self._previous_progress_sink
+                    if previous_sink is not None:
+                        previous_result = previous_sink(progress_data)
+                        if asyncio.iscoroutine(previous_result):
+                            await previous_result
+                    if self._notification_center is not None:
+                        await self._notification_center.publish_progress(progress_data)
+
+                self._installed_notification_sink = _notification_sink
+                self._installed_progress_sink = _progress_sink
                 self._scheduler.notification_sink = _notification_sink
-                self._scheduler.progress_sink = self._notification_center.publish_progress
+                self._scheduler.progress_sink = _progress_sink
 
                 if not getattr(self._scheduler, "running", False):
                     await self._scheduler.start()
@@ -653,13 +675,26 @@ class AcpStdioServer:
             self._cron_bridge.unregister_session(session_id)
 
         scheduler = self._scheduler
+        previous_notification_sink = self._previous_notification_sink
+        previous_progress_sink = self._previous_progress_sink
+        installed_notification_sink = self._installed_notification_sink
+        installed_progress_sink = self._installed_progress_sink
         self._state_by_session.clear()
         self._cron_runtime_started = False
         self._scheduler = None
         self._notification_center = None
+        self._previous_notification_sink = None
+        self._previous_progress_sink = None
+        self._installed_notification_sink = None
+        self._installed_progress_sink = None
 
         if scheduler is None:
             return
+
+        if getattr(scheduler, "notification_sink", None) is installed_notification_sink:
+            scheduler.notification_sink = previous_notification_sink
+        if getattr(scheduler, "progress_sink", None) is installed_progress_sink:
+            scheduler.progress_sink = previous_progress_sink
 
         stop = getattr(scheduler, "stop", None)
         if callable(stop) and getattr(scheduler, "running", False):

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -134,6 +134,98 @@ async def test_prompt_bootstraps_cron_runtime_once(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_acp_cron_runtime_fanouts_to_existing_notification_sink_and_restores_on_shutdown(monkeypatch) -> None:
+    previous_notifications: list[dict] = []
+
+    async def previous_sink(notification: dict) -> None:
+        previous_notifications.append(notification)
+
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.start_calls = 0
+            self.stop_calls = 0
+            self.running = False
+            self.notification_sink = previous_sink
+            self.progress_sink = None
+
+        async def start(self) -> None:
+            self.start_calls += 1
+            self.running = True
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.running = False
+
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-cron-1",
+                function=Function(
+                    name="cron",
+                    arguments='{"action":"add","request":"一分钟后提醒我喝水"}',
+                ),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-tool-start",
+                    model="demo",
+                    content="",
+                    tool_calls=[tool_call],
+                )
+            )
+            yield ToolResultOutput(
+                tool_name="cron",
+                data={"success": True, "job_id": "job-main"},
+                origin_tool_call=tool_call,
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        2,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "bind cron"}]},
+        },
+    )
+
+    assert response["result"]["status"] == "completed"
+    writes.clear()
+
+    await fake_scheduler.notification_sink(  # type: ignore[misc]
+        {
+            "job_id": "job-main",
+            "job_name": "喝水提醒",
+            "status": "ok",
+            "summary": 'Cron task "喝水提醒" completed',
+            "detail": "提醒我喝水",
+            "created_at": "2026-04-27T00:00:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert len(previous_notifications) == 1
+    assert len(notifications) == 1
+    assert notifications[0]["params"]["sessionId"] == session["sessionId"]
+
+    await server._shutdown()
+    assert fake_scheduler.notification_sink is previous_sink
+    assert fake_scheduler.stop_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_bound_cron_notification_is_pushed_only_to_own_session(monkeypatch) -> None:
     class FakeScheduler:
         def __init__(self) -> None:

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -87,6 +87,233 @@ async def test_prompt_streams_executor_outputs_through_adapter_and_mapper() -> N
 
 
 @pytest.mark.asyncio
+async def test_prompt_bootstraps_cron_runtime_once(monkeypatch) -> None:
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.start_calls = 0
+            self.running = False
+            self.notification_sink = None
+            self.progress_sink = None
+
+        async def start(self) -> None:
+            self.start_calls += 1
+            self.running = True
+
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            yield MessageOutput(
+                source=ModelResponse(id="resp-1", model="demo", content="ok"),
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    first = await server._handle_prompt(
+        1,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "first"}]},
+        },
+    )
+    second = await server._handle_prompt(
+        2,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "second"}]},
+        },
+    )
+
+    assert first["result"]["status"] == "completed"
+    assert second["result"]["status"] == "completed"
+    assert fake_scheduler.start_calls == 1
+    assert fake_scheduler.notification_sink is not None
+    assert fake_scheduler.progress_sink is not None
+
+
+@pytest.mark.asyncio
+async def test_bound_cron_notification_is_pushed_only_to_own_session(monkeypatch) -> None:
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.running = False
+            self.notification_sink = None
+            self.progress_sink = None
+
+        async def start(self) -> None:
+            self.running = True
+
+    class FakeOutputBridge:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def stream_outputs(self, *, record, prompt_text):
+            self.calls += 1
+            if self.calls == 1:
+                tool_call = ToolCall(
+                    id="call-cron-1",
+                    function=Function(
+                        name="cron",
+                        arguments='{"action":"add","request":"一分钟后提醒我喝水"}',
+                    ),
+                )
+                yield MessageOutput(
+                    source=ModelResponse(
+                        id="resp-tool-start",
+                        model="demo",
+                        content="",
+                        tool_calls=[tool_call],
+                    )
+                )
+                yield ToolResultOutput(
+                    tool_name="cron",
+                    data={
+                        "success": True,
+                        "job_id": "job-main",
+                        "advance_reminder": {"job_id": "job-advance"},
+                    },
+                    origin_tool_call=tool_call,
+                )
+                return
+
+            yield MessageOutput(
+                source=ModelResponse(id=f"resp-{self.calls}", model="demo", content="noop"),
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session_one = server._handle_new_session({"cwd": ".", "mcpServers": []})
+    session_two = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        3,
+        {
+            "sessionId": session_one["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "bind cron"}]},
+        },
+    )
+
+    assert response["result"]["status"] == "completed"
+    writes.clear()
+
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-main",
+            "job_name": "喝水提醒",
+            "status": "ok",
+            "summary": 'Cron task "喝水提醒" completed',
+            "detail": "提醒我喝水",
+            "created_at": "2026-04-26T00:00:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+
+    assert len(notifications) == 1
+    assert notifications[0]["params"]["sessionId"] == session_one["sessionId"]
+    assert notifications[0]["params"]["sessionId"] != session_two["sessionId"]
+    assert notifications[0]["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+    assert notifications[0]["params"]["update"]["content"]["text"] == 'Cron task "喝水提醒" completed\n提醒我喝水'
+
+
+@pytest.mark.asyncio
+async def test_silent_terminal_cron_notification_clears_binding_without_visible_push(monkeypatch) -> None:
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.running = False
+            self.notification_sink = None
+            self.progress_sink = None
+
+        async def start(self) -> None:
+            self.running = True
+
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-cron-1",
+                function=Function(
+                    name="cron",
+                    arguments='{"action":"add","request":"一分钟后提醒我喝水"}',
+                ),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-tool-start",
+                    model="demo",
+                    content="",
+                    tool_calls=[tool_call],
+                )
+            )
+            yield ToolResultOutput(
+                tool_name="cron",
+                data={"success": True, "job_id": "job-main"},
+                origin_tool_call=tool_call,
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        4,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "bind cron"}]},
+        },
+    )
+
+    assert response["result"]["status"] == "completed"
+    writes.clear()
+
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-main",
+            "job_name": "silent recurring job",
+            "status": "ok",
+            "summary": 'Cron task "silent recurring job" completed',
+            "detail": "本次静默结束，仅用于清理绑定",
+            "created_at": "2026-04-26T00:00:00+00:00",
+            "next_run_at": None,
+            "user_visible": False,
+        }
+    )
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-main",
+            "job_name": "silent recurring job",
+            "status": "ok",
+            "summary": 'Cron task "silent recurring job" completed',
+            "detail": "should not deliver after cleanup",
+            "created_at": "2026-04-26T00:00:01+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert notifications == []
+
+
+@pytest.mark.asyncio
 async def test_prompt_resets_turn_local_runtime_state_between_prompts() -> None:
     class FakeOutputBridge:
         def __init__(self) -> None:

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -314,6 +314,167 @@ async def test_silent_terminal_cron_notification_clears_binding_without_visible_
 
 
 @pytest.mark.asyncio
+async def test_cron_run_success_rebinds_existing_job_id_to_current_session(monkeypatch) -> None:
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.running = False
+            self.notification_sink = None
+            self.progress_sink = None
+
+        async def start(self) -> None:
+            self.running = True
+
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-cron-run-1",
+                function=Function(
+                    name="cron",
+                    arguments='{"action":"run","job_id":"job-existing"}',
+                ),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-tool-start",
+                    model="demo",
+                    content="",
+                    tool_calls=[tool_call],
+                )
+            )
+            yield ToolResultOutput(
+                tool_name="cron",
+                data={"success": True, "message": "Job executed"},
+                origin_tool_call=tool_call,
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        5,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "run existing cron"}]},
+        },
+    )
+
+    assert response["result"]["status"] == "completed"
+    writes.clear()
+
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-existing",
+            "job_name": "existing job",
+            "status": "ok",
+            "summary": 'Cron task "existing job" completed',
+            "detail": "rebound to current session",
+            "created_at": "2026-04-27T00:00:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert len(notifications) == 1
+    assert notifications[0]["params"]["sessionId"] == session["sessionId"]
+    assert notifications[0]["params"]["update"]["content"]["text"] == 'Cron task "existing job" completed\nrebound to current session'
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_cron_runtime_and_unregisters_sessions(monkeypatch) -> None:
+    class FakeScheduler:
+        def __init__(self) -> None:
+            self.running = False
+            self.notification_sink = None
+            self.progress_sink = None
+            self.start_calls = 0
+            self.stop_calls = 0
+
+        async def start(self) -> None:
+            self.start_calls += 1
+            self.running = True
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.running = False
+
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-cron-1",
+                function=Function(
+                    name="cron",
+                    arguments='{"action":"add","request":"一分钟后提醒我喝水"}',
+                ),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-tool-start",
+                    model="demo",
+                    content="",
+                    tool_calls=[tool_call],
+                )
+            )
+            yield ToolResultOutput(
+                tool_name="cron",
+                data={"success": True, "job_id": "job-main"},
+                origin_tool_call=tool_call,
+            )
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        6,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "bind before shutdown"}]},
+        },
+    )
+
+    assert response["result"]["status"] == "completed"
+    assert fake_scheduler.start_calls == 1
+
+    await server._shutdown()
+    assert fake_scheduler.stop_calls == 1
+
+    writes.clear()
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-main",
+            "job_name": "job after shutdown",
+            "status": "ok",
+            "summary": 'Cron task "job after shutdown" completed',
+            "detail": "must not emit after unregister",
+            "created_at": "2026-04-27T00:00:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert notifications == []
+
+
+@pytest.mark.asyncio
 async def test_prompt_resets_turn_local_runtime_state_between_prompts() -> None:
     class FakeOutputBridge:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- add an ACP-local cron bridge so cron jobs created or run through ACP can push terminal notifications back to the bound session
- bootstrap cron runtime in ACP mode, preserve local inbox behavior, and rebind `cron run <job_id>` to the current ACP session
- preserve DingTalk's existing cron notification fanout by chaining existing scheduler sinks instead of overwriting them

## Test Plan
- `python -m pytest tests/acp/test_server_runtime_wiring.py -q`
- `python -m pytest tests/gateway/test_dingding_connector.py -q -k "cron or bootstraps_cron_scheduler"`
- `python -m pytest tests/gateway/test_dingding_cron_bindings.py -q`
