### PR TITLE
feat(gateway): add wechat and wecom channels

### DIFF
--- a/aworld_gateway/channels/wechat/__init__.py
+++ b/aworld_gateway/channels/wechat/__init__.py
@@ -1,0 +1,3 @@
+from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+__all__ = ["WechatChannelAdapter"]

--- a/aworld_gateway/channels/wechat/account_store.py
+++ b/aworld_gateway/channels/wechat/account_store.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _account_file(root: Path, account_id: str) -> Path:
+    return root / f"{account_id}.json"
+
+
+def save_account(
+    root: Path,
+    *,
+    account_id: str,
+    token: str,
+    base_url: str,
+    user_id: str = "",
+) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "token": token,
+        "base_url": base_url,
+        "user_id": user_id,
+    }
+    path = _account_file(root, account_id)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def load_account(root: Path, account_id: str) -> dict[str, str] | None:
+    path = _account_file(root, account_id)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return {
+        "token": str(payload.get("token") or ""),
+        "base_url": str(payload.get("base_url") or ""),
+        "user_id": str(payload.get("user_id") or ""),
+    }

--- a/aworld_gateway/channels/wechat/adapter.py
+++ b/aworld_gateway/channels/wechat/adapter.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
 from aworld_gateway.channels.base import ChannelAdapter, ChannelMetadata
-from aworld_gateway.channels.wecom.connector import WecomConnector
-from aworld_gateway.config import WecomChannelConfig
+from aworld_gateway.channels.wechat.connector import WechatConnector
+from aworld_gateway.config import WechatChannelConfig
 from aworld_gateway.types import OutboundEnvelope
 
 
-class WecomChannelAdapter(ChannelAdapter):
+class WechatChannelAdapter(ChannelAdapter):
     def __init__(
         self,
-        config: WecomChannelConfig | None = None,
+        config: WechatChannelConfig | None = None,
         *,
         router: object | None = None,
-        connector_cls: type[WecomConnector] = WecomConnector,
+        connector_cls: type[WechatConnector] = WechatConnector,
     ) -> None:
         if config is None:
-            config = WecomChannelConfig()
+            config = WechatChannelConfig()
         super().__init__(config)
         self._config = config
         self._router = router
         self._connector_cls = connector_cls
-        self._connector: WecomConnector | None = None
+        self._connector: WechatConnector | None = None
 
     @classmethod
     def metadata(cls) -> ChannelMetadata:
-        return ChannelMetadata(name="wecom", implemented=True)
+        return ChannelMetadata(name="wechat", implemented=True)
 
     async def start(self) -> None:
         self._connector = self._connector_cls(
@@ -39,7 +39,7 @@ class WecomChannelAdapter(ChannelAdapter):
 
     async def send(self, envelope: OutboundEnvelope):
         if self._connector is None:
-            raise RuntimeError("WeCom channel adapter is not started.")
+            raise RuntimeError("WeChat channel adapter is not started.")
         metadata = dict(envelope.metadata)
         outbound_attachments = self._event_attachments(envelope.events)
         if outbound_attachments:
@@ -50,7 +50,6 @@ class WecomChannelAdapter(ChannelAdapter):
         return await self._connector.send_text(
             chat_id=envelope.conversation_id,
             text=envelope.text,
-            reply_to_message_id=envelope.reply_to_message_id,
             metadata=metadata,
         )
 

--- a/aworld_gateway/channels/wechat/connector.py
+++ b/aworld_gateway/channels/wechat/connector.py
@@ -1,0 +1,837 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import secrets
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from aworld_gateway.channels.wechat.account_store import load_account
+from aworld_gateway.channels.wechat.context_token_store import ContextTokenStore
+from aworld_gateway.channels.wechat.media import (
+    DEFAULT_CDN_BASE_URL,
+    ITEM_FILE,
+    ITEM_IMAGE,
+    ITEM_TEXT,
+    ITEM_VIDEO,
+    ITEM_VOICE,
+    OutboundMediaRequest,
+    aes128_ecb_decrypt,
+    aes128_ecb_encrypt,
+    aes_padded_size,
+    assert_wechat_cdn_url,
+    build_attachment_prompt,
+    build_image_data_url,
+    build_outbound_media_item,
+    cdn_download_url,
+    cdn_upload_url,
+    extract_local_file_path,
+    extract_outbound_media_requests,
+    mime_from_filename,
+    parse_aes_key,
+    sanitize_filename,
+)
+from aworld_gateway.config import WechatChannelConfig
+from aworld_gateway.types import InboundEnvelope
+
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - optional dependency boundary
+    aiohttp = None  # type: ignore[assignment]
+
+DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com"
+CHANNEL_VERSION = "2.2.0"
+ILINK_APP_ID = "bot"
+ILINK_APP_CLIENT_VERSION = str((2 << 16) | (2 << 8) | 0)
+EP_GET_UPDATES = "ilink/bot/getupdates"
+EP_SEND_MESSAGE = "ilink/bot/sendmessage"
+EP_GET_UPLOAD_URL = "ilink/bot/getuploadurl"
+
+SendMessageFunc = Callable[..., Awaitable[dict[str, object]]]
+GetUpdatesFunc = Callable[..., Awaitable[dict[str, object]]]
+DownloadMediaFunc = Callable[..., Awaitable[bytes]]
+GetUploadUrlFunc = Callable[..., Awaitable[dict[str, object]]]
+UploadCiphertextFunc = Callable[..., Awaitable[str]]
+SendMediaMessageFunc = Callable[..., Awaitable[dict[str, object]]]
+
+
+def _base_info() -> dict[str, str]:
+    return {"channel_version": CHANNEL_VERSION}
+
+
+async def _default_post_json(
+    *,
+    session,
+    base_url: str,
+    token: str,
+    endpoint: str,
+    payload: dict[str, Any],
+    timeout_ms: int,
+) -> dict[str, object]:
+    body = _json_dumps({**payload, "base_info": _base_info()})
+    async with session.post(
+        _endpoint_url(base_url, endpoint),
+        data=body,
+        headers=_headers(token, body),
+        timeout=_build_timeout(timeout_ms),
+    ) as response:
+        raw = await response.text()
+        if not getattr(response, "ok", False):
+            raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+        return json.loads(raw)
+
+
+async def _default_send_message(
+    *,
+    session,
+    base_url: str,
+    token: str,
+    to: str,
+    text: str,
+    context_token: str | None,
+    client_id: str,
+) -> dict[str, object]:
+    payload: dict[str, Any] = {
+        "msg": {
+            "from_user_id": "",
+            "to_user_id": to,
+            "client_id": client_id,
+            "message_type": 2,
+            "message_state": 2,
+            "item_list": [{"type": ITEM_TEXT, "text_item": {"text": text}}],
+        }
+    }
+    if context_token:
+        payload["msg"]["context_token"] = context_token
+    return await _default_post_json(
+        session=session,
+        base_url=base_url,
+        token=token,
+        endpoint=EP_SEND_MESSAGE,
+        payload=payload,
+        timeout_ms=15_000,
+    )
+
+
+async def _default_send_media_message(
+    *,
+    session,
+    base_url: str,
+    token: str,
+    to: str,
+    item: dict[str, object],
+    context_token: str | None,
+    client_id: str,
+) -> dict[str, object]:
+    payload: dict[str, Any] = {
+        "msg": {
+            "from_user_id": "",
+            "to_user_id": to,
+            "client_id": client_id,
+            "message_type": 2,
+            "message_state": 2,
+            "item_list": [item],
+        }
+    }
+    if context_token:
+        payload["msg"]["context_token"] = context_token
+    return await _default_post_json(
+        session=session,
+        base_url=base_url,
+        token=token,
+        endpoint=EP_SEND_MESSAGE,
+        payload=payload,
+        timeout_ms=15_000,
+    )
+
+
+async def _default_get_updates(
+    *,
+    session,
+    base_url: str,
+    token: str,
+    sync_buf: str,
+    timeout_ms: int,
+) -> dict[str, object]:
+    try:
+        return await _default_post_json(
+            session=session,
+            base_url=base_url,
+            token=token,
+            endpoint=EP_GET_UPDATES,
+            payload={"get_updates_buf": sync_buf},
+            timeout_ms=timeout_ms,
+        )
+    except asyncio.TimeoutError:
+        return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
+
+
+async def _default_get_upload_url(
+    *,
+    session,
+    base_url: str,
+    token: str,
+    to_user_id: str,
+    media_type: int,
+    filekey: str,
+    rawsize: int,
+    rawfilemd5: str,
+    filesize: int,
+    aeskey_hex: str,
+) -> dict[str, object]:
+    return await _default_post_json(
+        session=session,
+        base_url=base_url,
+        token=token,
+        endpoint=EP_GET_UPLOAD_URL,
+        payload={
+            "filekey": filekey,
+            "media_type": media_type,
+            "to_user_id": to_user_id,
+            "rawsize": rawsize,
+            "rawfilemd5": rawfilemd5,
+            "filesize": filesize,
+            "no_need_thumb": True,
+            "aeskey": aeskey_hex,
+        },
+        timeout_ms=15_000,
+    )
+
+
+async def _default_upload_ciphertext(
+    *,
+    session,
+    ciphertext: bytes,
+    upload_url: str,
+) -> str:
+    async with session.post(
+        upload_url,
+        data=ciphertext,
+        headers={"Content-Type": "application/octet-stream"},
+        timeout=_build_timeout_seconds(120.0),
+    ) as response:
+        if response.status == 200:
+            encrypted_param = response.headers.get("x-encrypted-param")
+            if encrypted_param:
+                await response.read()
+                return encrypted_param
+            raw = await response.text()
+            raise RuntimeError(f"CDN upload missing x-encrypted-param header: {raw[:200]}")
+        raw = await response.text()
+        raise RuntimeError(f"CDN upload HTTP {response.status}: {raw[:200]}")
+
+
+async def _download_bytes(
+    *,
+    session,
+    url: str,
+    timeout_seconds: float,
+) -> bytes:
+    async with session.get(url, timeout=_build_timeout_seconds(timeout_seconds)) as response:
+        response.raise_for_status()
+        return await response.read()
+
+
+async def _default_download_media(
+    *,
+    session,
+    cdn_base_url: str,
+    encrypted_query_param: str | None,
+    aes_key_b64: str | None,
+    full_url: str | None,
+    timeout_seconds: float,
+) -> bytes:
+    if encrypted_query_param:
+        raw = await _download_bytes(
+            session=session,
+            url=cdn_download_url(cdn_base_url, encrypted_query_param),
+            timeout_seconds=timeout_seconds,
+        )
+    elif full_url:
+        assert_wechat_cdn_url(full_url)
+        raw = await _download_bytes(
+            session=session,
+            url=full_url,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        raise RuntimeError("media item had neither encrypt_query_param nor full_url")
+    if aes_key_b64:
+        raw = aes128_ecb_decrypt(raw, parse_aes_key(aes_key_b64))
+    return raw
+
+
+class WechatConnector:
+    def __init__(
+        self,
+        *,
+        config: WechatChannelConfig,
+        router: object | None = None,
+        storage_root: Path | None = None,
+        get_updates_func: GetUpdatesFunc | None = None,
+        send_message_func: SendMessageFunc | None = None,
+        download_media_func: DownloadMediaFunc | None = None,
+        get_upload_url_func: GetUploadUrlFunc | None = None,
+        upload_ciphertext_func: UploadCiphertextFunc | None = None,
+        send_media_message_func: SendMediaMessageFunc | None = None,
+    ) -> None:
+        self.config = config
+        self.router = router
+        self.started = False
+        self._storage_root = storage_root or (Path.cwd() / ".aworld" / "gateway" / "wechat")
+        self._token_store = ContextTokenStore(self._storage_root)
+        self._get_updates_func = get_updates_func or _default_get_updates
+        self._send_message_func = send_message_func or _default_send_message
+        self._download_media_func = download_media_func or _default_download_media
+        self._get_upload_url_func = get_upload_url_func or _default_get_upload_url
+        self._upload_ciphertext_func = upload_ciphertext_func or _default_upload_ciphertext
+        self._send_media_message_func = send_media_message_func or _default_send_media_message
+        self._poll_session: object | None = None
+        self._send_session: object | None = None
+        self._poll_task: asyncio.Task[None] | None = None
+        self._account_id = ""
+        self._token = ""
+        self._base_url = DEFAULT_BASE_URL
+        self._cdn_base_url = DEFAULT_CDN_BASE_URL
+        self._sync_buf = ""
+        self._seen_message_ids: set[str] = set()
+
+    async def start(self) -> None:
+        account_id_env = self._optional_env(self.config.account_id_env)
+        token_env = self._optional_env(self.config.token_env)
+        base_url_env = self._optional_env(self.config.base_url_env)
+        cdn_base_url_env = self._optional_env(self.config.cdn_base_url_env)
+
+        persisted = load_account(self._storage_root, account_id_env) if account_id_env else None
+        self._account_id = account_id_env or str((persisted or {}).get("account_id") or "")
+        self._token = token_env or str((persisted or {}).get("token") or "")
+        self._base_url = base_url_env or str((persisted or {}).get("base_url") or "") or DEFAULT_BASE_URL
+        self._cdn_base_url = cdn_base_url_env or DEFAULT_CDN_BASE_URL
+
+        if not self._account_id:
+            raise ValueError("Missing WeChat account id env")
+        if not self._token:
+            raise ValueError("Missing WeChat token env")
+
+        self._token_store.restore(self._account_id)
+        self._poll_session = self._build_session()
+        self._send_session = self._build_session()
+        self.started = True
+        self._poll_task = asyncio.create_task(self._poll_loop())
+
+    async def stop(self) -> None:
+        self.started = False
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        self._poll_task = None
+        await _close_session(self._poll_session)
+        await _close_session(self._send_session)
+        self._poll_session = None
+        self._send_session = None
+
+    async def send_text(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        metadata: dict | None = None,
+    ) -> dict[str, object]:
+        if not self.started or self._send_session is None:
+            raise RuntimeError("WeChat connector is not started.")
+
+        context_token = self._token_store.get(self._account_id, chat_id)
+        cleaned_text, inline_requests = extract_outbound_media_requests(text)
+        metadata_requests = self._metadata_media_requests(metadata)
+        media_requests = [*inline_requests, *metadata_requests]
+        last_result: dict[str, object] = {}
+
+        if cleaned_text:
+            last_result = await self._send_text_chunks(
+                chat_id=chat_id,
+                text=cleaned_text,
+                context_token=context_token,
+            )
+        elif not media_requests:
+            last_result = await self._send_text_chunks(
+                chat_id=chat_id,
+                text=text,
+                context_token=context_token,
+            )
+
+        for request in media_requests:
+            last_result = await self._send_local_media(
+                chat_id=chat_id,
+                request=request,
+                context_token=context_token,
+            )
+        return last_result
+
+    async def _send_text_chunks(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        context_token: str | None,
+    ) -> dict[str, object]:
+        last_result: dict[str, object] = {}
+        for chunk in self._split_text(text):
+            client_id = f"aworld-wechat-{uuid.uuid4().hex}"
+            result = await self._send_message_func(
+                session=self._send_session,
+                base_url=self._base_url,
+                token=self._token,
+                to=chat_id,
+                text=chunk,
+                context_token=context_token,
+                client_id=client_id,
+            )
+            if "client_id" not in result:
+                result["client_id"] = client_id
+            last_result = result
+        return last_result
+
+    async def _send_local_media(
+        self,
+        *,
+        chat_id: str,
+        request: OutboundMediaRequest,
+        context_token: str | None,
+    ) -> dict[str, object]:
+        plaintext = await asyncio.to_thread(request.path.read_bytes)
+        rawsize = len(plaintext)
+        rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        filekey = secrets.token_hex(16)
+        aes_key = secrets.token_bytes(16)
+        media_type, media_item = build_outbound_media_item(
+            path=request.path,
+            encrypted_query_param="",
+            aes_key_for_api="",
+            ciphertext_size=0,
+            plaintext_size=rawsize,
+            rawfilemd5=rawfilemd5,
+            force_file_attachment=request.force_file_attachment,
+            media_kind_override=request.media_kind_override,
+        )
+        upload_response = await self._get_upload_url_func(
+            session=self._send_session,
+            base_url=self._base_url,
+            token=self._token,
+            to_user_id=chat_id,
+            media_type=media_type,
+            filekey=filekey,
+            rawsize=rawsize,
+            rawfilemd5=rawfilemd5,
+            filesize=aes_padded_size(rawsize),
+            aeskey_hex=aes_key.hex(),
+        )
+        upload_param = str(upload_response.get("upload_param") or "").strip()
+        upload_full_url = str(upload_response.get("upload_full_url") or "").strip()
+        ciphertext = aes128_ecb_encrypt(plaintext, aes_key)
+        if upload_full_url:
+            upload_url = upload_full_url
+        elif upload_param:
+            upload_url = cdn_upload_url(self._cdn_base_url, upload_param, filekey)
+        else:
+            raise RuntimeError(
+                f"getUploadUrl returned neither upload_param nor upload_full_url: {upload_response}"
+            )
+        encrypted_query_param = await self._upload_ciphertext_func(
+            session=self._send_session,
+            ciphertext=ciphertext,
+            upload_url=upload_url,
+        )
+        aes_key_for_api = base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii")
+        _media_type, media_item = build_outbound_media_item(
+            path=request.path,
+            encrypted_query_param=encrypted_query_param,
+            aes_key_for_api=aes_key_for_api,
+            ciphertext_size=len(ciphertext),
+            plaintext_size=rawsize,
+            rawfilemd5=rawfilemd5,
+            force_file_attachment=request.force_file_attachment,
+            media_kind_override=request.media_kind_override,
+        )
+        client_id = f"aworld-wechat-{uuid.uuid4().hex}"
+        result = await self._send_media_message_func(
+            session=self._send_session,
+            base_url=self._base_url,
+            token=self._token,
+            to=chat_id,
+            item=media_item,
+            context_token=context_token,
+            client_id=client_id,
+        )
+        if "client_id" not in result:
+            result["client_id"] = client_id
+        return result
+
+    async def _process_message(self, message: dict[str, Any]) -> None:
+        sender_id = str(message.get("from_user_id") or "").strip()
+        if not sender_id:
+            return
+
+        message_id = str(message.get("message_id") or "").strip()
+        if message_id:
+            if message_id in self._seen_message_ids:
+                return
+            self._seen_message_ids.add(message_id)
+
+        context_token = str(message.get("context_token") or "").strip()
+        if context_token:
+            self._token_store.set(self._account_id, sender_id, context_token)
+
+        conversation_type, conversation_id = self._conversation_target(message, sender_id)
+        if conversation_type == "group":
+            if not self._is_group_allowed(conversation_id):
+                return
+        elif not self._is_dm_allowed(sender_id):
+            return
+
+        item_list = message.get("item_list") or []
+        text = self._extract_text(item_list)
+        inbound_media = await self._collect_inbound_attachments(
+            message_id=message_id or f"wx-{uuid.uuid4().hex}",
+            item_list=item_list,
+        )
+        attachments = inbound_media["attachments"]
+        attachment_prompt = build_attachment_prompt(attachments)
+        if attachment_prompt:
+            text = f"{text}\n\n{attachment_prompt}".strip() if text else attachment_prompt
+        if not text:
+            return
+
+        if self.router is None:
+            return
+
+        metadata: dict[str, Any] = {}
+        if attachments:
+            metadata["attachments"] = attachments
+            metadata["wechat_media"] = inbound_media["wechat_media"]
+            metadata["multimodal_parts"] = inbound_media["multimodal_parts"]
+        outbound = await self.router.handle_inbound(
+            InboundEnvelope(
+                channel="wechat",
+                account_id=self._account_id,
+                conversation_id=conversation_id,
+                conversation_type=conversation_type,
+                sender_id=sender_id,
+                sender_name=sender_id,
+                message_id=message_id or f"wx-{uuid.uuid4().hex}",
+                text=text,
+                raw_payload=message,
+                metadata=metadata,
+            ),
+            channel_default_agent_id=self.config.default_agent_id,
+        )
+        await self.send_text(
+            chat_id=outbound.conversation_id,
+            text=outbound.text,
+            metadata=outbound.metadata,
+        )
+
+    async def _collect_inbound_attachments(
+        self,
+        *,
+        message_id: str,
+        item_list: list[dict[str, Any]],
+    ) -> dict[str, list[dict[str, Any]]]:
+        if self._poll_session is None:
+            return {"attachments": [], "wechat_media": [], "multimodal_parts": []}
+        attachments: list[dict[str, str]] = []
+        wechat_media: list[dict[str, Any]] = []
+        multimodal_parts: list[dict[str, Any]] = []
+        for index, item in enumerate(item_list):
+            candidate = self._inbound_media_candidate(item)
+            if candidate is None:
+                continue
+            try:
+                payload = await self._download_media_func(
+                    session=self._poll_session,
+                    cdn_base_url=self._cdn_base_url,
+                    encrypted_query_param=candidate["encrypted_query_param"],
+                    aes_key_b64=candidate["aes_key_b64"],
+                    full_url=candidate["full_url"],
+                    timeout_seconds=candidate["timeout_seconds"],
+                )
+            except Exception:
+                continue
+            path = await asyncio.to_thread(
+                self._write_inbound_attachment,
+                message_id,
+                index,
+                candidate["file_name"],
+                payload,
+            )
+            attachments.append(
+                {
+                    "type": candidate["type"],
+                    "path": str(path),
+                    "file_name": candidate["file_name"],
+                    "mime_type": candidate["mime_type"],
+                }
+            )
+            wechat_media.append(
+                {
+                    "kind": candidate["type"],
+                    "local_path": str(path),
+                    "file_name": candidate["file_name"],
+                    "mime_type": candidate["mime_type"],
+                    "size_bytes": len(payload),
+                    "item_index": index,
+                }
+            )
+            image_data_url = build_image_data_url(payload, candidate["mime_type"])
+            if image_data_url:
+                multimodal_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image_data_url},
+                    }
+                )
+        return {
+            "attachments": attachments,
+            "wechat_media": wechat_media,
+            "multimodal_parts": multimodal_parts,
+        }
+
+    def _write_inbound_attachment(
+        self,
+        message_id: str,
+        index: int,
+        file_name: str,
+        payload: bytes,
+    ) -> Path:
+        target_dir = (self._storage_root / "attachments" / sanitize_filename(self._account_id)).resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        safe_message_id = sanitize_filename(message_id).replace(".", "_")
+        safe_name = sanitize_filename(file_name)
+        target_path = target_dir / f"{safe_message_id}_{index}_{safe_name}"
+        target_path.write_bytes(payload)
+        return target_path
+
+    def _inbound_media_candidate(self, item: dict[str, Any]) -> dict[str, Any] | None:
+        item_type = item.get("type")
+        if item_type == ITEM_IMAGE:
+            image_item = item.get("image_item") or {}
+            media = image_item.get("media") or {}
+            return {
+                "type": "image",
+                "file_name": "image.jpg",
+                "mime_type": "image/jpeg",
+                "encrypted_query_param": media.get("encrypt_query_param"),
+                "aes_key_b64": self._image_aes_key(image_item),
+                "full_url": media.get("full_url"),
+                "timeout_seconds": 30.0,
+            }
+        if item_type == ITEM_VIDEO:
+            video_item = item.get("video_item") or {}
+            media = video_item.get("media") or {}
+            return {
+                "type": "video",
+                "file_name": "video.mp4",
+                "mime_type": "video/mp4",
+                "encrypted_query_param": media.get("encrypt_query_param"),
+                "aes_key_b64": media.get("aes_key"),
+                "full_url": media.get("full_url"),
+                "timeout_seconds": 120.0,
+            }
+        if item_type == ITEM_FILE:
+            file_item = item.get("file_item") or {}
+            media = file_item.get("media") or {}
+            file_name = str(file_item.get("file_name") or "document.bin")
+            return {
+                "type": "file",
+                "file_name": file_name,
+                "mime_type": mime_from_filename(file_name),
+                "encrypted_query_param": media.get("encrypt_query_param"),
+                "aes_key_b64": media.get("aes_key"),
+                "full_url": media.get("full_url"),
+                "timeout_seconds": 60.0,
+            }
+        if item_type == ITEM_VOICE:
+            voice_item = item.get("voice_item") or {}
+            media = voice_item.get("media") or {}
+            return {
+                "type": "voice",
+                "file_name": "voice.silk",
+                "mime_type": "audio/silk",
+                "encrypted_query_param": media.get("encrypt_query_param"),
+                "aes_key_b64": media.get("aes_key"),
+                "full_url": media.get("full_url"),
+                "timeout_seconds": 60.0,
+            }
+        return None
+
+    @staticmethod
+    def _image_aes_key(image_item: dict[str, Any]) -> str | None:
+        aes_key_hex = str(image_item.get("aeskey") or "").strip()
+        if aes_key_hex:
+            try:
+                return base64.b64encode(bytes.fromhex(aes_key_hex)).decode("ascii")
+            except ValueError:
+                return None
+        media = image_item.get("media") or {}
+        value = str(media.get("aes_key") or "").strip()
+        return value or None
+
+    @staticmethod
+    def _extract_text(item_list: list[dict[str, Any]]) -> str:
+        texts: list[str] = []
+        for item in item_list:
+            if item.get("type") != ITEM_TEXT:
+                continue
+            text_item = item.get("text_item") or {}
+            text = str(text_item.get("text") or "").strip()
+            if text:
+                texts.append(text)
+        return "\n".join(texts)
+
+    @staticmethod
+    def _optional_env(name: str | None) -> str:
+        if not name:
+            return ""
+        return str(os.getenv(name, "")).strip()
+
+    def _split_text(self, text: str) -> list[str]:
+        if not self.config.split_multiline_messages:
+            return [text]
+        return [line.strip() for line in text.splitlines() if line.strip()] or [text]
+
+    @staticmethod
+    def _conversation_target(message: dict[str, Any], sender_id: str) -> tuple[str, str]:
+        room_id = str(message.get("room_id") or message.get("chat_room_id") or "").strip()
+        if room_id:
+            return "group", room_id
+        return "dm", sender_id
+
+    def _is_dm_allowed(self, sender_id: str) -> bool:
+        if self.config.dm_policy == "disabled":
+            return False
+        if self.config.dm_policy == "allowlist":
+            return sender_id in self.config.allow_from
+        return True
+
+    def _is_group_allowed(self, group_id: str) -> bool:
+        if self.config.group_policy == "disabled":
+            return False
+        if self.config.group_policy == "allowlist":
+            return group_id in self.config.group_allow_from
+        return True
+
+    def _metadata_media_requests(self, metadata: dict | None) -> list[OutboundMediaRequest]:
+        if not isinstance(metadata, dict):
+            return []
+        requests: list[OutboundMediaRequest] = []
+        raw_items = metadata.get("outbound_attachments")
+        if not isinstance(raw_items, list):
+            return requests
+        for raw_item in raw_items:
+            raw_path = ""
+            force_file_attachment = False
+            attachment_type = ""
+            if isinstance(raw_item, str):
+                raw_path = raw_item
+            elif isinstance(raw_item, dict):
+                raw_path = str(
+                    raw_item.get("path")
+                    or raw_item.get("file_path")
+                    or raw_item.get("local_path")
+                    or ""
+                ).strip()
+                force_file_attachment = bool(raw_item.get("force_file_attachment"))
+                attachment_type = str(raw_item.get("type") or "").strip().lower()
+            if not raw_path:
+                continue
+            local_path = extract_local_file_path(raw_path)
+            if local_path is None:
+                continue
+            requests.append(
+                OutboundMediaRequest(
+                    path=local_path,
+                    force_file_attachment=force_file_attachment or attachment_type == "file",
+                    media_kind_override=attachment_type if attachment_type in {"image", "video", "voice", "file"} else None,
+                )
+            )
+        return requests
+
+    async def _poll_loop(self) -> None:
+        while self.started:
+            response = await self._get_updates_func(
+                session=self._poll_session,
+                base_url=self._base_url,
+                token=self._token,
+                sync_buf=self._sync_buf,
+                timeout_ms=35_000,
+            )
+            next_sync_buf = str(response.get("get_updates_buf") or "").strip()
+            if next_sync_buf:
+                self._sync_buf = next_sync_buf
+            for message in response.get("msgs") or []:
+                if isinstance(message, dict):
+                    await self._process_message(message)
+
+    def _build_session(self) -> object:
+        if aiohttp is None:
+            return _NoopSession()
+        return aiohttp.ClientSession(trust_env=True)
+
+
+class _NoopSession:
+    def post(self, *args, **kwargs):
+        raise RuntimeError("aiohttp is required for default WeChat network operations")
+
+    def get(self, *args, **kwargs):
+        raise RuntimeError("aiohttp is required for default WeChat network operations")
+
+
+def _json_dumps(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _endpoint_url(base_url: str, endpoint: str) -> str:
+    return f"{base_url.rstrip('/')}/{endpoint}"
+
+
+def _headers(token: str, body: str) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "AuthorizationType": "ilink_bot_token",
+        "Content-Length": str(len(body.encode("utf-8"))),
+        "X-WECHAT-UIN": uuid.uuid4().hex[:16],
+        "iLink-App-Id": ILINK_APP_ID,
+        "iLink-App-ClientVersion": ILINK_APP_CLIENT_VERSION,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _build_timeout(timeout_ms: int):
+    if aiohttp is None:
+        return timeout_ms / 1000
+    return aiohttp.ClientTimeout(total=timeout_ms / 1000)
+
+
+def _build_timeout_seconds(timeout_seconds: float):
+    if aiohttp is None:
+        return timeout_seconds
+    return aiohttp.ClientTimeout(total=timeout_seconds)
+
+
+async def _close_session(session: object | None) -> None:
+    if session is None:
+        return
+    close = getattr(session, "close", None)
+    if close is None:
+        return
+    result = close()
+    if asyncio.iscoroutine(result):
+        await result

--- a/aworld_gateway/channels/wechat/context_token_store.py
+++ b/aworld_gateway/channels/wechat/context_token_store.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class ContextTokenStore:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._cache: dict[str, str] = {}
+
+    def _path(self, account_id: str) -> Path:
+        return self._root / f"{account_id}.context-tokens.json"
+
+    @staticmethod
+    def _key(account_id: str, peer_id: str) -> str:
+        return f"{account_id}:{peer_id}"
+
+    def restore(self, account_id: str) -> None:
+        path = self._path(account_id)
+        if not path.exists():
+            return
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+        if not isinstance(payload, dict):
+            return
+        for peer_id, token in payload.items():
+            if isinstance(token, str) and token:
+                self._cache[self._key(account_id, str(peer_id))] = token
+
+    def get(self, account_id: str, peer_id: str) -> str | None:
+        return self._cache.get(self._key(account_id, peer_id))
+
+    def set(self, account_id: str, peer_id: str, token: str) -> None:
+        self._cache[self._key(account_id, peer_id)] = token
+        self._persist(account_id)
+
+    def _persist(self, account_id: str) -> None:
+        self._root.mkdir(parents=True, exist_ok=True)
+        prefix = f"{account_id}:"
+        payload = {
+            key[len(prefix) :]: value
+            for key, value in self._cache.items()
+            if key.startswith(prefix)
+        }
+        self._path(account_id).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )

--- a/aworld_gateway/channels/wechat/media.py
+++ b/aworld_gateway/channels/wechat/media.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import base64
+import mimetypes
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, unquote, urlparse
+
+try:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+except ImportError:  # pragma: no cover - optional dependency boundary
+    default_backend = None  # type: ignore[assignment]
+    Cipher = None  # type: ignore[assignment]
+    algorithms = None  # type: ignore[assignment]
+    modes = None  # type: ignore[assignment]
+
+ITEM_TEXT = 1
+ITEM_IMAGE = 2
+ITEM_VOICE = 3
+ITEM_FILE = 4
+ITEM_VIDEO = 5
+
+MEDIA_IMAGE = 1
+MEDIA_VIDEO = 2
+MEDIA_FILE = 3
+MEDIA_VOICE = 4
+
+DEFAULT_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
+
+MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
+INLINE_CODE_MEDIA_REF_RE = re.compile(r"`((?:attachment://|file://|MEDIA:)[^\s`]+)`")
+PLAIN_MEDIA_REF_RE = re.compile(r"((?:attachment://|file://|MEDIA:)[^\s<>)]+)")
+
+_WECHAT_CDN_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "novac2c.cdn.weixin.qq.com",
+        "ilinkai.weixin.qq.com",
+        "wx.qlogo.cn",
+        "thirdwx.qlogo.cn",
+        "res.wx.qq.com",
+        "mmbiz.qpic.cn",
+        "mmbiz.qlogo.cn",
+    }
+)
+
+
+@dataclass(frozen=True)
+class OutboundMediaRequest:
+    path: Path
+    force_file_attachment: bool = False
+    media_kind_override: str | None = None
+
+
+def sanitize_filename(file_name: str) -> str:
+    name = os.path.basename(file_name or "").strip() or "attachment"
+    safe = "".join(ch if (ch.isalnum() or ch in {"-", "_", "."}) else "_" for ch in name)
+    return safe or "attachment"
+
+
+def mime_from_filename(filename: str) -> str:
+    return mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+
+def build_image_data_url(payload: bytes, mime_type: str) -> str | None:
+    normalized = str(mime_type or "").strip().lower()
+    if not normalized.startswith("image/"):
+        return None
+    if not payload:
+        return None
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"data:{normalized};base64,{encoded}"
+
+
+def infer_media_kind(path: Path, *, force_file_attachment: bool = False) -> str:
+    if force_file_attachment:
+        return "file"
+    mime = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+    if mime.startswith("image/"):
+        return "image"
+    if mime.startswith("video/"):
+        return "video"
+    if path.suffix.lower() == ".silk":
+        return "voice"
+    return "file"
+
+
+def build_attachment_prompt(attachments: list[dict[str, Any]]) -> str:
+    if not attachments:
+        return ""
+    lines = ["Attachments:"]
+    for attachment in attachments:
+        kind = str(attachment.get("type") or "file").strip() or "file"
+        path = str(attachment.get("path") or "").strip()
+        if path:
+            lines.append(f"- {kind}: {path}")
+    return "\n".join(lines)
+
+
+def extract_local_file_path(raw_reference: str) -> Path | None:
+    candidate = raw_reference.strip().strip("<>").strip("'").strip('"').strip("`")
+    if not candidate:
+        return None
+    candidate = candidate.replace("\\ ", " ")
+    if candidate.startswith("file://"):
+        candidate = candidate[len("file://") :]
+    elif candidate.startswith("attachment://"):
+        candidate = candidate[len("attachment://") :]
+    elif candidate.startswith("MEDIA:"):
+        candidate = candidate[len("MEDIA:") :]
+    candidate = unquote(candidate).strip()
+    if not candidate:
+        return None
+    path = Path(candidate).expanduser()
+    if not path.is_absolute() or not path.exists() or not path.is_file():
+        return None
+    return path
+
+
+def extract_outbound_media_requests(content: str) -> tuple[str, list[OutboundMediaRequest]]:
+    if not content:
+        return content, []
+
+    result = content
+    requests: list[OutboundMediaRequest] = []
+
+    for match in list(MARKDOWN_IMAGE_RE.finditer(result)):
+        full_match, _alt_text, raw_url = match.group(0), match.group(1), match.group(2)
+        local_path = extract_local_file_path(raw_url)
+        if local_path is None:
+            continue
+        requests.append(OutboundMediaRequest(path=local_path, force_file_attachment=False))
+        result = result.replace(full_match, "", 1)
+
+    for match in list(MARKDOWN_LINK_RE.finditer(result)):
+        full_match, _link_text, raw_url = match.group(0), match.group(1), match.group(2)
+        local_path = extract_local_file_path(raw_url)
+        if local_path is None:
+            continue
+        requests.append(OutboundMediaRequest(path=local_path, force_file_attachment=True))
+        result = result.replace(full_match, "", 1)
+
+    def _replace_inline_code_reference(match: re.Match[str]) -> str:
+        local_path = extract_local_file_path(match.group(1))
+        if local_path is None:
+            return match.group(0)
+        requests.append(OutboundMediaRequest(path=local_path, force_file_attachment=False))
+        return ""
+
+    def _replace_plain_reference(match: re.Match[str]) -> str:
+        local_path = extract_local_file_path(match.group(1))
+        if local_path is None:
+            return match.group(0)
+        requests.append(OutboundMediaRequest(path=local_path, force_file_attachment=False))
+        return ""
+
+    result = INLINE_CODE_MEDIA_REF_RE.sub(_replace_inline_code_reference, result)
+    result = PLAIN_MEDIA_REF_RE.sub(_replace_plain_reference, result)
+    return cleanup_processed_text(result), requests
+
+
+def cleanup_processed_text(content: str) -> str:
+    lines = [line.rstrip() for line in content.splitlines()]
+    result: list[str] = []
+    blank_run = 0
+    for line in lines:
+        if not line.strip():
+            blank_run += 1
+            if blank_run > 1:
+                continue
+            result.append("")
+            continue
+        blank_run = 0
+        result.append(line.strip())
+    return "\n".join(result).strip()
+
+
+def cdn_download_url(cdn_base_url: str, encrypted_query_param: str) -> str:
+    return f"{cdn_base_url.rstrip('/')}/download?encrypted_query_param={quote(encrypted_query_param, safe='')}"
+
+
+def cdn_upload_url(cdn_base_url: str, upload_param: str, filekey: str) -> str:
+    return (
+        f"{cdn_base_url.rstrip('/')}/upload"
+        f"?encrypted_query_param={quote(upload_param, safe='')}"
+        f"&filekey={quote(filekey, safe='')}"
+    )
+
+
+def assert_wechat_cdn_url(url: str) -> None:
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        host = parsed.hostname or ""
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Unparseable media URL: {url!r}") from exc
+    if scheme not in {"http", "https"}:
+        raise ValueError(f"Media URL has disallowed scheme {scheme!r}.")
+    if host not in _WECHAT_CDN_ALLOWLIST:
+        raise ValueError(f"Media URL host {host!r} is not in the WeChat CDN allowlist.")
+
+
+def parse_aes_key(aes_key_b64: str) -> bytes:
+    decoded = base64.b64decode(aes_key_b64)
+    if len(decoded) == 16:
+        return decoded
+    if len(decoded) == 32:
+        text = decoded.decode("ascii", errors="ignore")
+        if text and all(ch in "0123456789abcdefABCDEF" for ch in text):
+            return bytes.fromhex(text)
+    raise ValueError(f"unexpected aes_key format ({len(decoded)} decoded bytes)")
+
+
+def pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
+    pad_len = block_size - (len(data) % block_size)
+    return data + bytes([pad_len] * pad_len)
+
+
+def aes128_ecb_encrypt(plaintext: bytes, key: bytes) -> bytes:
+    if Cipher is None or algorithms is None or modes is None or default_backend is None:
+        raise RuntimeError("cryptography is required for WeChat media encryption")
+    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    encryptor = cipher.encryptor()
+    return encryptor.update(pkcs7_pad(plaintext)) + encryptor.finalize()
+
+
+def aes128_ecb_decrypt(ciphertext: bytes, key: bytes) -> bytes:
+    if Cipher is None or algorithms is None or modes is None or default_backend is None:
+        raise RuntimeError("cryptography is required for WeChat media decryption")
+    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+    if not padded:
+        return padded
+    pad_len = padded[-1]
+    if 1 <= pad_len <= 16 and padded.endswith(bytes([pad_len]) * pad_len):
+        return padded[:-pad_len]
+    return padded
+
+
+def aes_padded_size(size: int) -> int:
+    return ((size + 1 + 15) // 16) * 16
+
+
+def build_outbound_media_item(
+    *,
+    path: Path,
+    encrypted_query_param: str,
+    aes_key_for_api: str,
+    ciphertext_size: int,
+    plaintext_size: int,
+    rawfilemd5: str,
+    force_file_attachment: bool = False,
+    media_kind_override: str | None = None,
+) -> tuple[int, dict[str, Any]]:
+    kind = str(media_kind_override or "").strip().lower() or infer_media_kind(
+        path,
+        force_file_attachment=force_file_attachment,
+    )
+    if kind == "image":
+        return MEDIA_IMAGE, {
+            "type": ITEM_IMAGE,
+            "image_item": {
+                "media": {
+                    "encrypt_query_param": encrypted_query_param,
+                    "aes_key": aes_key_for_api,
+                    "encrypt_type": 1,
+                },
+                "mid_size": ciphertext_size,
+            },
+        }
+    if kind == "video":
+        return MEDIA_VIDEO, {
+            "type": ITEM_VIDEO,
+            "video_item": {
+                "media": {
+                    "encrypt_query_param": encrypted_query_param,
+                    "aes_key": aes_key_for_api,
+                    "encrypt_type": 1,
+                },
+                "video_size": ciphertext_size,
+                "play_length": 0,
+                "video_md5": rawfilemd5,
+            },
+        }
+    if kind == "voice":
+        return MEDIA_VOICE, {
+            "type": ITEM_VOICE,
+            "voice_item": {
+                "media": {
+                    "encrypt_query_param": encrypted_query_param,
+                    "aes_key": aes_key_for_api,
+                    "encrypt_type": 1,
+                },
+                "encode_type": 6,
+                "bits_per_sample": 16,
+                "sample_rate": 24000,
+                "playtime": 0,
+            },
+        }
+    return MEDIA_FILE, {
+        "type": ITEM_FILE,
+        "file_item": {
+            "media": {
+                "encrypt_query_param": encrypted_query_param,
+                "aes_key": aes_key_for_api,
+                "encrypt_type": 1,
+            },
+            "file_name": path.name,
+            "len": str(plaintext_size),
+        },
+    }

--- a/aworld_gateway/channels/wecom/connector.py
+++ b/aworld_gateway/channels/wecom/connector.py
@@ -1,0 +1,1007 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import mimetypes
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Protocol
+
+from aworld_gateway.config import WecomChannelConfig
+from aworld_gateway.types import InboundEnvelope
+from aworld_gateway.channels.wechat.media import (
+    build_attachment_prompt,
+    build_image_data_url,
+    extract_local_file_path,
+    sanitize_filename,
+)
+
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - optional dependency boundary
+    aiohttp = None  # type: ignore[assignment]
+
+DEFAULT_WS_URL = "wss://openws.work.weixin.qq.com"
+
+APP_CMD_SUBSCRIBE = "aibot_subscribe"
+APP_CMD_CALLBACK = "aibot_msg_callback"
+APP_CMD_LEGACY_CALLBACK = "aibot_callback"
+APP_CMD_EVENT_CALLBACK = "aibot_event_callback"
+APP_CMD_RESPONSE = "aibot_respond_msg"
+APP_CMD_SEND = "aibot_send_msg"
+APP_CMD_PING = "ping"
+APP_CMD_UPLOAD_MEDIA_INIT = "aibot_upload_media_init"
+APP_CMD_UPLOAD_MEDIA_CHUNK = "aibot_upload_media_chunk"
+APP_CMD_UPLOAD_MEDIA_FINISH = "aibot_upload_media_finish"
+
+CALLBACK_COMMANDS = {APP_CMD_CALLBACK, APP_CMD_LEGACY_CALLBACK}
+NON_RESPONSE_COMMANDS = CALLBACK_COMMANDS | {APP_CMD_EVENT_CALLBACK}
+DEDUP_MAX_SIZE = 1000
+UPLOAD_CHUNK_SIZE = 512 * 1024
+IMAGE_MAX_BYTES = 10 * 1024 * 1024
+VIDEO_MAX_BYTES = 10 * 1024 * 1024
+VOICE_MAX_BYTES = 2 * 1024 * 1024
+FILE_MAX_BYTES = 20 * 1024 * 1024
+ABSOLUTE_MAX_BYTES = FILE_MAX_BYTES
+VOICE_SUPPORTED_MIMES = {"audio/amr"}
+CONNECT_TIMEOUT_SECONDS = 20.0
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+RECONNECT_BACKOFF_SECONDS = [2.0, 5.0, 10.0, 30.0, 60.0]
+
+
+class WecomTransport(Protocol):
+    closed: bool
+
+    async def send_json(self, payload: dict[str, object]) -> None: ...
+    async def receive_json(self) -> dict[str, object]: ...
+    async def close(self) -> None: ...
+
+
+ConnectFunc = Callable[[str], Awaitable[WecomTransport]]
+
+
+class _AiohttpTransport:
+    def __init__(self, *, session, ws) -> None:
+        self._session = session
+        self._ws = ws
+
+    @property
+    def closed(self) -> bool:
+        return bool(getattr(self._ws, "closed", False))
+
+    async def send_json(self, payload: dict[str, object]) -> None:
+        await self._ws.send_json(payload)
+
+    async def receive_json(self) -> dict[str, object]:
+        while True:
+            message = await self._ws.receive()
+            if message.type == aiohttp.WSMsgType.TEXT:
+                payload = _parse_json(message.data)
+                if payload is not None:
+                    return payload
+                continue
+            if message.type in (
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                raise RuntimeError("WeCom websocket closed")
+
+    async def close(self) -> None:
+        if not self._ws.closed:
+            await self._ws.close()
+        if not self._session.closed:
+            await self._session.close()
+
+
+async def _default_connect(url: str) -> WecomTransport:
+    if aiohttp is None:
+        raise RuntimeError("aiohttp is required for WeCom channel.")
+    session = aiohttp.ClientSession(trust_env=True)
+    ws = await session.ws_connect(url, heartbeat=60, timeout=20)
+    return _AiohttpTransport(session=session, ws=ws)
+
+
+class WecomConnector:
+    def __init__(
+        self,
+        *,
+        config: WecomChannelConfig,
+        router: object | None = None,
+        connect_func: ConnectFunc | None = None,
+    ) -> None:
+        self.config = config
+        self.router = router
+        self.started = False
+        self._connect_func = connect_func or _default_connect
+        self._transport: WecomTransport | None = None
+        self._listen_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._pending_responses: dict[str, asyncio.Future[dict[str, object]]] = {}
+        self._reply_req_ids: dict[str, str] = {}
+        self._last_chat_req_ids: dict[str, str] = {}
+        self._seen_message_ids: set[str] = set()
+        self._bot_id = ""
+        self._secret = ""
+        self._ws_url = DEFAULT_WS_URL
+
+    async def start(self) -> None:
+        self._bot_id = self._required_env(self.config.bot_id_env, "Missing WeCom bot id env")
+        self._secret = self._required_env(self.config.secret_env, "Missing WeCom secret env")
+        self._ws_url = self._optional_env(self.config.websocket_url_env) or DEFAULT_WS_URL
+
+        self.started = True
+        await self._open_connection()
+        self._listen_task = asyncio.create_task(self._listen_loop())
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def stop(self) -> None:
+        self.started = False
+        if self._listen_task is not None:
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+        self._listen_task = None
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+        self._heartbeat_task = None
+        self._fail_pending_responses(RuntimeError("WeCom connector stopped"))
+        await self._close_transport()
+
+    async def _open_connection(self) -> None:
+        await self._close_transport()
+        self._transport = await self._connect_func(self._ws_url)
+        req_id = self._new_req_id("subscribe")
+        await self._transport.send_json(
+            {
+                "cmd": APP_CMD_SUBSCRIBE,
+                "headers": {"req_id": req_id},
+                "body": {
+                    "bot_id": self._bot_id,
+                    "secret": self._secret,
+                },
+            }
+        )
+        response = await self._wait_for_handshake(req_id)
+        errcode = response.get("errcode", 0)
+        if errcode not in (0, None):
+            raise RuntimeError(str(response.get("errmsg") or "WeCom subscribe failed"))
+
+    async def _close_transport(self) -> None:
+        if self._transport is not None:
+            await self._transport.close()
+        self._transport = None
+
+    async def send_text(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        reply_to_message_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> dict[str, object]:
+        if not self.started or self._transport is None:
+            raise RuntimeError("WeCom connector is not started.")
+        if not chat_id:
+            raise ValueError("chat_id is required")
+
+        media_requests = self._metadata_media_requests(metadata)
+        if media_requests:
+            return await self._send_with_attachments(
+                chat_id=chat_id,
+                text=text,
+                reply_to_message_id=reply_to_message_id,
+                attachments=media_requests,
+            )
+
+        reply_req_id = self._reply_req_id_for_message(reply_to_message_id)
+        if not reply_req_id:
+            reply_req_id = self._last_chat_req_ids.get(chat_id)
+        if reply_req_id:
+            return await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "markdown",
+                    "markdown": {"content": text},
+                },
+            )
+        return await self._send_request(
+            APP_CMD_SEND,
+            {
+                "chatid": chat_id,
+                "msgtype": "markdown",
+                "markdown": {"content": text},
+            },
+        )
+
+    async def _wait_for_handshake(self, req_id: str) -> dict[str, object]:
+        if self._transport is None:
+            raise RuntimeError("WeCom transport is not initialized")
+        deadline = asyncio.get_running_loop().time() + CONNECT_TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for WeCom subscribe acknowledgement")
+            payload = await asyncio.wait_for(self._transport.receive_json(), timeout=remaining)
+            cmd = str(payload.get("cmd") or "")
+            if cmd in {APP_CMD_PING, APP_CMD_EVENT_CALLBACK}:
+                continue
+            if self._payload_req_id(payload) == req_id:
+                return payload
+
+    async def _listen_loop(self) -> None:
+        backoff_index = 0
+        while self.started:
+            transport = self._transport
+            if transport is None:
+                delay = RECONNECT_BACKOFF_SECONDS[min(backoff_index, len(RECONNECT_BACKOFF_SECONDS) - 1)]
+                backoff_index += 1
+                await asyncio.sleep(delay)
+                try:
+                    await self._open_connection()
+                    backoff_index = 0
+                    continue
+                except Exception:
+                    continue
+            try:
+                while self.started and self._transport is transport and not transport.closed:
+                    payload = await transport.receive_json()
+                    await self._dispatch_payload(payload)
+                if not self.started:
+                    return
+                raise RuntimeError("WeCom websocket closed")
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                if not self.started:
+                    return
+                self._fail_pending_responses(RuntimeError("WeCom connection interrupted"))
+                delay = RECONNECT_BACKOFF_SECONDS[min(backoff_index, len(RECONNECT_BACKOFF_SECONDS) - 1)]
+                backoff_index += 1
+                await asyncio.sleep(delay)
+                try:
+                    await self._open_connection()
+                    backoff_index = 0
+                except Exception:
+                    continue
+
+    async def _heartbeat_loop(self) -> None:
+        while self.started:
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                return
+            transport = self._transport
+            if transport is None or transport.closed:
+                continue
+            try:
+                await transport.send_json(
+                    {
+                        "cmd": APP_CMD_PING,
+                        "headers": {"req_id": self._new_req_id("ping")},
+                        "body": {},
+                    }
+                )
+            except Exception:
+                continue
+
+    async def _dispatch_payload(self, payload: dict[str, object]) -> None:
+        req_id = self._payload_req_id(payload)
+        cmd = str(payload.get("cmd") or "")
+
+        if req_id and req_id in self._pending_responses and cmd not in NON_RESPONSE_COMMANDS:
+            future = self._pending_responses.get(req_id)
+            if future is not None and not future.done():
+                future.set_result(payload)
+            return
+
+        if cmd in CALLBACK_COMMANDS:
+            await self._process_callback(payload)
+            return
+
+    async def _process_callback(self, payload: dict[str, object]) -> None:
+        body = payload.get("body")
+        if not isinstance(body, dict):
+            return
+
+        message_id = str(body.get("msgid") or self._payload_req_id(payload) or uuid.uuid4().hex).strip()
+        if not message_id:
+            return
+        if message_id in self._seen_message_ids:
+            return
+        self._seen_message_ids.add(message_id)
+        self._trim_seen_message_ids()
+
+        sender = body.get("from") if isinstance(body.get("from"), dict) else {}
+        sender_id = str(sender.get("userid") or "").strip()
+        chat_id = str(body.get("chatid") or sender_id).strip()
+        if not chat_id:
+            return
+
+        conversation_type = "group" if str(body.get("chattype") or "").lower() == "group" else "dm"
+        if conversation_type == "group":
+            if not self._is_group_allowed(chat_id):
+                return
+        elif not self._is_dm_allowed(sender_id):
+            return
+
+        req_id = self._payload_req_id(payload)
+        self._remember_reply_req_id(message_id, req_id)
+        self._remember_chat_req_id(chat_id, req_id)
+
+        text = self._extract_text(body)
+        inbound_media = await self._extract_inbound_media(body, message_id=message_id)
+        attachments = inbound_media["attachments"]
+        attachment_prompt = build_attachment_prompt(attachments)
+        if attachment_prompt:
+            text = f"{text}\n\n{attachment_prompt}".strip() if text else attachment_prompt
+        if not text or self.router is None:
+            return
+
+        metadata: dict[str, Any] = {}
+        if attachments:
+            metadata["attachments"] = attachments
+            metadata["wecom_media"] = inbound_media["wecom_media"]
+            metadata["multimodal_parts"] = inbound_media["multimodal_parts"]
+
+        outbound = await self.router.handle_inbound(
+            InboundEnvelope(
+                channel="wecom",
+                account_id=self._bot_id,
+                conversation_id=chat_id,
+                conversation_type=conversation_type,
+                sender_id=sender_id,
+                sender_name=sender_id or None,
+                message_id=message_id,
+                text=text,
+                raw_payload=payload,
+                metadata=metadata,
+            ),
+            channel_default_agent_id=self.config.default_agent_id,
+        )
+        await self.send_text(
+            chat_id=outbound.conversation_id,
+            text=outbound.text,
+            reply_to_message_id=outbound.reply_to_message_id,
+            metadata=outbound.metadata,
+        )
+
+    async def _send_request(
+        self,
+        cmd: str,
+        body: dict[str, object],
+        timeout: float = 15.0,
+    ) -> dict[str, object]:
+        if self._transport is None or self._transport.closed:
+            raise RuntimeError("WeCom transport is not connected")
+        req_id = self._new_req_id(cmd)
+        future: asyncio.Future[dict[str, object]] = asyncio.get_running_loop().create_future()
+        self._pending_responses[req_id] = future
+        try:
+            await self._transport.send_json({"cmd": cmd, "headers": {"req_id": req_id}, "body": body})
+            return await asyncio.wait_for(future, timeout=timeout)
+        finally:
+            self._pending_responses.pop(req_id, None)
+
+    async def _send_reply_request(
+        self,
+        reply_req_id: str,
+        body: dict[str, object],
+        timeout: float = 15.0,
+    ) -> dict[str, object]:
+        if self._transport is None or self._transport.closed:
+            raise RuntimeError("WeCom transport is not connected")
+        normalized_req_id = str(reply_req_id or "").strip()
+        if not normalized_req_id:
+            raise ValueError("reply_req_id is required")
+        future: asyncio.Future[dict[str, object]] = asyncio.get_running_loop().create_future()
+        self._pending_responses[normalized_req_id] = future
+        try:
+            await self._transport.send_json(
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": normalized_req_id}, "body": body}
+            )
+            return await asyncio.wait_for(future, timeout=timeout)
+        finally:
+            self._pending_responses.pop(normalized_req_id, None)
+
+    def _remember_reply_req_id(self, message_id: str, req_id: str) -> None:
+        normalized_message_id = str(message_id or "").strip()
+        normalized_req_id = str(req_id or "").strip()
+        if not normalized_message_id or not normalized_req_id:
+            return
+        self._reply_req_ids[normalized_message_id] = normalized_req_id
+        while len(self._reply_req_ids) > DEDUP_MAX_SIZE:
+            self._reply_req_ids.pop(next(iter(self._reply_req_ids)))
+
+    def _remember_chat_req_id(self, chat_id: str, req_id: str) -> None:
+        normalized_chat_id = str(chat_id or "").strip()
+        normalized_req_id = str(req_id or "").strip()
+        if not normalized_chat_id or not normalized_req_id:
+            return
+        self._last_chat_req_ids[normalized_chat_id] = normalized_req_id
+        while len(self._last_chat_req_ids) > DEDUP_MAX_SIZE:
+            self._last_chat_req_ids.pop(next(iter(self._last_chat_req_ids)))
+
+    def _reply_req_id_for_message(self, reply_to: str | None) -> str | None:
+        normalized = str(reply_to or "").strip()
+        if not normalized:
+            return None
+        return self._reply_req_ids.get(normalized)
+
+    def _trim_seen_message_ids(self) -> None:
+        while len(self._seen_message_ids) > DEDUP_MAX_SIZE:
+            self._seen_message_ids.pop()
+
+    async def _extract_inbound_media(
+        self,
+        body: dict[str, object],
+        *,
+        message_id: str,
+    ) -> dict[str, list[dict[str, Any]]]:
+        attachments: list[dict[str, Any]] = []
+        wecom_media: list[dict[str, Any]] = []
+        multimodal_parts: list[dict[str, Any]] = []
+        refs: list[tuple[str, dict[str, Any]]] = []
+
+        msgtype = str(body.get("msgtype") or "").lower()
+        if isinstance(body.get("image"), dict):
+            refs.append(("image", body["image"]))
+        if msgtype == "file" and isinstance(body.get("file"), dict):
+            refs.append(("file", body["file"]))
+        if msgtype == "appmsg" and isinstance(body.get("appmsg"), dict):
+            appmsg = body["appmsg"]
+            if isinstance(appmsg.get("file"), dict):
+                refs.append(("file", appmsg["file"]))
+            elif isinstance(appmsg.get("image"), dict):
+                refs.append(("image", appmsg["image"]))
+
+        for index, (kind, ref) in enumerate(refs):
+            cached = await self._cache_media(kind, ref, message_id=message_id, item_index=index)
+            if cached is None:
+                continue
+            attachments.append(cached["attachment"])
+            wecom_media.append(cached["wecom_media"])
+            if cached["multimodal_part"] is not None:
+                multimodal_parts.append(cached["multimodal_part"])
+
+        return {
+            "attachments": attachments,
+            "wecom_media": wecom_media,
+            "multimodal_parts": multimodal_parts,
+        }
+
+    async def _send_with_attachments(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        reply_to_message_id: str | None,
+        attachments: list[dict[str, object]],
+    ) -> dict[str, object]:
+        reply_req_id = self._reply_req_id_for_message(reply_to_message_id)
+        if not reply_req_id:
+            reply_req_id = self._last_chat_req_ids.get(chat_id)
+
+        media_result: dict[str, object] | None = None
+        for attachment in attachments:
+            raw_path = str(attachment.get("path") or "").strip()
+            file_name = None
+            local_path = extract_local_file_path(raw_path)
+            if local_path is not None:
+                file_name = local_path.name
+            try:
+                prepared = await self._prepare_outbound_media(
+                    raw_path,
+                    attachment_type=str(attachment.get("type") or "").strip().lower(),
+                    force_file_attachment=bool(attachment.get("force_file_attachment")),
+                    file_name=file_name,
+                )
+            except Exception as exc:
+                return {"error": str(exc)}
+            if prepared["rejected"]:
+                note_result = await self._send_followup_markdown(
+                    chat_id=chat_id,
+                    text=str(prepared["reject_reason"] or ""),
+                    reply_req_id=reply_req_id,
+                )
+                return {"error": str(prepared["reject_reason"] or ""), "caption": note_result}
+            if not prepared["data"]:
+                continue
+            upload = await self._upload_media_bytes(
+                prepared["data"],
+                str(prepared["final_type"]),
+                str(prepared["file_name"]),
+            )
+            if reply_req_id:
+                media_result = await self._send_reply_media_message(
+                    reply_req_id,
+                    str(prepared["final_type"]),
+                    str(upload.get("media_id") or ""),
+                )
+            else:
+                media_result = await self._send_media_message(
+                    chat_id,
+                    str(prepared["final_type"]),
+                    str(upload.get("media_id") or ""),
+                )
+            if media_result is not None:
+                media_result = {
+                    "upload": upload,
+                    "body": {
+                        "type": prepared["final_type"],
+                        "media_id": upload.get("media_id"),
+                    },
+                    "response": media_result,
+                }
+            if prepared["downgraded"] and prepared["downgrade_note"]:
+                await self._send_followup_markdown(
+                    chat_id=chat_id,
+                    text=str(prepared["downgrade_note"]),
+                    reply_req_id=reply_req_id,
+                )
+
+        caption_result: dict[str, object] | None = None
+        if text.strip():
+            caption_result = await self._send_followup_markdown(
+                chat_id=chat_id,
+                text=text,
+                reply_req_id=reply_req_id,
+            )
+
+        result: dict[str, object] = {}
+        if media_result is not None:
+            upload_payload = media_result.get("upload")
+            response_payload = media_result.get("response")
+            media_body = media_result.get("body")
+            result["media"] = {
+                "body": media_body if isinstance(media_body, dict) else {},
+                "upload": upload_payload if isinstance(upload_payload, dict) else {},
+                "response": response_payload if isinstance(response_payload, dict) else {},
+            }
+        if caption_result is not None:
+            result["caption"] = caption_result
+        return result
+
+    async def _send_followup_markdown(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        reply_req_id: str | None,
+    ) -> dict[str, object]:
+        if reply_req_id:
+            return await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "markdown",
+                    "markdown": {"content": text},
+                },
+            )
+        return await self._send_request(
+            APP_CMD_SEND,
+            {
+                "chatid": chat_id,
+                "msgtype": "markdown",
+                "markdown": {"content": text},
+            },
+        )
+
+    async def _prepare_outbound_media(
+        self,
+        media_source: str,
+        *,
+        attachment_type: str,
+        force_file_attachment: bool,
+        file_name: str | None = None,
+    ) -> dict[str, object]:
+        data, content_type, resolved_name = await self._load_outbound_media(
+            media_source,
+            file_name=file_name,
+        )
+        detected_type = self._detect_outbound_media_type_from_content(
+            content_type=content_type,
+            attachment_type=attachment_type,
+            force_file_attachment=force_file_attachment,
+        )
+        size_check = self._apply_file_size_limits(
+            file_size=len(data),
+            detected_type=detected_type,
+            content_type=content_type,
+        )
+        return {
+            "data": data,
+            "content_type": content_type,
+            "file_name": resolved_name,
+            "detected_type": detected_type,
+            **size_check,
+        }
+
+    async def _load_outbound_media(
+        self,
+        media_source: str,
+        *,
+        file_name: str | None = None,
+    ) -> tuple[bytes, str, str]:
+        local_path = extract_local_file_path(media_source)
+        if local_path is None:
+            raise FileNotFoundError(f"Media file not found: {media_source}")
+        data = await asyncio.to_thread(local_path.read_bytes)
+        resolved_name = file_name or local_path.name
+        content_type = mimetypes.guess_type(resolved_name)[0] or "application/octet-stream"
+        return data, content_type, resolved_name
+
+    async def _upload_media_bytes(
+        self,
+        data: bytes,
+        media_type: str,
+        filename: str,
+    ) -> dict[str, object]:
+        if not data:
+            raise ValueError("Cannot upload empty media")
+
+        total_size = len(data)
+        total_chunks = (total_size + UPLOAD_CHUNK_SIZE - 1) // UPLOAD_CHUNK_SIZE
+        init_response = await self._send_request(
+            APP_CMD_UPLOAD_MEDIA_INIT,
+            {
+                "type": media_type,
+                "filename": filename,
+                "total_size": total_size,
+                "total_chunks": total_chunks,
+                "md5": hashlib.md5(data).hexdigest(),
+            },
+        )
+        init_body = init_response.get("body") if isinstance(init_response.get("body"), dict) else {}
+        upload_id = str(init_body.get("upload_id") or "").strip()
+        if not upload_id:
+            raise RuntimeError(f"media upload init failed: missing upload_id in response {init_response}")
+
+        for chunk_index, start in enumerate(range(0, total_size, UPLOAD_CHUNK_SIZE)):
+            chunk = data[start : start + UPLOAD_CHUNK_SIZE]
+            await self._send_request(
+                APP_CMD_UPLOAD_MEDIA_CHUNK,
+                {
+                    "upload_id": upload_id,
+                    "chunk_index": chunk_index,
+                    "base64_data": base64.b64encode(chunk).decode("ascii"),
+                },
+            )
+
+        finish_response = await self._send_request(
+            APP_CMD_UPLOAD_MEDIA_FINISH,
+            {"upload_id": upload_id},
+        )
+        finish_body = finish_response.get("body") if isinstance(finish_response.get("body"), dict) else {}
+        media_id = str(finish_body.get("media_id") or "").strip()
+        if not media_id:
+            raise RuntimeError(f"media upload finish failed: missing media_id in response {finish_response}")
+        return finish_body
+
+    async def _send_media_message(
+        self,
+        chat_id: str,
+        media_type: str,
+        media_id: str,
+    ) -> dict[str, object]:
+        return await self._send_request(
+            APP_CMD_SEND,
+            {
+                "chatid": chat_id,
+                "msgtype": media_type,
+                media_type: {"media_id": media_id},
+            },
+        )
+
+    async def _send_reply_media_message(
+        self,
+        reply_req_id: str,
+        media_type: str,
+        media_id: str,
+    ) -> dict[str, object]:
+        return await self._send_reply_request(
+            reply_req_id,
+            {
+                "msgtype": media_type,
+                media_type: {"media_id": media_id},
+            },
+        )
+
+    def _metadata_media_requests(self, metadata: dict | None) -> list[dict[str, object]]:
+        if not isinstance(metadata, dict):
+            return []
+        raw_items = metadata.get("outbound_attachments")
+        if not isinstance(raw_items, list):
+            return []
+        requests: list[dict[str, object]] = []
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+            raw_path = str(
+                raw_item.get("path")
+                or raw_item.get("file_path")
+                or raw_item.get("local_path")
+                or ""
+            ).strip()
+            if not raw_path:
+                continue
+            requests.append(
+                {
+                    "path": raw_path,
+                    "type": str(raw_item.get("type") or "").strip().lower(),
+                    "force_file_attachment": bool(raw_item.get("force_file_attachment")),
+                }
+            )
+        return requests
+
+    @staticmethod
+    def _detect_outbound_media_type(
+        *,
+        local_path: Path,
+        attachment_type: str,
+        force_file_attachment: bool,
+    ) -> str:
+        if force_file_attachment or attachment_type == "file":
+            return "file"
+        if attachment_type in {"image", "video", "voice"}:
+            return attachment_type
+        mime_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
+        if mime_type.startswith("image/"):
+            return "image"
+        if mime_type.startswith("video/"):
+            return "video"
+        if mime_type.startswith("audio/"):
+            return "voice"
+        return "file"
+
+    @staticmethod
+    def _detect_outbound_media_type_from_content(
+        *,
+        content_type: str,
+        attachment_type: str,
+        force_file_attachment: bool,
+    ) -> str:
+        if force_file_attachment or attachment_type == "file":
+            return "file"
+        if attachment_type in {"image", "video", "voice"}:
+            return attachment_type
+        mime_type = str(content_type or "").strip().lower()
+        if mime_type.startswith("image/"):
+            return "image"
+        if mime_type.startswith("video/"):
+            return "video"
+        if mime_type.startswith("audio/") or mime_type == "application/ogg":
+            return "voice"
+        return "file"
+
+    @staticmethod
+    def _apply_file_size_limits(
+        *,
+        file_size: int,
+        detected_type: str,
+        content_type: str,
+    ) -> dict[str, object]:
+        file_size_mb = file_size / (1024 * 1024)
+        normalized_type = str(detected_type or "file").lower()
+        normalized_content_type = str(content_type or "").strip().lower()
+
+        if file_size > ABSOLUTE_MAX_BYTES:
+            return {
+                "final_type": normalized_type,
+                "rejected": True,
+                "reject_reason": (
+                    f"文件大小 {file_size_mb:.2f}MB 超过了企业微信允许的最大限制 20MB，无法发送。"
+                ),
+                "downgraded": False,
+                "downgrade_note": None,
+            }
+        if normalized_type == "image" and file_size > IMAGE_MAX_BYTES:
+            return {
+                "final_type": "file",
+                "rejected": False,
+                "reject_reason": None,
+                "downgraded": True,
+                "downgrade_note": f"图片大小 {file_size_mb:.2f}MB 超过 10MB 限制，已转为文件格式发送",
+            }
+        if normalized_type == "video" and file_size > VIDEO_MAX_BYTES:
+            return {
+                "final_type": "file",
+                "rejected": False,
+                "reject_reason": None,
+                "downgraded": True,
+                "downgrade_note": f"视频大小 {file_size_mb:.2f}MB 超过 10MB 限制，已转为文件格式发送",
+            }
+        if normalized_type == "voice":
+            if normalized_content_type and normalized_content_type not in VOICE_SUPPORTED_MIMES:
+                return {
+                    "final_type": "file",
+                    "rejected": False,
+                    "reject_reason": None,
+                    "downgraded": True,
+                    "downgrade_note": f"语音格式 {normalized_content_type} 不支持，企微仅支持 AMR 格式，已转为文件格式发送",
+                }
+            if file_size > VOICE_MAX_BYTES:
+                return {
+                    "final_type": "file",
+                    "rejected": False,
+                    "reject_reason": None,
+                    "downgraded": True,
+                    "downgrade_note": f"语音大小 {file_size_mb:.2f}MB 超过 2MB 限制，已转为文件格式发送",
+                }
+        return {
+            "final_type": normalized_type,
+            "rejected": False,
+            "reject_reason": None,
+            "downgraded": False,
+            "downgrade_note": None,
+        }
+
+    async def _cache_media(
+        self,
+        kind: str,
+        media: dict[str, Any],
+        *,
+        message_id: str,
+        item_index: int,
+    ) -> dict[str, Any] | None:
+        payload_b64 = str(media.get("base64") or "").strip()
+        if not payload_b64:
+            return None
+        try:
+            payload = base64.b64decode(payload_b64)
+        except Exception:
+            return None
+        if not payload:
+            return None
+
+        if kind == "image":
+            ext = self._detect_image_ext(payload)
+            mime_type = mimetypes.types_map.get(ext, "image/jpeg")
+            file_name = str(media.get("filename") or media.get("name") or f"image{ext}").strip() or f"image{ext}"
+        else:
+            file_name = str(media.get("filename") or media.get("name") or "wecom_file").strip() or "wecom_file"
+            mime_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
+
+        path = await asyncio.to_thread(
+            self._write_inbound_attachment,
+            message_id,
+            item_index,
+            file_name,
+            payload,
+        )
+        attachment = {
+            "type": kind,
+            "path": str(path),
+            "file_name": file_name,
+            "mime_type": mime_type,
+        }
+        media_entry = {
+            "kind": kind,
+            "local_path": str(path),
+            "file_name": file_name,
+            "mime_type": mime_type,
+            "size_bytes": len(payload),
+            "item_index": item_index,
+        }
+        data_url = build_image_data_url(payload, mime_type)
+        multimodal_part = {"type": "image_url", "image_url": {"url": data_url}} if data_url else None
+        return {
+            "attachment": attachment,
+            "wecom_media": media_entry,
+            "multimodal_part": multimodal_part,
+        }
+
+    def _write_inbound_attachment(
+        self,
+        message_id: str,
+        item_index: int,
+        file_name: str,
+        payload: bytes,
+    ) -> Path:
+        target_dir = (Path.cwd() / ".aworld" / "gateway" / "wecom" / "attachments" / sanitize_filename(self._bot_id)).resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        safe_message_id = sanitize_filename(message_id).replace(".", "_")
+        safe_name = sanitize_filename(file_name)
+        target_path = target_dir / f"{safe_message_id}_{item_index}_{safe_name}"
+        target_path.write_bytes(payload)
+        return target_path
+
+    @staticmethod
+    def _detect_image_ext(data: bytes) -> str:
+        if data.startswith(b"\x89PNG\r\n\x1a\n"):
+            return ".png"
+        if data.startswith(b"\xff\xd8\xff"):
+            return ".jpg"
+        if data.startswith((b"GIF87a", b"GIF89a")):
+            return ".gif"
+        if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+            return ".webp"
+        return ".jpg"
+
+    def _is_dm_allowed(self, sender_id: str) -> bool:
+        if self.config.dm_policy == "disabled":
+            return False
+        if self.config.dm_policy == "allowlist":
+            return sender_id in self.config.allow_from
+        return True
+
+    def _is_group_allowed(self, group_id: str) -> bool:
+        if self.config.group_policy == "disabled":
+            return False
+        if self.config.group_policy == "allowlist":
+            return group_id in self.config.group_allow_from
+        return True
+
+    @staticmethod
+    def _extract_text(body: dict[str, object]) -> str:
+        msgtype = str(body.get("msgtype") or "").lower()
+        text_parts: list[str] = []
+        if msgtype == "mixed":
+            mixed = body.get("mixed") if isinstance(body.get("mixed"), dict) else {}
+            items = mixed.get("msg_item") if isinstance(mixed.get("msg_item"), list) else []
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                if str(item.get("msgtype") or "").lower() != "text":
+                    continue
+                text_block = item.get("text") if isinstance(item.get("text"), dict) else {}
+                content = str(text_block.get("content") or "").strip()
+                if content:
+                    text_parts.append(content)
+            return "\n".join(text_parts).strip()
+
+        text_block = body.get("text") if isinstance(body.get("text"), dict) else {}
+        content = str(text_block.get("content") or "").strip()
+        if content:
+            text_parts.append(content)
+        if msgtype == "voice":
+            voice_block = body.get("voice") if isinstance(body.get("voice"), dict) else {}
+            voice_text = str(voice_block.get("content") or "").strip()
+            if voice_text:
+                text_parts.append(voice_text)
+        return "\n".join(text_parts).strip()
+
+    @staticmethod
+    def _payload_req_id(payload: dict[str, object]) -> str:
+        headers = payload.get("headers")
+        if isinstance(headers, dict):
+            return str(headers.get("req_id") or "")
+        return ""
+
+    @staticmethod
+    def _new_req_id(prefix: str) -> str:
+        return f"{prefix}-{uuid.uuid4().hex}"
+
+    @staticmethod
+    def _optional_env(name: str | None) -> str:
+        if not name:
+            return ""
+        return str(os.getenv(name, "")).strip()
+
+    def _required_env(self, name: str | None, error_message: str) -> str:
+        value = self._optional_env(name)
+        if value:
+            return value
+        raise ValueError(error_message)
+
+    def _fail_pending_responses(self, exc: Exception) -> None:
+        for req_id, future in list(self._pending_responses.items()):
+            if not future.done():
+                future.set_exception(exc)
+            self._pending_responses.pop(req_id, None)
+
+
+def _parse_json(raw: Any) -> dict[str, object] | None:
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None

--- a/aworld_gateway/config/__init__.py
+++ b/aworld_gateway/config/__init__.py
@@ -8,6 +8,8 @@ from aworld_gateway.config.models import (
     PlaceholderChannelConfig,
     RouteRule,
     TelegramChannelConfig,
+    WechatChannelConfig,
+    WecomChannelConfig,
 )
 
 __all__ = [
@@ -20,4 +22,6 @@ __all__ = [
     "PlaceholderChannelConfig",
     "RouteRule",
     "TelegramChannelConfig",
+    "WechatChannelConfig",
+    "WecomChannelConfig",
 ]

--- a/aworld_gateway/config/loader.py
+++ b/aworld_gateway/config/loader.py
@@ -44,3 +44,11 @@ class GatewayConfigLoader:
         dingding = channels.get("dingding")
         if isinstance(dingding, dict):
             dingding.pop("implemented", None)
+
+        wechat = channels.get("wechat")
+        if isinstance(wechat, dict):
+            wechat.pop("implemented", None)
+
+        wecom = channels.get("wecom")
+        if isinstance(wecom, dict):
+            wecom.pop("implemented", None)

--- a/aworld_gateway/config/models.py
+++ b/aworld_gateway/config/models.py
@@ -34,6 +34,28 @@ class DingdingChannelConfig(BaseChannelConfig):
     workspace_dir: Optional[str] = None
 
 
+class WechatChannelConfig(BaseChannelConfig):
+    account_id_env: Optional[str] = "AWORLD_WECHAT_ACCOUNT_ID"
+    token_env: Optional[str] = "AWORLD_WECHAT_TOKEN"
+    base_url_env: Optional[str] = "AWORLD_WECHAT_BASE_URL"
+    cdn_base_url_env: Optional[str] = "AWORLD_WECHAT_CDN_BASE_URL"
+    dm_policy: Literal["open", "allowlist", "disabled"] = "open"
+    group_policy: Literal["open", "allowlist", "disabled"] = "disabled"
+    allow_from: list[str] = Field(default_factory=list)
+    group_allow_from: list[str] = Field(default_factory=list)
+    split_multiline_messages: bool = False
+
+
+class WecomChannelConfig(BaseChannelConfig):
+    bot_id_env: Optional[str] = "AWORLD_WECOM_BOT_ID"
+    secret_env: Optional[str] = "AWORLD_WECOM_SECRET"
+    websocket_url_env: Optional[str] = "AWORLD_WECOM_WEBSOCKET_URL"
+    dm_policy: Literal["open", "allowlist", "disabled"] = "open"
+    group_policy: Literal["open", "allowlist", "disabled"] = "open"
+    allow_from: list[str] = Field(default_factory=list)
+    group_allow_from: list[str] = Field(default_factory=list)
+
+
 class PlaceholderChannelConfig(BaseChannelConfig):
     implemented: bool = Field(default=False, exclude=True)
 
@@ -42,8 +64,9 @@ class ChannelConfigMap(StrictConfigModel):
     web: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
     telegram: TelegramChannelConfig = Field(default_factory=TelegramChannelConfig)
     dingding: DingdingChannelConfig = Field(default_factory=DingdingChannelConfig)
+    wechat: WechatChannelConfig = Field(default_factory=WechatChannelConfig)
     feishu: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
-    wecom: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
+    wecom: WecomChannelConfig = Field(default_factory=WecomChannelConfig)
 
 
 class RouteRule(StrictConfigModel):

--- a/aworld_gateway/registry.py
+++ b/aworld_gateway/registry.py
@@ -11,11 +11,14 @@ from aworld_gateway.channels.dingding.adapter import DingdingChannelAdapter
 from aworld_gateway.channels.feishu.adapter import FeishuChannelAdapter
 from aworld_gateway.channels.telegram.adapter import TelegramChannelAdapter
 from aworld_gateway.channels.web.adapter import WebChannelAdapter
+from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
 from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
 from aworld_gateway.config import (
     BaseChannelConfig,
     DingdingChannelConfig,
     TelegramChannelConfig,
+    WechatChannelConfig,
+    WecomChannelConfig,
 )
 
 ChannelMetaSummary: TypeAlias = dict[str, object]
@@ -46,13 +49,18 @@ class ChannelRegistry:
                     label="DingTalk",
                     adapter_class=DingdingChannelAdapter,
                 ),
+                "wechat": ChannelRegistration(
+                    metadata=ChannelMetadata(name="wechat", implemented=True),
+                    label="WeChat",
+                    adapter_class=WechatChannelAdapter,
+                ),
                 "feishu": ChannelRegistration(
                     metadata=ChannelMetadata(name="feishu", implemented=False),
                     label="Feishu",
                     adapter_class=FeishuChannelAdapter,
                 ),
                 "wecom": ChannelRegistration(
-                    metadata=ChannelMetadata(name="wecom", implemented=False),
+                    metadata=ChannelMetadata(name="wecom", implemented=True),
                     label="WeCom",
                     adapter_class=WecomChannelAdapter,
                 ),
@@ -119,6 +127,24 @@ class ChannelRegistry:
                 return False
             return bool(os.getenv(config.client_id_env)) and bool(
                 os.getenv(config.client_secret_env)
+            )
+
+        if channel_id == "wechat":
+            if not isinstance(config, WechatChannelConfig):
+                return False
+            if not config.account_id_env or not config.token_env:
+                return False
+            return bool(os.getenv(config.account_id_env)) and bool(
+                os.getenv(config.token_env)
+            )
+
+        if channel_id == "wecom":
+            if not isinstance(config, WecomChannelConfig):
+                return False
+            if not config.bot_id_env or not config.secret_env:
+                return False
+            return bool(os.getenv(config.bot_id_env)) and bool(
+                os.getenv(config.secret_env)
             )
 
         return True

--- a/aworld_gateway/runtime.py
+++ b/aworld_gateway/runtime.py
@@ -5,6 +5,8 @@ import copy
 from aworld_gateway.channels.base import ChannelAdapter
 from aworld_gateway.config import DingdingChannelConfig
 from aworld_gateway.config import GatewayConfig
+from aworld_gateway.config import WechatChannelConfig
+from aworld_gateway.config import WecomChannelConfig
 from aworld_gateway.registry import ChannelRegistry
 
 
@@ -42,6 +44,18 @@ class GatewayRuntime:
             if (
                 channel_name == "dingding"
                 and isinstance(channel_config, DingdingChannelConfig)
+                and not channel_config.default_agent_id
+            ):
+                channel_config.default_agent_id = self._config.default_agent_id
+            if (
+                channel_name == "wechat"
+                and isinstance(channel_config, WechatChannelConfig)
+                and not channel_config.default_agent_id
+            ):
+                channel_config.default_agent_id = self._config.default_agent_id
+            if (
+                channel_name == "wecom"
+                and isinstance(channel_config, WecomChannelConfig)
                 and not channel_config.default_agent_id
             ):
                 channel_config.default_agent_id = self._config.default_agent_id

--- a/openspec/changes/wechat-channel-ilink/.openspec.yaml
+++ b/openspec/changes/wechat-channel-ilink/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/wechat-channel-ilink/design.md
+++ b/openspec/changes/wechat-channel-ilink/design.md
@@ -1,0 +1,262 @@
+## Context
+
+当前 `aworld_gateway` 已经形成了两层边界：
+
+- 公共控制平面：
+  - `config`
+  - `registry`
+  - `runtime`
+  - `router`
+  - `status`
+- channel 本地实现：
+  - `telegram` 采用较薄的 webhook + final-text 适配
+  - `dingding` 已经演化成 channel-local subsystem
+
+从参考实现 `/Users/wuman/Documents/workspace/hermes-agent/gateway/platforms/weixin.py` 和 `/Users/wuman/Documents/workspace/hermes-agent/gateway/platforms/wecom.py` 来看，个人微信与企业微信的差异非常大：
+
+- `weixin`:
+  - `getupdates` 长轮询
+  - 每个 peer 需要缓存最新 `context_token`
+  - 出站回复通常要回传该 token
+  - 可选 QR 登录与账号恢复
+  - 平台不支持消息编辑，发送侧采用 final-only
+- `wecom`:
+  - WebSocket 订阅和 callback
+  - `req_id` 关联响应
+  - 群聊主动发送受限
+  - media upload 分块流程
+
+因此，本次 change 不应尝试定义一个同时覆盖 `weixin` 和 `wecom` 的统一微信实现模型。正确边界是：
+
+- `wechat` 独立作为个人微信 channel
+- `wecom` 继续保留为企业微信 channel
+- 二者只在必要处共享极小 helper
+
+## Goals / Non-Goals
+
+**Goals**
+
+- 为 gateway 增加一个可运行的 `wechat` channel。
+- 明确 `wechat` 的公共命名和 `weixin / iLink` 的协议来源之间的关系。
+- 在不扩大回归面的前提下复用现有 gateway 控制平面。
+- 第一阶段跑通文本消息闭环、长轮询、`context_token` 缓存与回传。
+- 用 OpenSpec 固化 `wechat` 与 `wecom` 的边界，避免后续实现把两者重新揉成一个 channel。
+
+**Non-Goals**
+
+- 不把 `wechat` 和 `wecom` 合并成一个统一 `wx` channel。
+- 不把 `wechat` channel 直接内嵌进 `aworld-cli acp` 的 stdio host 进程。
+- 不在第一阶段实现全局流式 `GatewayRouter` 重构。
+- 不在第一阶段承诺完整媒体上传/下载闭环。
+- 不在第一阶段要求 QR 登录 CLI 命令面。
+- 不在本 change 中顺手完成 `wecom` 的完整实现。
+
+## Decisions
+
+### Decision: Public channel naming uses `wechat`, while protocol details remain `weixin / iLink`
+
+新增 channel 的公共 id、目录名和 operator-facing 配置名统一使用 `wechat`，而底层协议说明保留为 `weixin / iLink Bot`。
+
+Why:
+
+- `wechat` / `wecom` 对 operator 更直观。
+- 公共层避免把具体 provider 实现名写死。
+- 后续若个人微信还有其他接入方式，不需要重命名 channel 抽象。
+
+Rejected alternatives:
+
+- 公共 channel id 直接使用 `weixin`
+  Rejected，因为会把协议实现名固化到公共抽象层。
+- 用一个总的 `wx` channel 再在内部细分
+  Rejected，因为公共抽象会比真实能力边界更模糊。
+
+### Decision: `wechat` and `wecom` remain independent channels
+
+虽然两者都属于微信生态，但它们在连接方式、发送限制、会话模型和账号形态上都不同，必须保持两个独立 channel。
+
+Why:
+
+- `weixin` 是 poll + token state 模型。
+- `wecom` 是 websocket + correlated response 模型。
+- 把两者合并会让主 connector 和 state model 充满条件分支。
+
+Rejected alternatives:
+
+- 做一个统一的“微信 family”主实现
+  Rejected，因为共享面过小，不值得引入更高层的抽象复杂度。
+
+### Decision: Happy ACP and `wechat` coexist through two separate processes
+
+当用户同时希望通过 Happy ACP 和 `wechat` 访问同一套 AWorld 能力时，宿主方式固定为两个并行进程：
+
+- `aworld-cli acp`
+- `aworld-cli gateway server`
+
+二者可以共享同一套 agent 定义、同一台 worker host 和同一个仓库/workspace，但不应合并成单个混合宿主进程。
+
+Why:
+
+- `aworld-cli acp` 的 `stdout` 必须保持 JSON-RPC/NDJSON 协议纯净。
+- `wechat` 的 long-poll lifecycle 与 ACP session lifecycle 是两类不同宿主问题。
+- 将二者混在一个进程里会放大故障域并增加日志/生命周期耦合。
+
+Rejected alternatives:
+
+- 在 `aworld-cli acp` 进程内直接启动 `wechat` channel
+  Rejected，因为这会把 stdio backend host 和 channel runtime 混成一个失败域，并增加协议输出污染风险。
+
+### Decision: `wechat` uses a channel-local subsystem instead of a thin adapter
+
+`wechat` 不采用 `telegram` 那种薄 adapter 结构，而是参考 `dingding` 的边界，在 `aworld_gateway/channels/wechat/` 下收敛实现复杂度。
+
+推荐模块拆分：
+
+- `adapter.py`
+- `connector.py`
+- `account_store.py`
+- `context_token_store.py`
+- `transform.py`
+- `media.py`
+- 可选 `login.py`
+
+Why:
+
+- `weixin.py` 的核心复杂度在长轮询和 token 状态，而不是单个 API 调用。
+- 这些状态不应污染 `aworld_gateway/router.py` 或 `runtime.py`。
+
+Rejected alternatives:
+
+- 先把实现塞进一个单文件 adapter
+  Rejected，因为后续媒体、登录和 typing 很快会让文件失控。
+- 直接照搬 `telegram` 的 `handle_update -> router -> send`
+  Rejected，因为会丢失 `context_token` 和账号状态的主导地位。
+
+### Decision: Phase 1 keeps the current non-streaming `GatewayRouter` contract
+
+第一阶段继续沿用现有 `InboundEnvelope -> GatewayRouter -> OutboundEnvelope(final text)` contract，不先改造全局 streaming router。
+
+Why:
+
+- `hermes-agent` 的 `weixin.py` 明确设置 `SUPPORTS_MESSAGE_EDITING = False`。
+- 注释已说明 WeChat 平台侧发送要走 `send-final-only` 回退。
+- 因此先做文本闭环与 token 状态管理，收益远高于提前重构全局流式框架。
+
+Rejected alternatives:
+
+- 先为 `wechat` 引入 channel-specific 流式 router
+  Rejected，因为第一阶段目标只是对齐参考实现中的 final-only 平台发送特性。
+- 借 `wechat` 一次性推动整个 gateway 流式化
+  Rejected，因为会把局部 channel 扩展变成全局架构改造。
+
+### Decision: Phase 1 scope is limited to text delivery and required state caches
+
+第一阶段只冻结下列能力：
+
+- 文本消息入站
+- `getupdates` 长轮询
+- 基础 dedup
+- `context_token` 更新与回传
+- account/token/base_url 恢复
+- 文本分段发送
+- gateway config / registry / runtime / status 接入
+
+Deferred to later stages:
+
+- 入站图片/文件/语音下载
+- 出站媒体上传
+- typing ticket
+- QR 登录命令面
+- 更完整的 markdown / 富文本策略
+
+Why:
+
+- 这能最小化实现切片，并对齐当前 branch 的核心目标。
+- 媒体与登录都依赖更多平台细节，适合在文本闭环稳定后继续推进。
+
+## Configuration Model
+
+建议新增 `WechatChannelConfig`，第一阶段只包含最小字段：
+
+- `enabled`
+- `default_agent_id`
+- `account_id_env`
+- `token_env`
+- `base_url_env`
+- `cdn_base_url_env`
+- `dm_policy`
+- `group_policy`
+- `allow_from`
+- `group_allow_from`
+- `split_multiline_messages`
+
+`account_id / token / base_url` 的运行态恢复继续由 channel-local store 管理，不直接把持久状态写入 gateway config。
+
+## Phase Plan
+
+### Phase 1
+
+- 文本收发闭环
+- 长轮询 connector
+- `context_token` store
+- account restore
+- gateway runtime / registry / config / status 接入
+- 基础测试覆盖
+
+### Phase 2
+
+- 入站媒体下载
+- 出站媒体上传
+- typing ticket
+- 更精细文本拆分和富文本兼容
+
+当前这个 change 在不改 `GatewayRouter` 的前提下，进一步冻结了一个最小可行的 Phase 2 方案：
+
+- 入站图片/文件/视频/语音继续由 `wechat` connector 自己下载到 channel-local cache。
+- `InboundEnvelope` 不新增媒体字段，而是通过 `metadata.attachments` 和附加到 `text` 的 attachment prompt 暴露本地缓存路径。
+- 出站不消费通用 `metadata.attachments`，避免和 router 当前的 metadata 回传行为形成“收到什么就发回什么”的回环。
+- 出站媒体能力以显式本地引用为边界：markdown image、markdown link、`file://` / `attachment://` / `MEDIA:` 形式的引用会被解释为“发送附件”意图，其余普通文本不做自动文件提取。
+- 所有 `full_url` 型入站下载都必须经过 WeChat CDN allowlist 校验，避免 connector 退化成通用 URL 抓取器。
+
+### Phase 3
+
+- QR 登录
+- 运维命令面
+- 更复杂的群聊策略
+- 如有需要，再单独推进 `wecom` 实现 change
+
+## File Map
+
+Planned primary files:
+
+- `aworld_gateway/channels/wechat/__init__.py`
+- `aworld_gateway/channels/wechat/adapter.py`
+- `aworld_gateway/channels/wechat/connector.py`
+- `aworld_gateway/channels/wechat/account_store.py`
+- `aworld_gateway/channels/wechat/context_token_store.py`
+- `aworld_gateway/channels/wechat/transform.py`
+- `aworld_gateway/channels/wechat/media.py`
+- `aworld_gateway/config/models.py`
+- `aworld_gateway/config/__init__.py`
+- `aworld_gateway/config/loader.py`
+- `aworld_gateway/registry.py`
+- `aworld_gateway/runtime.py`
+- `tests/gateway/test_wechat_config.py`
+- `tests/gateway/test_wechat_adapter.py`
+- `tests/gateway/test_wechat_connector.py`
+- updates to existing `tests/gateway/test_registry.py` and `tests/gateway/test_runtime.py`
+
+## Risks / Trade-offs
+
+- [Config surface grows before full media support exists] -> 将 Phase 1 config 限定为文本闭环必需字段，避免预先暴露过多未实现选项。
+- [`wechat` and `wecom` may still want helper reuse later] -> 允许后续抽 helper，但当前不提前引入 family-level base class。
+- [Long-poll connector adds stateful failure modes] -> 将重试、dedup、token store 都限定在 `channels/wechat/` 内，不向 gateway 公共层泄漏。
+- [Later streaming work may revisit router shape] -> 在 design 中明确这是后续 change，而不是 Phase 1 的隐含依赖。
+- [Users may expect ACP and `wechat` to co-host in one process] -> 在 design 中显式冻结为双进程方案，避免后续实现误入混合宿主。
+
+## Migration Plan
+
+1. 在 gateway config/registry/runtime 中注册 `wechat`。
+2. 建立 `channels/wechat/` 子系统骨架。
+3. 先实现文本闭环与 `context_token` 状态管理。
+4. 补齐 gateway 测试和 `wechat` 子系统测试。
+5. 完成后再决定是否开启 Phase 2 媒体能力。

--- a/openspec/changes/wechat-channel-ilink/implementation-plan.md
+++ b/openspec/changes/wechat-channel-ilink/implementation-plan.md
@@ -1,0 +1,519 @@
+# WeChat Channel ILink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `wechat` gateway channel for personal WeChat / Weixin iLink Bot with long-poll intake, peer-scoped `context_token` reuse, final-text replies, and a minimal phase-2 media path without redesigning the global router.
+
+**Architecture:** Keep the existing gateway control plane (`config`, `registry`, `runtime`, `router`, `status`) stable and introduce a channel-local subsystem under `aworld_gateway/channels/wechat/`. Phase 1 covers config/env validation, credential restore, long-poll intake, message-to-envelope translation, token caching, and final-text outbound send. The current extension adds a minimal phase-2 media slice inside the same connector boundary: inbound media downloads to local cache paths, attachment prompts plus metadata for router compatibility, and outbound media upload triggered by explicit local file references in final text. Happy ACP coexistence remains a separate-process deployment concern and does not change the ACP host.
+
+**Tech Stack:** Python 3.10+, `asyncio`, `json`, `pathlib`, `pydantic`, `httpx` for Telegram only, optional `aiohttp` for WeChat long-poll/runtime sessions, existing `aworld_gateway` router/runtime models, `pytest`.
+
+---
+
+## File Structure
+
+### New implementation files
+
+- `aworld_gateway/channels/wechat/__init__.py`
+  Exports the WeChat adapter.
+- `aworld_gateway/channels/wechat/adapter.py`
+  Lifecycle wrapper that instantiates the connector and exposes `send()`.
+- `aworld_gateway/channels/wechat/account_store.py`
+  Loads and saves account credentials under `.aworld/gateway/wechat/`.
+- `aworld_gateway/channels/wechat/context_token_store.py`
+  Keeps the latest `context_token` by `account_id + peer_id`.
+- `aworld_gateway/channels/wechat/connector.py`
+  Owns polling, retry, dedup, inbound translation, and final-text outbound sending.
+- `tests/gateway/test_wechat_config.py`
+  Config model and loader compatibility coverage.
+- `tests/gateway/test_wechat_adapter.py`
+  Adapter lifecycle and send delegation.
+- `tests/gateway/test_wechat_connector.py`
+  Text-only connector behavior, token cache, and polling translation.
+
+### Existing files to modify
+
+- `aworld_gateway/config/models.py`
+  Add `WechatChannelConfig` and insert it into `ChannelConfigMap`.
+- `aworld_gateway/config/__init__.py`
+  Export `WechatChannelConfig`.
+- `aworld_gateway/config/loader.py`
+  Normalize any legacy `channels.wechat` placeholder-shaped payloads.
+- `aworld_gateway/registry.py`
+  Register `wechat`, label it, validate env-backed credentials, and build the adapter.
+- `aworld_gateway/runtime.py`
+  Allow `wechat` to inherit `default_agent_id` just like `dingding`.
+- `tests/gateway/test_config_loader.py`
+  Extend persisted default config expectations to include `wechat`.
+- `tests/gateway/test_registry.py`
+  Cover `wechat` list/implemented/configured behavior.
+- `tests/gateway/test_runtime.py`
+  Cover `wechat` degraded/running status.
+- `tests/gateway/test_gateway_status_command.py`
+  Ensure `wechat` appears in list/status responses.
+
+### Explicitly avoided files in phase 1
+
+- `aworld_gateway/router.py`
+- `aworld_gateway/types.py`
+- `aworld-cli/src/aworld_cli/acp/**`
+- `aworld_gateway/channels/wecom/**`
+
+The current router contract stays final-text only, and ACP coexistence remains a two-process deployment concern rather than an in-process integration change.
+
+---
+
+### Task 1: Register `wechat` In The Gateway Control Plane
+
+**Files:**
+- Modify: `aworld_gateway/config/models.py`
+- Modify: `aworld_gateway/config/__init__.py`
+- Modify: `aworld_gateway/config/loader.py`
+- Modify: `aworld_gateway/registry.py`
+- Modify: `aworld_gateway/runtime.py`
+- Modify: `tests/gateway/test_config_loader.py`
+- Modify: `tests/gateway/test_registry.py`
+- Modify: `tests/gateway/test_runtime.py`
+- Modify: `tests/gateway/test_gateway_status_command.py`
+- Create: `tests/gateway/test_wechat_config.py`
+
+- [ ] **Step 1: Write the failing control-plane tests**
+
+```python
+# tests/gateway/test_wechat_config.py
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import GatewayConfigLoader
+from aworld_gateway.config import WechatChannelConfig
+
+
+def test_wechat_config_defaults_are_text_phase_one_safe() -> None:
+    cfg = WechatChannelConfig()
+    assert cfg.enabled is False
+    assert cfg.account_id_env == "AWORLD_WECHAT_ACCOUNT_ID"
+    assert cfg.token_env == "AWORLD_WECHAT_TOKEN"
+    assert cfg.base_url_env == "AWORLD_WECHAT_BASE_URL"
+    assert cfg.cdn_base_url_env == "AWORLD_WECHAT_CDN_BASE_URL"
+    assert cfg.dm_policy == "open"
+    assert cfg.group_policy == "disabled"
+    assert cfg.split_multiline_messages is False
+
+
+def test_loader_persists_wechat_defaults(tmp_path: Path) -> None:
+    base_dir = tmp_path / "project"
+    base_dir.mkdir()
+    config = GatewayConfigLoader(base_dir=base_dir).load_or_init()
+    assert config.channels.wechat.enabled is False
+    config_path = base_dir / ".aworld" / "gateway" / "config.yaml"
+    with config_path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    assert raw["channels"]["wechat"]["enabled"] is False
+```
+
+```python
+# tests/gateway/test_registry.py
+def test_registry_lists_wechat_as_implemented_channel():
+    summary = ChannelRegistry().list_channels()
+    assert summary["wechat"]["implemented"] is True
+```
+
+```python
+# tests/gateway/test_runtime.py
+def test_runtime_start_degrades_when_enabled_wechat_is_not_configured(monkeypatch):
+    monkeypatch.delenv("AWORLD_WECHAT_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+    config = GatewayConfig()
+    config.channels.wechat.enabled = True
+    runtime = GatewayRuntime(config=config, registry=ChannelRegistry(), router=None)
+    asyncio.run(runtime.start())
+    status = runtime.status()
+    assert status["channels"]["wechat"]["state"] == "degraded"
+```
+
+- [ ] **Step 2: Run the targeted tests to verify `wechat` is missing**
+
+Run: `python -m pytest tests/gateway/test_wechat_config.py tests/gateway/test_registry.py tests/gateway/test_runtime.py tests/gateway/test_gateway_status_command.py -q`
+
+Expected: FAIL because `WechatChannelConfig` does not exist and registry/runtime do not know `wechat`.
+
+- [ ] **Step 3: Add `WechatChannelConfig` and wire it through config/registry/runtime**
+
+```python
+# aworld_gateway/config/models.py
+class WechatChannelConfig(BaseChannelConfig):
+    account_id_env: Optional[str] = "AWORLD_WECHAT_ACCOUNT_ID"
+    token_env: Optional[str] = "AWORLD_WECHAT_TOKEN"
+    base_url_env: Optional[str] = "AWORLD_WECHAT_BASE_URL"
+    cdn_base_url_env: Optional[str] = "AWORLD_WECHAT_CDN_BASE_URL"
+    dm_policy: Literal["open", "allowlist", "disabled"] = "open"
+    group_policy: Literal["open", "allowlist", "disabled"] = "disabled"
+    allow_from: list[str] = Field(default_factory=list)
+    group_allow_from: list[str] = Field(default_factory=list)
+    split_multiline_messages: bool = False
+
+
+class ChannelConfigMap(StrictConfigModel):
+    web: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
+    telegram: TelegramChannelConfig = Field(default_factory=TelegramChannelConfig)
+    dingding: DingdingChannelConfig = Field(default_factory=DingdingChannelConfig)
+    wechat: WechatChannelConfig = Field(default_factory=WechatChannelConfig)
+    feishu: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
+    wecom: PlaceholderChannelConfig = Field(default_factory=PlaceholderChannelConfig)
+```
+
+```python
+# aworld_gateway/registry.py
+from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+from aworld_gateway.config import WechatChannelConfig
+
+"wechat": ChannelRegistration(
+    metadata=ChannelMetadata(name="wechat", implemented=True),
+    label="WeChat",
+    adapter_class=WechatChannelAdapter,
+),
+
+if channel_id == "wechat":
+    if not isinstance(config, WechatChannelConfig):
+        return False
+    if not config.account_id_env or not config.token_env:
+        return False
+    return bool(os.getenv(config.account_id_env)) and bool(os.getenv(config.token_env))
+```
+
+- [ ] **Step 4: Update loader and status/list tests for the new channel**
+
+```python
+# aworld_gateway/config/loader.py
+wechat = channels.get("wechat")
+if isinstance(wechat, dict):
+    wechat.pop("implemented", None)
+```
+
+```python
+# tests/gateway/test_gateway_status_command.py
+assert set(rows) >= {"telegram", "web", "dingding", "wechat", "feishu", "wecom"}
+```
+
+- [ ] **Step 5: Run the control-plane tests and confirm they pass**
+
+Run: `python -m pytest tests/gateway/test_config_loader.py tests/gateway/test_wechat_config.py tests/gateway/test_registry.py tests/gateway/test_runtime.py tests/gateway/test_gateway_status_command.py -q`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the control-plane slice**
+
+```bash
+git add aworld_gateway/config/models.py aworld_gateway/config/__init__.py aworld_gateway/config/loader.py aworld_gateway/registry.py aworld_gateway/runtime.py tests/gateway/test_config_loader.py tests/gateway/test_wechat_config.py tests/gateway/test_registry.py tests/gateway/test_runtime.py tests/gateway/test_gateway_status_command.py
+git commit -m "feat: add wechat gateway control plane"
+```
+
+### Task 2: Add The WeChat Adapter, Account Store, And Context Token Store
+
+**Files:**
+- Create: `aworld_gateway/channels/wechat/__init__.py`
+- Create: `aworld_gateway/channels/wechat/adapter.py`
+- Create: `aworld_gateway/channels/wechat/account_store.py`
+- Create: `aworld_gateway/channels/wechat/context_token_store.py`
+- Create: `tests/gateway/test_wechat_adapter.py`
+
+- [ ] **Step 1: Write the failing adapter/store tests**
+
+```python
+# tests/gateway/test_wechat_adapter.py
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import WechatChannelConfig
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeConnector:
+    def __init__(self, *, config, router):
+        self.config = config
+        self.router = router
+        self.started = False
+        self.stopped = False
+        self.send_calls = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def send_text(self, *, chat_id: str, text: str, metadata: dict | None = None):
+        self.send_calls.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+
+def test_wechat_adapter_start_builds_connector():
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(WechatChannelConfig(), connector_cls=_FakeConnector)
+    asyncio.run(adapter.start())
+    assert adapter._connector is not None
+    assert adapter._connector.started is True
+
+
+def test_wechat_adapter_send_requires_started_connector():
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(WechatChannelConfig(), connector_cls=_FakeConnector)
+    with pytest.raises(RuntimeError, match="not started"):
+        asyncio.run(adapter.send(OutboundEnvelope(channel="wechat", account_id="wechat", conversation_id="peer-1", text="hello")))
+```
+
+- [ ] **Step 2: Run the adapter tests to verify the package does not exist yet**
+
+Run: `python -m pytest tests/gateway/test_wechat_adapter.py -q`
+
+Expected: FAIL with `ModuleNotFoundError` for `aworld_gateway.channels.wechat`.
+
+- [ ] **Step 3: Implement the adapter and stores**
+
+```python
+# aworld_gateway/channels/wechat/adapter.py
+class WechatChannelAdapter(ChannelAdapter):
+    def __init__(self, config: WechatChannelConfig | None = None, *, router: object | None = None, connector_cls: type[WechatConnector] = WechatConnector) -> None:
+        ...
+
+    @classmethod
+    def metadata(cls) -> ChannelMetadata:
+        return ChannelMetadata(name="wechat", implemented=True)
+
+    async def start(self) -> None:
+        self._connector = self._connector_cls(config=self._config, router=self._router)
+        await self._connector.start()
+
+    async def stop(self) -> None:
+        if self._connector is not None:
+            await self._connector.stop()
+
+    async def send(self, envelope: OutboundEnvelope):
+        if self._connector is None:
+            raise RuntimeError("WeChat channel adapter is not started.")
+        return await self._connector.send_text(chat_id=envelope.conversation_id, text=envelope.text, metadata=envelope.metadata)
+```
+
+```python
+# aworld_gateway/channels/wechat/account_store.py
+def load_account(root: Path, account_id: str) -> dict[str, str] | None: ...
+def save_account(root: Path, *, account_id: str, token: str, base_url: str, user_id: str = "") -> None: ...
+```
+
+```python
+# aworld_gateway/channels/wechat/context_token_store.py
+class ContextTokenStore:
+    def get(self, account_id: str, peer_id: str) -> str | None: ...
+    def set(self, account_id: str, peer_id: str, token: str) -> None: ...
+    def restore(self, account_id: str) -> None: ...
+```
+
+- [ ] **Step 4: Run the adapter tests and confirm the lifecycle slice passes**
+
+Run: `python -m pytest tests/gateway/test_wechat_adapter.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the adapter/store slice**
+
+```bash
+git add aworld_gateway/channels/wechat/__init__.py aworld_gateway/channels/wechat/adapter.py aworld_gateway/channels/wechat/account_store.py aworld_gateway/channels/wechat/context_token_store.py tests/gateway/test_wechat_adapter.py
+git commit -m "feat: add wechat adapter and token stores"
+```
+
+### Task 3: Implement The Phase-1 Text Connector
+
+**Files:**
+- Create: `aworld_gateway/channels/wechat/connector.py`
+- Create: `tests/gateway/test_wechat_connector.py`
+
+- [ ] **Step 1: Write the failing connector tests for text polling and token reuse**
+
+```python
+# tests/gateway/test_wechat_connector.py
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def handle_inbound(self, inbound, *, channel_default_agent_id):
+        self.calls.append((inbound, channel_default_agent_id))
+        return OutboundEnvelope(
+            channel="wechat",
+            account_id=inbound.account_id,
+            conversation_id=inbound.conversation_id,
+            reply_to_message_id=inbound.message_id,
+            text=f"echo:{inbound.text}",
+        )
+
+
+def test_connector_process_message_caches_context_token_and_routes_text(monkeypatch, tmp_path: Path):
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+    from aworld_gateway.config import WechatChannelConfig
+
+    router = _FakeRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    connector = WechatConnector(config=cfg, router=router, storage_root=tmp_path)
+    asyncio.run(connector.start())
+    asyncio.run(
+        connector._process_message(
+            {
+                "message_id": "m-1",
+                "from_user_id": "user-1",
+                "context_token": "ctx-1",
+                "item_list": [{"type": 1, "text_item": {"text": "ping"}}],
+            }
+        )
+    )
+    assert router.calls[0][0].text == "ping"
+    assert connector._token_store.get("wx-account", "user-1") == "ctx-1"
+
+
+def test_connector_send_text_reuses_latest_context_token(monkeypatch, tmp_path: Path):
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+    from aworld_gateway.config import WechatChannelConfig
+
+    seen = {}
+
+    async def fake_send_message(*, base_url, token, to, text, context_token, client_id, session):
+        seen.update(
+            {
+                "base_url": base_url,
+                "token": token,
+                "to": to,
+                "text": text,
+                "context_token": context_token,
+            }
+        )
+        return {"ret": 0}
+
+    cfg = WechatChannelConfig()
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+    connector = WechatConnector(config=cfg, router=None, storage_root=tmp_path, send_message_func=fake_send_message)
+    asyncio.run(connector.start())
+    connector._token_store.set("wx-account", "user-1", "ctx-9")
+    asyncio.run(connector.send_text(chat_id="user-1", text="pong"))
+    assert seen["context_token"] == "ctx-9"
+```
+
+- [ ] **Step 2: Run connector tests to verify the connector is still missing**
+
+Run: `python -m pytest tests/gateway/test_wechat_connector.py -q`
+
+Expected: FAIL with `ModuleNotFoundError` or missing attributes for `WechatConnector`.
+
+- [ ] **Step 3: Implement the text-only connector with injectable poll/send helpers**
+
+```python
+# aworld_gateway/channels/wechat/connector.py
+class WechatConnector:
+    ITEM_TEXT = 1
+    LONG_POLL_TIMEOUT_MS = 35_000
+
+    def __init__(..., storage_root: Path | None = None, get_updates_func=None, send_message_func=None) -> None:
+        ...
+
+    async def start(self) -> None:
+        self._account_id = self._required_env(self._config.account_id_env)
+        self._token = self._required_env(self._config.token_env)
+        self._base_url = self._optional_env(self._config.base_url_env, default="https://ilinkai.weixin.qq.com")
+        self._token_store.restore(self._account_id)
+
+    async def _process_message(self, message: dict[str, object]) -> None:
+        sender_id = str(message.get("from_user_id") or "").strip()
+        text = self._extract_text(message.get("item_list") or [])
+        context_token = str(message.get("context_token") or "").strip()
+        if context_token:
+            self._token_store.set(self._account_id, sender_id, context_token)
+        if not text or self._router is None:
+            return
+        outbound = await self._router.handle_inbound(...)
+        await self.send_text(chat_id=outbound.conversation_id, text=outbound.text, metadata=outbound.metadata)
+
+    async def send_text(self, *, chat_id: str, text: str, metadata: dict | None = None):
+        context_token = self._token_store.get(self._account_id, chat_id)
+        return await self._send_message_func(...)
+```
+
+- [ ] **Step 4: Run connector tests and the affected gateway suite**
+
+Run: `python -m pytest tests/gateway/test_wechat_connector.py tests/gateway/test_wechat_adapter.py tests/gateway/test_registry.py tests/gateway/test_runtime.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the connector slice**
+
+```bash
+git add aworld_gateway/channels/wechat/connector.py tests/gateway/test_wechat_connector.py
+git commit -m "feat: add wechat text polling connector"
+```
+
+### Task 4: Verify The OpenSpec Change And Gateway Regression Surface
+
+**Files:**
+- Modify: `openspec/changes/wechat-channel-ilink/tasks.md`
+- Modify: `openspec/changes/wechat-channel-ilink/implementation-plan.md`
+
+- [ ] **Step 1: Mark completed OpenSpec tasks inline as implementation progresses**
+
+```markdown
+- [x] 1.1 Add `WechatChannelConfig` to `aworld_gateway/config/models.py` and wire it into `ChannelConfigMap`.
+```
+
+- [ ] **Step 2: Run the full targeted gateway regression**
+
+Run: `python -m pytest tests/gateway/test_config_loader.py tests/gateway/test_wechat_config.py tests/gateway/test_wechat_adapter.py tests/gateway/test_wechat_connector.py tests/gateway/test_registry.py tests/gateway/test_runtime.py tests/gateway/test_gateway_status_command.py -q`
+
+Expected: PASS
+
+- [ ] **Step 3: Validate the OpenSpec change**
+
+Run: `openspec validate wechat-channel-ilink`
+
+Expected: `Change 'wechat-channel-ilink' is valid`
+
+- [ ] **Step 4: Commit the finished phase-1 slice**
+
+```bash
+git add openspec/changes/wechat-channel-ilink/tasks.md openspec/changes/wechat-channel-ilink/implementation-plan.md
+git commit -m "docs: track wechat phase one implementation progress"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers the OpenSpec proposal/design/tasks scope for phase-1 text delivery, long-poll intake, token caching, control-plane wiring, and targeted validation. Deferred media, typing, QR login, and `wecom` work are intentionally excluded.
+- Placeholder scan: No `TODO`/`TBD` placeholders remain in the plan steps. Deferred items are named explicitly as phase-two or phase-three work rather than left ambiguous.
+- Type consistency: The plan consistently uses `WechatChannelConfig`, `WechatChannelAdapter`, `WechatConnector`, `ContextTokenStore`, and the existing `InboundEnvelope` / `OutboundEnvelope` contracts. No later task renames these interfaces.

--- a/openspec/changes/wechat-channel-ilink/proposal.md
+++ b/openspec/changes/wechat-channel-ilink/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+`aworld_gateway` 当前已经有 `telegram` 和 `dingding` 两类 channel，但还没有个人微信能力。仓库里虽然保留了 `wecom` 占位 channel，实际个人微信与企业微信并不是同一种接入问题：
+
+- 个人微信在参考实现中走的是 Weixin iLink Bot 协议，核心是 `getupdates` 长轮询、`context_token` 回传、账号恢复和可选 QR 登录。
+- 企业微信在参考实现中走的是 WeCom AI Bot WebSocket 协议，核心是订阅握手、`req_id` 关联响应、群聊限制和上传会话。
+
+因此，这次扩展不能把两者合并成一个泛化但模糊的“微信 channel”。需要先把个人微信能力独立落成一个 `wechat` channel，并明确与 `wecom` 的边界。
+
+另外，参考 `hermes-agent` 的 `weixin.py` 可以确认一个关键事实：虽然运行时可产生流式文本，WeChat 平台侧并不支持消息编辑，实际发送路径采用 `send-final-only` 回退。因此本次第一阶段没有必要先把 `GatewayRouter` 改造成全局流式框架。
+
+## What Changes
+
+- 新增一个独立的 `wechat` channel，用于对接个人微信 / Weixin iLink Bot。
+- 明确 `wechat` 与 `wecom` 是两个独立 channel：
+  - `wechat` 负责个人微信
+  - `wecom` 负责企业微信
+  - 二者可以共享少量 helper，但不共享主 connector / state model
+- 明确当用户同时需要 Happy ACP 访问与 `wechat` channel 访问时，采用两个并行进程满足该诉求：
+  - `aworld-cli acp`
+  - `aworld-cli gateway server`
+  - 不要求把 `wechat` channel 直接内嵌进 ACP stdio host 进程
+- 在 gateway 公共层新增 `WechatChannelConfig`，并把 `wechat` 接入：
+  - `aworld_gateway/config/models.py`
+  - `aworld_gateway/config/__init__.py`
+  - `aworld_gateway/config/loader.py`
+  - `aworld_gateway/registry.py`
+  - `aworld_gateway/runtime.py`
+- 在 `aworld_gateway/channels/wechat/` 下实现 channel-local subsystem，而不是套用 `telegram` 式薄适配器。
+- 第一阶段保持现有 `GatewayRouter` 的单次入站 -> 最终文本回复 contract，不引入全局流式 router 改造。
+
+## Capabilities
+
+### New Capabilities
+
+- `wechat-channel`: Aworld gateway 可以作为个人微信 channel 运行，接收文本消息并返回最终文本回复。
+
+### Modified Capabilities
+
+- `gateway-channel-runtime`: gateway runtime、registry、status 和 config 能识别并管理新的 `wechat` channel。
+
+## Impact
+
+- Affected code:
+  - `aworld_gateway/config/`
+  - `aworld_gateway/registry.py`
+  - `aworld_gateway/runtime.py`
+  - `aworld_gateway/channels/wechat/`
+  - `tests/gateway/`
+- Affected behavior:
+  - `gateway status` / `channels list` 会出现 `wechat`
+  - `wechat` enabled 且配置完整时可启动长轮询 connector
+  - 文本消息可通过现有 router 进入默认 Aworld Agent 并返回最终文本回复
+- Constraints preserved:
+  - `wechat` 与 `wecom` 保持独立 channel
+  - Happy ACP 与 `wechat` 并存时采用两个进程，而不是单进程混合宿主
+  - 第一阶段不改全局 `GatewayRouter` 为流式框架
+  - 第一阶段不要求完整媒体闭环或 QR 登录命令面

--- a/openspec/changes/wechat-channel-ilink/specs/wechat-channel/spec.md
+++ b/openspec/changes/wechat-channel-ilink/specs/wechat-channel/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Gateway MUST expose `wechat` as a distinct personal-WeChat channel
+
+The gateway MUST register a `wechat` channel for personal WeChat access and MUST keep it distinct from the existing `wecom` enterprise channel.
+
+#### Scenario: Channel list shows separate personal and enterprise WeChat entries
+
+- **WHEN** an operator lists built-in gateway channels
+- **THEN** `wechat` MUST appear as a distinct channel entry
+- **AND** `wecom` MUST remain a separate channel entry
+- **AND** the design MUST NOT require a merged `wx` or shared primary connector abstraction
+
+### Requirement: `wechat` coexistence with Happy ACP MUST use separate host processes
+
+When users need both Happy ACP access and `wechat` channel access to the same AWorld deployment, the system MUST support that coexistence through separate host processes rather than a single mixed ACP+channel process.
+
+#### Scenario: Happy ACP and WeChat access are enabled for the same worker host
+
+- **WHEN** an operator wants the same AWorld deployment to be reachable from Happy ACP and from the `wechat` channel
+- **THEN** the supported host shape MUST be separate processes such as `aworld-cli acp` and `aworld-cli gateway server`
+- **AND** the design MUST NOT require embedding the `wechat` channel runtime directly into the ACP stdio host process
+
+### Requirement: `wechat` MUST use a channel-local stateful connector model
+
+The `wechat` channel MUST encapsulate its long-polling, token, and account state within a channel-local subsystem rather than spreading that state into gateway-wide routing components.
+
+#### Scenario: WeChat runtime state is required for message delivery
+
+- **WHEN** the `wechat` channel receives and replies to messages
+- **THEN** long-poll state, account credentials, and peer-scoped `context_token` state MUST be managed within `aworld_gateway/channels/wechat/`
+- **AND** the gateway-wide router contract MUST NOT become responsible for storing WeChat protocol state
+
+### Requirement: Phase-1 `wechat` delivery MUST preserve the current final-text router contract
+
+Phase 1 of the `wechat` channel MUST integrate with the existing `InboundEnvelope -> GatewayRouter -> OutboundEnvelope` final-text contract and MUST NOT require a gateway-wide streaming router redesign.
+
+#### Scenario: A WeChat text message is handled in phase 1
+
+- **WHEN** a text message arrives through the `wechat` connector
+- **THEN** the channel MUST translate it into an `InboundEnvelope`
+- **AND** the gateway router MUST produce a final `OutboundEnvelope`
+- **AND** the `wechat` channel MUST send the final text reply back to the platform
+- **AND** phase 1 MUST NOT depend on message-edit based streaming delivery
+
+### Requirement: `wechat` MUST retain the latest peer-scoped `context_token`
+
+The `wechat` channel MUST cache the latest `context_token` observed for a peer and MUST reuse that token on later outbound replies when the platform contract requires it.
+
+#### Scenario: Reply reuses the latest context token
+
+- **WHEN** an inbound `wechat` message from peer `P` contains a `context_token`
+- **THEN** the channel MUST update the cached token for that peer
+- **AND** a later outbound reply to `P` MUST include the latest cached token when available
+
+### Requirement: `wechat` MUST support phase-1 long-poll text intake without media parity
+
+Phase 1 of the `wechat` channel MUST support long-poll based text intake and final-text reply even if full media handling remains deferred.
+
+#### Scenario: Text-only phase-1 deployment
+
+- **WHEN** an operator enables and configures `wechat` with the required credentials
+- **THEN** the channel MUST be able to start its long-poll intake loop
+- **AND** text messages MUST be processed end-to-end
+- **AND** the absence of full media parity MUST NOT block phase-1 startup or text delivery
+
+### Requirement: `wechat` media intake MUST preserve the current envelope contract
+
+When inbound personal-WeChat messages contain media items, the channel MUST keep the gateway-wide `InboundEnvelope` schema unchanged while still surfacing the downloaded artifacts to downstream agents.
+
+#### Scenario: Inbound image or file message is received
+
+- **WHEN** a `wechat` inbound message contains image, file, video, or voice items
+- **THEN** the connector MUST download supported media into channel-local cache paths
+- **AND** the resulting `InboundEnvelope` MUST keep using the existing text-plus-metadata contract
+- **AND** the connector MUST surface the cached paths through attachment metadata and attachment prompt text rather than introducing a new gateway-wide media envelope type
+- **AND** the connector MUST expose a structured channel-local media metadata list for programmatic consumers
+- **AND** image attachments SHOULD additionally expose multimodal-friendly image parts in metadata so later multimodal routing work has a stable handoff shape
+
+### Requirement: `wechat` media download MUST restrict fetches to trusted WeChat CDN hosts
+
+Inbound media download helpers MUST reject untrusted remote hosts to avoid turning the connector into a general-purpose fetch primitive.
+
+#### Scenario: Media payload points at an untrusted host
+
+- **WHEN** a `wechat` media item resolves to a `full_url` outside the trusted WeChat CDN host allowlist
+- **THEN** the connector MUST refuse the download
+- **AND** the refusal MUST happen before any outbound network fetch is attempted for that URL
+
+### Requirement: `wechat` outbound media MUST support explicit local file references
+
+The final-text router contract remains unchanged, but outbound `wechat` replies MUST be able to turn explicit local media references into native WeChat media messages.
+
+#### Scenario: Final reply includes a local image or file reference
+
+- **WHEN** the final outbound `wechat` text contains an explicit local media reference such as a markdown image, markdown link, or `file://` style marker
+- **THEN** the connector MUST resolve the local file path
+- **AND** the connector MUST upload the encrypted payload through the iLink media upload flow
+- **AND** the connector MUST send a native media item message to the peer
+- **AND** any remaining plain text MUST continue to be delivered through the existing final-text send path
+
+#### Scenario: Final reply carries media send intent through envelope events
+
+- **WHEN** the final outbound `wechat` reply includes media-oriented `OutboundEnvelope.events`
+- **THEN** the `wechat` adapter MUST translate those events into connector-local outbound attachment requests
+- **AND** event types such as `file` MUST be able to force file-attachment delivery even when the referenced path is an image
+- **AND** explicit event types such as `video` or `voice` MUST be able to override file-extension based media inference when the sender already knows the intended delivery type
+- **AND** this translation MUST remain channel-local rather than changing the gateway-wide router contract

--- a/openspec/changes/wechat-channel-ilink/tasks.md
+++ b/openspec/changes/wechat-channel-ilink/tasks.md
@@ -1,0 +1,33 @@
+## 1. Gateway Control Plane
+
+- [x] 1.1 Add `WechatChannelConfig` to `aworld_gateway/config/models.py` and wire it into `ChannelConfigMap`.
+- [x] 1.2 Export the new config model from `aworld_gateway/config/__init__.py`.
+- [x] 1.3 Update `aworld_gateway/config/loader.py` to normalize any legacy or placeholder-shaped `wechat` payloads safely.
+- [x] 1.4 Register `wechat` in `aworld_gateway/registry.py` with the correct implementation flag, label, adapter class, and configuration checks.
+- [x] 1.5 Extend `aworld_gateway/runtime.py` status behavior so `wechat` participates in enabled/configured/running/degraded state derivation.
+
+## 2. WeChat Channel Subsystem
+
+- [x] 2.1 Create `aworld_gateway/channels/wechat/` and add the adapter/connector/store module skeleton.
+- [x] 2.2 Implement account credential restore for `account_id / token / base_url` without putting runtime state into gateway config.
+- [x] 2.3 Implement `context_token` storage keyed by account + peer.
+- [x] 2.4 Implement `getupdates` long-poll intake with dedup, retry, and message-to-envelope translation.
+- [x] 2.5 Implement final-text outbound send that reuses the latest `context_token` when available.
+- [x] 2.6 Implement Phase 1 policy filtering for DM/group traffic and text chunk splitting behavior.
+
+## 3. Validation
+
+- [x] 3.1 Add `tests/gateway/test_wechat_config.py` for defaults and config-loader behavior.
+- [x] 3.2 Add `tests/gateway/test_wechat_adapter.py` for lifecycle and send-path behavior.
+- [x] 3.3 Add `tests/gateway/test_wechat_connector.py` for long-poll intake, dedup, token caching, and final send behavior.
+- [x] 3.4 Extend `tests/gateway/test_registry.py` and `tests/gateway/test_runtime.py` to cover `wechat`.
+- [x] 3.5 Validate the OpenSpec change with `openspec validate wechat-channel-ilink`.
+
+## 4. Phase-2 Media Support
+
+- [x] 4.1 Add `aworld_gateway/channels/wechat/media.py` for CDN URL validation, AES helpers, and explicit local-media reference parsing.
+- [x] 4.2 Extend `aworld_gateway/channels/wechat/connector.py` to download inbound image/file/video/voice payloads into local attachment cache paths and surface them through attachment prompts plus metadata.
+- [x] 4.3 Extend outbound `wechat` send flow to detect explicit local media references, upload ciphertext through iLink CDN, and send media items without redesigning the gateway-wide router contract.
+- [x] 4.4 Extend `tests/gateway/test_wechat_connector.py` to cover inbound media download, CDN allowlist rejection, and outbound local image upload behavior.
+- [x] 4.5 Extend `aworld_gateway/channels/wechat/adapter.py` and send-path tests so `OutboundEnvelope.events` can express outbound attachment intent, including forced file-attachment delivery for image paths and explicit `video/voice` type overrides.
+- [x] 4.6 Extend inbound `wechat` media translation so metadata includes both compatibility attachments and a richer `wechat_media` / `multimodal_parts` structure for later multimodal consumers.

--- a/openspec/changes/wecom-channel-ws/design.md
+++ b/openspec/changes/wecom-channel-ws/design.md
@@ -1,0 +1,61 @@
+## Context
+
+企业微信 `wecom` 与个人微信 `wechat` 的协议模型不同：
+
+- `wechat`：poll + `context_token`
+- `wecom`：WebSocket + `req_id`
+
+因此 `wecom` 必须保持独立 channel 与独立 connector。
+
+## Decisions
+
+### Decision: `wecom` 保持 channel-local WebSocket 生命周期与协议状态
+
+当前范围：
+
+- WebSocket 建链与订阅握手
+- 入站文本回调到 `InboundEnvelope`
+- `req_id` 关联回复
+- 主动文本发送
+- DM / group 基础策略
+- 应用层心跳
+- 断线后的 connector-local 重连
+- 入站图片/文件缓存
+- 出站本地媒体上传与媒体类型/大小限制
+
+Deferred：
+
+- 群级细粒度 sender allowlist
+
+### Decision: `wecom` 继续沿用 final-text router contract
+
+`GatewayRouter` 不改。`wecom` connector 负责：
+
+- callback -> `InboundEnvelope`
+- `OutboundEnvelope` -> markdown/text send
+- channel-local attachment intent -> native media upload/send + follow-up markdown
+
+### Decision: 测试使用 connector-local transport abstraction
+
+为避免测试直接依赖真实 WebSocket，connector 引入本地 transport 抽象：
+
+- `send_json(payload)`
+- `receive_json()`
+- `close()`
+- `closed`
+
+默认实现由 `aiohttp` 提供，测试用 fake transport 注入。
+
+## File Map
+
+- `aworld_gateway/config/models.py`
+- `aworld_gateway/config/__init__.py`
+- `aworld_gateway/config/loader.py`
+- `aworld_gateway/registry.py`
+- `aworld_gateway/runtime.py`
+- `aworld_gateway/channels/wecom/adapter.py`
+- `aworld_gateway/channels/wecom/connector.py`
+- `tests/gateway/test_wecom_config.py`
+- `tests/gateway/test_wecom_adapter.py`
+- `tests/gateway/test_wecom_connector.py`
+- updates to existing registry/runtime/config-loader tests

--- a/openspec/changes/wecom-channel-ws/proposal.md
+++ b/openspec/changes/wecom-channel-ws/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`aworld_gateway` 当前已经有个人微信 `wechat` channel，但企业微信 `wecom` 仍然只是占位实现。根据参考实现 `/Users/wuman/Documents/workspace/hermes-agent/gateway/platforms/wecom.py`，企业微信的接入模型与个人微信明显不同：
+
+- `wecom` 使用 WebSocket 长连接与 `req_id` 关联响应
+- 群聊发送依赖 reply-bound `req_id`
+- 平台能力边界、鉴权方式、发送限制都不应复用 `wechat`
+
+因此需要单独落一个 `wecom` channel change，而不是继续把企业微信能力塞进已有 `wechat` change。
+
+## What Changes
+
+- 新增 `WecomChannelConfig` 并接入 gateway control plane。
+- 将 `wecom` 从占位 channel 升级为已实现 channel。
+- 新增 `aworld_gateway/channels/wecom/connector.py`，实现企业微信 channel-local WebSocket 收发。
+- 支持：
+  - `aibot_subscribe` 鉴权握手
+  - `aibot_msg_callback` 入站文本回调
+  - `aibot_send_msg` 主动文本发送
+  - `aibot_respond_msg` reply-bound 文本发送
+  - `req_id` 关联与聊天级 fallback reply 缓存
+  - DM / group 基础策略过滤
+  - 入站图片/文件缓存与 metadata 挂载
+  - 出站本地媒体上传、类型/大小限制、必要时降级为 `file`
+  - 应用层心跳与断线重连
+
+## Non-Goals
+
+- 不在本 change 中抽象 `wechat` / `wecom` 共用微信 family base class。
+- 不改造 `GatewayRouter` 为流式。
+- 不在本 change 中实现更细粒度的群成员级 allowlist 规则。

--- a/openspec/changes/wecom-channel-ws/specs/wecom-channel/spec.md
+++ b/openspec/changes/wecom-channel-ws/specs/wecom-channel/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Gateway MUST expose `wecom` as a distinct enterprise-WeChat channel
+
+The gateway MUST register `wecom` as a separate channel from `wechat`.
+
+#### Scenario: Channel list distinguishes personal and enterprise WeChat
+
+- **WHEN** an operator lists built-in channels
+- **THEN** `wechat` and `wecom` MUST appear as distinct entries
+- **AND** `wecom` MUST NOT depend on the `wechat` connector implementation
+
+### Requirement: `wecom` MUST use a channel-local WebSocket connector
+
+The `wecom` channel MUST encapsulate its WebSocket session, pending request futures, and reply caches inside `aworld_gateway/channels/wecom/`.
+
+#### Scenario: Enterprise WeChat runtime state is needed
+
+- **WHEN** `wecom` starts and handles messages
+- **THEN** the WebSocket transport and `req_id` correlation state MUST stay inside the channel-local subsystem
+- **AND** gateway-wide routing code MUST NOT become responsible for WeCom protocol state
+
+#### Scenario: The live WebSocket session is interrupted
+
+- **WHEN** the active `wecom` WebSocket transport closes or raises a read error after startup
+- **THEN** the connector MUST fail outstanding pending request futures for the interrupted session
+- **AND** the connector MUST retry establishing a new subscribed WebSocket session with connector-local backoff
+- **AND** after reconnection, new inbound callbacks and outbound sends MUST use the replacement transport without requiring gateway-wide router changes
+
+#### Scenario: The session stays idle
+
+- **WHEN** the `wecom` connector remains connected but otherwise idle
+- **THEN** the connector MUST periodically send application-level `ping` frames to keep the session alive
+
+### Requirement: `wecom` phase-1 delivery MUST preserve the current final-text router contract
+
+Phase 1 of the `wecom` channel MUST integrate with the existing `InboundEnvelope -> GatewayRouter -> OutboundEnvelope` final-text contract.
+
+#### Scenario: A text callback is handled in phase 1
+
+- **WHEN** a text callback arrives through the `wecom` connector
+- **THEN** the channel MUST translate it into an `InboundEnvelope`
+- **AND** the gateway router MUST produce a final `OutboundEnvelope`
+- **AND** the channel MUST send the final text reply back through the WeCom gateway
+
+### Requirement: `wecom` MUST support reply-bound text sends via cached `req_id`
+
+The channel MUST remember callback `req_id` values so replies can be correlated to prior inbound callbacks.
+
+#### Scenario: Reply uses cached callback `req_id`
+
+- **WHEN** an inbound `wecom` callback is accepted for routing
+- **THEN** the channel MUST cache the callback `req_id` for the message and chat
+- **AND** a later outbound reply SHOULD use the cached `req_id` when available
+
+### Requirement: `wecom` phase-1 MUST support basic DM and group policy filtering
+
+Phase 1 of `wecom` MUST support DM and group enablement rules before routing inbound callbacks.
+
+#### Scenario: Group traffic is disabled
+
+- **WHEN** an inbound callback comes from a group chat and the configured group policy is `disabled`
+- **THEN** the connector MUST drop the callback before invoking the router
+
+### Requirement: `wecom` inbound media MUST preserve the current envelope contract
+
+When enterprise-WeChat callbacks contain image or file content, the connector MUST keep using the current text-plus-metadata envelope contract.
+
+#### Scenario: Inbound image or file callback is received
+
+- **WHEN** a `wecom` callback carries image or file payloads
+- **THEN** the connector MUST cache supported media into a channel-local attachments directory under `.aworld/gateway/wecom/attachments/<bot_id>/`
+- **AND** the resulting `InboundEnvelope` MUST keep using the existing text-plus-metadata contract
+- **AND** the connector MUST expose compatibility attachment metadata, structured `wecom_media` metadata, and image-oriented `multimodal_parts` when applicable
+- **AND** if no user text exists, the connector MUST still be able to route the message using an attachment prompt derived from the cached files
+
+### Requirement: `wecom` outbound media MUST support channel-local attachment intent without changing the router contract
+
+Outbound enterprise-WeChat media sending MUST stay behind the channel-local adapter and connector boundary.
+
+#### Scenario: Final reply includes outbound attachment intent
+
+- **WHEN** a final outbound `wecom` reply carries channel-local attachment intent through `OutboundEnvelope.events` or `metadata.outbound_attachments`
+- **THEN** the `wecom` adapter MUST translate events into connector-local outbound attachment requests
+- **AND** the connector MUST load the referenced local file, upload it through `aibot_upload_media_init/chunk/finish`, and send the resulting native media message
+- **AND** if reply-correlated `req_id` state is available, the media send SHOULD use reply-bound delivery
+- **AND** any remaining text MUST continue to be deliverable as a follow-up markdown message without changing the gateway-wide router contract
+
+#### Scenario: Outbound media exceeds native type limits but can still be sent as a file
+
+- **WHEN** an outbound `wecom` attachment is classified as `image`, `video`, or `voice`
+- **AND** the file violates the native media constraints but still fits within the general file limit
+- **THEN** the connector MUST downgrade the send to native `file` delivery instead of failing immediately
+- **AND** the connector MUST send a follow-up markdown note that explains the downgrade reason
+- **AND** voice content that is not AMR MUST be treated as unsupported native voice and downgraded to `file`
+
+#### Scenario: Outbound media exceeds the absolute upload limit
+
+- **WHEN** an outbound `wecom` attachment is larger than the maximum file upload size supported by the channel
+- **THEN** the connector MUST reject the media before starting the upload handshake
+- **AND** the connector MUST return an error result for the send attempt
+- **AND** the connector MUST send a follow-up markdown note that explains the size limit failure

--- a/openspec/changes/wecom-channel-ws/tasks.md
+++ b/openspec/changes/wecom-channel-ws/tasks.md
@@ -1,0 +1,25 @@
+## 1. Gateway Control Plane
+
+- [x] 1.1 Add `WecomChannelConfig` and wire it into `ChannelConfigMap`.
+- [x] 1.2 Export the config model and normalize legacy `wecom` payloads in the loader.
+- [x] 1.3 Register `wecom` as implemented and validate env-backed credentials in the registry.
+- [x] 1.4 Extend runtime default-agent inheritance and status coverage for `wecom`.
+
+## 2. WeCom Channel Subsystem
+
+- [x] 2.1 Replace the placeholder adapter with an implemented adapter backed by a connector.
+- [x] 2.2 Add a minimal WebSocket connector with subscribe handshake, callback intake, and correlated responses.
+- [x] 2.3 Implement phase-1 text send with reply-bound and proactive fallback paths.
+- [x] 2.4 Implement DM/group policy filtering and dedup for inbound callbacks.
+- [x] 2.5 Implement phase-2 inbound image/file caching into `.aworld/gateway/wecom/attachments/<bot_id>/` and surface attachment / structured media / multimodal metadata without changing `InboundEnvelope`.
+- [x] 2.6 Implement phase-2 outbound local media upload/send using channel-local attachment intent, upload-media websocket commands, and follow-up markdown delivery for remaining text.
+- [x] 2.7 Enforce outbound media size/type limits, including downgrade-to-file behavior and pre-upload rejection for oversize payloads.
+- [x] 2.8 Add application heartbeat and connector-local reconnect handling for interrupted WebSocket sessions.
+
+## 3. Validation
+
+- [x] 3.1 Add `tests/gateway/test_wecom_config.py`.
+- [x] 3.2 Add `tests/gateway/test_wecom_adapter.py`.
+- [x] 3.3 Add `tests/gateway/test_wecom_connector.py`.
+- [x] 3.4 Update registry/runtime/config-loader tests for `wecom`.
+- [x] 3.5 Validate with `openspec validate wecom-channel-ws`.

--- a/tests/gateway/test_config_loader.py
+++ b/tests/gateway/test_config_loader.py
@@ -32,6 +32,8 @@ def test_load_or_init_creates_default_config_when_missing(tmp_path):
     assert raw["gateway"]["public_base_url"] is None
     assert raw["channels"]["telegram"]["enabled"] is False
     assert raw["channels"]["web"]["enabled"] is False
+    assert raw["channels"]["wechat"]["enabled"] is False
+    assert raw["channels"]["wecom"]["enabled"] is False
 
 
 def test_load_or_init_persists_public_base_url_default(tmp_path):
@@ -66,6 +68,8 @@ def test_load_or_init_preserves_existing_config(tmp_path):
             "    enabled: false\n"
             "  dingding:\n"
             "    enabled: false\n"
+            "  wechat:\n"
+            "    enabled: false\n"
             "  feishu:\n"
             "    enabled: false\n"
             "  wecom:\n"
@@ -99,6 +103,8 @@ def test_load_or_init_rejects_unknown_config_keys(tmp_path):
             "    enabled: false\n"
             "  dingding:\n"
             "    enabled: false\n"
+            "  wechat:\n"
+            "    enabled: false\n"
             "  feishu:\n"
             "    enabled: false\n"
             "  wecom:\n"
@@ -130,6 +136,8 @@ def test_load_or_init_ignores_legacy_empty_telegram_bot_token_field(tmp_path):
             "    enabled: false\n"
             "  dingding:\n"
             "    enabled: false\n"
+            "  wechat:\n"
+            "    enabled: false\n"
             "  feishu:\n"
             "    enabled: false\n"
             "  wecom:\n"
@@ -141,3 +149,36 @@ def test_load_or_init_ignores_legacy_empty_telegram_bot_token_field(tmp_path):
     config = GatewayConfigLoader(base_dir=base_dir).load_or_init()
 
     assert config.channels.telegram.bot_token_env == "AWORLD_TELEGRAM_BOT_TOKEN"
+
+
+def test_load_or_init_ignores_legacy_wecom_implemented_field(tmp_path):
+    base_dir = tmp_path / "project"
+    config_path = base_dir / ".aworld" / "gateway" / "config.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        (
+            "default_agent_id: aworld\n"
+            "gateway:\n"
+            "  host: 127.0.0.1\n"
+            "  port: 18888\n"
+            "channels:\n"
+            "  telegram:\n"
+            "    enabled: false\n"
+            "  web:\n"
+            "    enabled: false\n"
+            "  dingding:\n"
+            "    enabled: false\n"
+            "  wechat:\n"
+            "    enabled: false\n"
+            "  feishu:\n"
+            "    enabled: false\n"
+            "  wecom:\n"
+            "    enabled: false\n"
+            "    implemented: false\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = GatewayConfigLoader(base_dir=base_dir).load_or_init()
+
+    assert config.channels.wecom.enabled is False

--- a/tests/gateway/test_gateway_status_command.py
+++ b/tests/gateway/test_gateway_status_command.py
@@ -27,6 +27,10 @@ def test_gateway_status_reports_default_agent_and_channel_flags(
     assert status["channels"]["telegram"]["implemented"] is True
     assert status["channels"]["dingding"]["enabled"] is False
     assert status["channels"]["dingding"]["implemented"] is True
+    assert status["channels"]["wechat"]["enabled"] is False
+    assert status["channels"]["wechat"]["implemented"] is True
+    assert status["channels"]["wecom"]["enabled"] is False
+    assert status["channels"]["wecom"]["implemented"] is True
     assert status["channels"]["web"]["implemented"] is False
 
 
@@ -35,11 +39,15 @@ def test_gateway_channels_list_contains_placeholder_channels(
 ) -> None:
     rows = handle_gateway_channels_list(base_dir=tmp_path)
 
-    assert set(rows) >= {"telegram", "web", "dingding", "feishu", "wecom"}
+    assert set(rows) >= {"telegram", "web", "dingding", "wechat", "feishu", "wecom"}
     assert rows["telegram"]["enabled"] is False
     assert rows["telegram"]["implemented"] is True
     assert rows["dingding"]["enabled"] is False
     assert rows["dingding"]["implemented"] is True
+    assert rows["wechat"]["enabled"] is False
+    assert rows["wechat"]["implemented"] is True
+    assert rows["wecom"]["enabled"] is False
+    assert rows["wecom"]["implemented"] is True
     assert rows["web"]["implemented"] is False
 
 

--- a/tests/gateway/test_registry.py
+++ b/tests/gateway/test_registry.py
@@ -10,6 +10,8 @@ from aworld_gateway.config import (
     DingdingChannelConfig,
     PlaceholderChannelConfig,
     TelegramChannelConfig,
+    WechatChannelConfig,
+    WecomChannelConfig,
 )
 from aworld_gateway.registry import ChannelRegistry
 
@@ -20,14 +22,17 @@ def test_list_channels_reports_phase_one_builtins_with_implementation_flags():
     assert summary["telegram"]["implemented"] is True
     assert summary["web"]["implemented"] is False
     assert summary["dingding"]["implemented"] is True
+    assert summary["wechat"]["implemented"] is True
     assert summary["feishu"]["implemented"] is False
-    assert summary["wecom"]["implemented"] is False
+    assert summary["wecom"]["implemented"] is True
 
 
 def test_registry_exposes_metadata_and_adapter_class_paths():
     registry = ChannelRegistry()
     telegram_meta = registry.get_meta("telegram")
     dingding_meta = registry.get_meta("dingding")
+    wechat_meta = registry.get_meta("wechat")
+    wecom_meta = registry.get_meta("wecom")
     web_meta = registry.get_meta("web")
 
     assert telegram_meta is not None
@@ -49,6 +54,20 @@ def test_registry_exposes_metadata_and_adapter_class_paths():
     assert issubclass(dingding_adapter_cls, ChannelAdapter)
     assert dingding_adapter_cls.metadata().implemented is True
 
+    assert wechat_meta is not None
+    assert wechat_meta["implemented"] is True
+    wechat_adapter_cls = registry.get_adapter_class("wechat")
+    assert wechat_adapter_cls is not None
+    assert issubclass(wechat_adapter_cls, ChannelAdapter)
+    assert wechat_adapter_cls.metadata().implemented is True
+
+    assert wecom_meta is not None
+    assert wecom_meta["implemented"] is True
+    wecom_adapter_cls = registry.get_adapter_class("wecom")
+    assert wecom_adapter_cls is not None
+    assert issubclass(wecom_adapter_cls, ChannelAdapter)
+    assert wecom_adapter_cls.metadata().implemented is True
+
 
 def test_registry_validates_channel_configuration(monkeypatch):
     registry = ChannelRegistry()
@@ -56,10 +75,16 @@ def test_registry_validates_channel_configuration(monkeypatch):
     monkeypatch.delenv("AWORLD_TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_ID", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_SECRET", raising=False)
 
     assert registry.is_configured("web", PlaceholderChannelConfig()) is True
     assert registry.is_configured("telegram", TelegramChannelConfig()) is False
     assert registry.is_configured("dingding", DingdingChannelConfig()) is False
+    assert registry.is_configured("wechat", WechatChannelConfig()) is False
+    assert registry.is_configured("wecom", WecomChannelConfig()) is False
     assert registry.is_configured("unknown", PlaceholderChannelConfig()) is False
 
     monkeypatch.setenv("CUSTOM_TELEGRAM_TOKEN", "env-token")
@@ -76,3 +101,15 @@ def test_registry_validates_channel_configuration(monkeypatch):
 
     monkeypatch.setenv("AWORLD_DINGTALK_CLIENT_SECRET", "ding-secret")
     assert registry.is_configured("dingding", DingdingChannelConfig()) is True
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wechat-account")
+    assert registry.is_configured("wechat", WechatChannelConfig()) is False
+
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wechat-token")
+    assert registry.is_configured("wechat", WechatChannelConfig()) is True
+
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "wecom-bot")
+    assert registry.is_configured("wecom", WecomChannelConfig()) is False
+
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "wecom-secret")
+    assert registry.is_configured("wecom", WecomChannelConfig()) is True

--- a/tests/gateway/test_runtime.py
+++ b/tests/gateway/test_runtime.py
@@ -16,6 +16,10 @@ def test_runtime_status_is_initialized_before_start(monkeypatch):
     monkeypatch.delenv("AWORLD_TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_ID", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_SECRET", raising=False)
 
     runtime = GatewayRuntime(
         config=GatewayConfig(),
@@ -27,6 +31,8 @@ def test_runtime_status_is_initialized_before_start(monkeypatch):
     assert status["state"] == "registered"
     assert status["channels"]["telegram"]["state"] == "registered"
     assert status["channels"]["dingding"]["state"] == "registered"
+    assert status["channels"]["wechat"]["state"] == "registered"
+    assert status["channels"]["wecom"]["state"] == "registered"
     assert status["channels"]["web"]["state"] == "registered"
 
 
@@ -51,6 +57,10 @@ def test_runtime_start_reports_registered_channels_when_no_channels_enabled(
     monkeypatch.delenv("AWORLD_TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_ID", raising=False)
     monkeypatch.delenv("AWORLD_DINGTALK_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_SECRET", raising=False)
 
     runtime = GatewayRuntime(
         config=GatewayConfig(),
@@ -77,6 +87,16 @@ def test_runtime_start_reports_registered_channels_when_no_channels_enabled(
     assert status["channels"]["dingding"]["implemented"] is True
     assert status["channels"]["dingding"]["running"] is False
     assert status["channels"]["dingding"]["state"] == "registered"
+    assert status["channels"]["wechat"]["enabled"] is False
+    assert status["channels"]["wechat"]["configured"] is False
+    assert status["channels"]["wechat"]["implemented"] is True
+    assert status["channels"]["wechat"]["running"] is False
+    assert status["channels"]["wechat"]["state"] == "registered"
+    assert status["channels"]["wecom"]["enabled"] is False
+    assert status["channels"]["wecom"]["configured"] is False
+    assert status["channels"]["wecom"]["implemented"] is True
+    assert status["channels"]["wecom"]["running"] is False
+    assert status["channels"]["wecom"]["state"] == "registered"
 
     asyncio.run(runtime.stop())
     stopped_status = runtime.status()
@@ -129,6 +149,64 @@ def test_runtime_start_degrades_when_enabled_dingding_is_not_configured(
     assert status["channels"]["dingding"]["state"] == "degraded"
     assert (
         status["channels"]["dingding"]["error"]
+        == "Channel is enabled but not configured enough to start."
+    )
+
+
+def test_runtime_start_degrades_when_enabled_wechat_is_not_configured(
+    monkeypatch,
+):
+    monkeypatch.delenv("AWORLD_WECHAT_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+
+    config = GatewayConfig()
+    config.channels.wechat.enabled = True
+    runtime = GatewayRuntime(
+        config=config,
+        registry=ChannelRegistry(),
+        router=None,
+    )
+
+    asyncio.run(runtime.start())
+
+    status = runtime.status()
+    assert status["state"] == "degraded"
+    assert status["channels"]["wechat"]["enabled"] is True
+    assert status["channels"]["wechat"]["configured"] is False
+    assert status["channels"]["wechat"]["implemented"] is True
+    assert status["channels"]["wechat"]["running"] is False
+    assert status["channels"]["wechat"]["state"] == "degraded"
+    assert (
+        status["channels"]["wechat"]["error"]
+        == "Channel is enabled but not configured enough to start."
+    )
+
+
+def test_runtime_start_degrades_when_enabled_wecom_is_not_configured(
+    monkeypatch,
+):
+    monkeypatch.delenv("AWORLD_WECOM_BOT_ID", raising=False)
+    monkeypatch.delenv("AWORLD_WECOM_SECRET", raising=False)
+
+    config = GatewayConfig()
+    config.channels.wecom.enabled = True
+    runtime = GatewayRuntime(
+        config=config,
+        registry=ChannelRegistry(),
+        router=None,
+    )
+
+    asyncio.run(runtime.start())
+
+    status = runtime.status()
+    assert status["state"] == "degraded"
+    assert status["channels"]["wecom"]["enabled"] is True
+    assert status["channels"]["wecom"]["configured"] is False
+    assert status["channels"]["wecom"]["implemented"] is True
+    assert status["channels"]["wecom"]["running"] is False
+    assert status["channels"]["wecom"]["state"] == "degraded"
+    assert (
+        status["channels"]["wecom"]["error"]
         == "Channel is enabled but not configured enough to start."
     )
 

--- a/tests/gateway/test_wechat_adapter.py
+++ b/tests/gateway/test_wechat_adapter.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import WechatChannelConfig
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeConnector:
+    def __init__(self, *, config, router) -> None:
+        self.config = config
+        self.router = router
+        self.started = False
+        self.stopped = False
+        self.send_calls: list[tuple[str, str, dict | None]] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def send_text(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        metadata: dict | None = None,
+    ) -> dict[str, object]:
+        self.send_calls.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text, "metadata": metadata or {}}
+
+
+def test_wechat_adapter_metadata_reports_implemented_true() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    assert WechatChannelAdapter.metadata().implemented is True
+
+
+def test_wechat_adapter_start_builds_connector_and_starts() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    router = object()
+    config = WechatChannelConfig(default_agent_id="aworld")
+    adapter = WechatChannelAdapter(
+        config=config,
+        router=router,
+        connector_cls=_FakeConnector,
+    )
+
+    asyncio.run(adapter.start())
+
+    assert adapter._connector is not None
+    assert adapter._connector.config is config
+    assert adapter._connector.router is router
+    assert adapter._connector.started is True
+
+
+def test_wechat_adapter_send_requires_started_connector() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(WechatChannelConfig(), connector_cls=_FakeConnector)
+
+    with pytest.raises(RuntimeError, match="not started"):
+        asyncio.run(
+            adapter.send(
+                OutboundEnvelope(
+                    channel="wechat",
+                    account_id="wechat",
+                    conversation_id="peer-1",
+                    text="hello",
+                )
+            )
+        )
+
+
+def test_wechat_adapter_send_delegates_to_connector() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(
+        WechatChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+
+    result = asyncio.run(
+        adapter.send(
+            OutboundEnvelope(
+                channel="wechat",
+                account_id="wechat",
+                conversation_id="peer-1",
+                text="reply text",
+                metadata={"source": "test"},
+            )
+        )
+    )
+
+    assert adapter._connector is not None
+    assert adapter._connector.send_calls == [("peer-1", "reply text", {"source": "test"})]
+    assert result == {"chat_id": "peer-1", "text": "reply text", "metadata": {"source": "test"}}
+
+
+def test_wechat_adapter_send_translates_media_events_into_outbound_attachments() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(
+        WechatChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+
+    result = asyncio.run(
+        adapter.send(
+            OutboundEnvelope(
+                channel="wechat",
+                account_id="wechat",
+                conversation_id="peer-1",
+                text="reply text",
+                metadata={"source": "test"},
+                events=[
+                    {"type": "image", "path": "/tmp/chart.png"},
+                    {"type": "file", "file_path": "/tmp/report.png"},
+                ],
+            )
+        )
+    )
+
+    assert adapter._connector is not None
+    assert adapter._connector.send_calls == [
+        (
+            "peer-1",
+            "reply text",
+            {
+                "source": "test",
+                "outbound_attachments": [
+                    {"path": "/tmp/chart.png", "type": "image", "force_file_attachment": False},
+                    {"path": "/tmp/report.png", "type": "file", "force_file_attachment": True},
+                ],
+            },
+        )
+    ]
+    assert result["metadata"]["outbound_attachments"][1]["force_file_attachment"] is True
+
+
+def test_wechat_adapter_send_preserves_explicit_video_and_voice_event_types() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(
+        WechatChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+
+    asyncio.run(
+        adapter.send(
+            OutboundEnvelope(
+                channel="wechat",
+                account_id="wechat",
+                conversation_id="peer-1",
+                text="reply text",
+                events=[
+                    {"type": "video", "path": "/tmp/movie.bin"},
+                    {"type": "voice", "path": "/tmp/audio.bin"},
+                ],
+            )
+        )
+    )
+
+    assert adapter._connector is not None
+    assert adapter._connector.send_calls == [
+        (
+            "peer-1",
+            "reply text",
+            {
+                "outbound_attachments": [
+                    {"path": "/tmp/movie.bin", "type": "video", "force_file_attachment": False},
+                    {"path": "/tmp/audio.bin", "type": "voice", "force_file_attachment": False},
+                ]
+            },
+        )
+    ]
+
+
+def test_wechat_adapter_stop_delegates_to_connector() -> None:
+    from aworld_gateway.channels.wechat.adapter import WechatChannelAdapter
+
+    adapter = WechatChannelAdapter(
+        WechatChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+    asyncio.run(adapter.stop())
+
+    assert adapter._connector is not None
+    assert adapter._connector.stopped is True
+
+
+def test_account_store_round_trips_credentials(tmp_path: Path) -> None:
+    from aworld_gateway.channels.wechat.account_store import load_account, save_account
+
+    save_account(
+        tmp_path,
+        account_id="wx-account",
+        token="wx-token",
+        base_url="https://ilink.example.test",
+        user_id="user-1",
+    )
+
+    payload = load_account(tmp_path, "wx-account")
+
+    assert payload is not None
+    assert payload["token"] == "wx-token"
+    assert payload["base_url"] == "https://ilink.example.test"
+    assert payload["user_id"] == "user-1"
+
+    raw = json.loads((tmp_path / "wx-account.json").read_text(encoding="utf-8"))
+    assert raw["token"] == "wx-token"
+
+
+def test_context_token_store_persists_latest_peer_token(tmp_path: Path) -> None:
+    from aworld_gateway.channels.wechat.context_token_store import ContextTokenStore
+
+    store = ContextTokenStore(tmp_path)
+    store.set("wx-account", "peer-1", "ctx-1")
+    store.set("wx-account", "peer-2", "ctx-2")
+
+    restored = ContextTokenStore(tmp_path)
+    restored.restore("wx-account")
+
+    assert restored.get("wx-account", "peer-1") == "ctx-1"
+    assert restored.get("wx-account", "peer-2") == "ctx-2"

--- a/tests/gateway/test_wechat_config.py
+++ b/tests/gateway/test_wechat_config.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import GatewayConfigLoader, WechatChannelConfig
+
+
+def test_wechat_config_defaults_are_text_phase_one_safe() -> None:
+    cfg = WechatChannelConfig()
+
+    assert cfg.enabled is False
+    assert cfg.account_id_env == "AWORLD_WECHAT_ACCOUNT_ID"
+    assert cfg.token_env == "AWORLD_WECHAT_TOKEN"
+    assert cfg.base_url_env == "AWORLD_WECHAT_BASE_URL"
+    assert cfg.cdn_base_url_env == "AWORLD_WECHAT_CDN_BASE_URL"
+    assert cfg.dm_policy == "open"
+    assert cfg.group_policy == "disabled"
+    assert cfg.allow_from == []
+    assert cfg.group_allow_from == []
+    assert cfg.split_multiline_messages is False
+
+
+def test_loader_persists_wechat_defaults(tmp_path: Path) -> None:
+    base_dir = tmp_path / "project"
+    base_dir.mkdir()
+
+    config = GatewayConfigLoader(base_dir=base_dir).load_or_init()
+    assert config.channels.wechat.enabled is False
+
+    config_path = base_dir / ".aworld" / "gateway" / "config.yaml"
+    with config_path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+
+    assert raw["channels"]["wechat"]["enabled"] is False

--- a/tests/gateway/test_wechat_connector.py
+++ b/tests/gateway/test_wechat_connector.py
@@ -1,0 +1,895 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import WechatChannelConfig
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, str | None]] = []
+
+    async def handle_inbound(self, inbound, *, channel_default_agent_id):
+        self.calls.append((inbound, channel_default_agent_id))
+        return OutboundEnvelope(
+            channel="wechat",
+            account_id=inbound.account_id,
+            conversation_id=inbound.conversation_id,
+            reply_to_message_id=inbound.message_id,
+            text=f"echo:{inbound.text}",
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_process_message_caches_context_token_and_routes_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(
+        config=cfg,
+        router=router,
+        storage_root=tmp_path,
+    )
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-1",
+            "from_user_id": "user-1",
+            "context_token": "ctx-1",
+            "item_list": [{"type": 1, "text_item": {"text": "ping"}}],
+        }
+    )
+
+    inbound, channel_default_agent_id = router.calls[0]
+    assert inbound.text == "ping"
+    assert inbound.conversation_id == "user-1"
+    assert channel_default_agent_id == "aworld"
+    assert connector._token_store.get("wx-account", "user-1") == "ctx-1"
+    assert sent == [("user-1", "echo:ping", {})]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_reuses_latest_context_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    seen: dict[str, object] = {}
+
+    async def fake_send_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        text: str,
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        seen.update(
+            {
+                "session": session,
+                "base_url": base_url,
+                "token": token,
+                "to": to,
+                "text": text,
+                "context_token": context_token,
+                "client_id": client_id,
+            }
+        )
+        return {"ret": 0, "client_id": client_id}
+
+    cfg = WechatChannelConfig()
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+    connector = WechatConnector(
+        config=cfg,
+        router=None,
+        storage_root=tmp_path,
+        send_message_func=fake_send_message,
+    )
+    await connector.start()
+    connector._token_store.set("wx-account", "user-1", "ctx-9")
+
+    result = await connector.send_text(chat_id="user-1", text="pong")
+
+    assert seen["base_url"] == "https://ilink.example.test"
+    assert seen["token"] == "wx-token"
+    assert seen["to"] == "user-1"
+    assert seen["text"] == "pong"
+    assert seen["context_token"] == "ctx-9"
+    assert isinstance(seen["client_id"], str)
+    assert result["client_id"] == seen["client_id"]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_requires_started_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    cfg = WechatChannelConfig()
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(config=cfg, router=None, storage_root=tmp_path)
+
+    with pytest.raises(RuntimeError, match="not started"):
+        await connector.send_text(chat_id="user-1", text="pong")
+
+
+@pytest.mark.asyncio
+async def test_connector_skips_group_message_when_group_policy_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld", group_policy="disabled")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=cfg,
+        router=router,
+        storage_root=tmp_path,
+    )
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-group",
+            "from_user_id": "user-1",
+            "room_id": "group-1",
+            "item_list": [{"type": 1, "text_item": {"text": "ping"}}],
+        }
+    )
+
+    assert router.calls == []
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_split_multiline_messages_sends_multiple_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    calls: list[tuple[str, str | None]] = []
+
+    async def fake_send_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        text: str,
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        calls.append((text, context_token))
+        return {"ret": 0, "client_id": client_id}
+
+    cfg = WechatChannelConfig(split_multiline_messages=True)
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=cfg,
+        router=None,
+        storage_root=tmp_path,
+        send_message_func=fake_send_message,
+    )
+    await connector.start()
+    connector._token_store.set("wx-account", "user-1", "ctx-1")
+
+    await connector.send_text(chat_id="user-1", text="line1\nline2\n\nline3")
+
+    assert calls == [("line1", "ctx-1"), ("line2", "ctx-1"), ("line3", "ctx-1")]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_start_launches_poll_loop_and_processes_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    updates_called = 0
+    processed: list[str] = []
+
+    async def fake_get_updates(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        sync_buf: str,
+        timeout_ms: int,
+    ) -> dict[str, object]:
+        nonlocal updates_called
+        updates_called += 1
+        if updates_called == 1:
+            return {
+                "ret": 0,
+                "get_updates_buf": "buf-1",
+                "msgs": [
+                    {
+                        "message_id": "m-1",
+                        "from_user_id": "user-1",
+                        "item_list": [{"type": 1, "text_item": {"text": "poll"}}],
+                    }
+                ],
+            }
+        await asyncio.sleep(0.01)
+        return {"ret": 0, "get_updates_buf": "buf-1", "msgs": []}
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+        get_updates_func=fake_get_updates,
+    )
+
+    async def fake_process_message(message: dict[str, object]) -> None:
+        processed.append(str(message["message_id"]))
+        connector.started = False
+
+    connector._process_message = fake_process_message  # type: ignore[method-assign]
+    await connector.start()
+    await asyncio.sleep(0.05)
+    await connector.stop()
+
+    assert updates_called >= 1
+    assert processed == ["m-1"]
+
+
+@pytest.mark.asyncio
+async def test_connector_start_restores_persisted_token_and_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.account_store import save_account
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    save_account(
+        tmp_path,
+        account_id="wx-account",
+        token="persisted-token",
+        base_url="https://persisted.example.test",
+        user_id="user-1",
+    )
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.delenv("AWORLD_WECHAT_TOKEN", raising=False)
+    monkeypatch.delenv("AWORLD_WECHAT_BASE_URL", raising=False)
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+    )
+    await connector.start()
+
+    assert connector._account_id == "wx-account"
+    assert connector._token == "persisted-token"
+    assert connector._base_url == "https://persisted.example.test"
+
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_default_send_message_posts_ilink_payload_with_context_token() -> None:
+    from aworld_gateway.channels.wechat.connector import _default_send_message
+
+    calls: dict[str, object] = {}
+
+    class _FakeResponse:
+        ok = True
+        status = 200
+
+        async def text(self) -> str:
+            return '{"ret":0,"msg":"ok"}'
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeSession:
+        def post(self, url: str, *, data: str, headers: dict[str, str], timeout):
+            calls["url"] = url
+            calls["data"] = data
+            calls["headers"] = headers
+            calls["timeout"] = timeout
+            return _FakeResponse()
+
+    result = await _default_send_message(
+        session=_FakeSession(),
+        base_url="https://ilink.example.test",
+        token="wx-token",
+        to="user-1",
+        text="pong",
+        context_token="ctx-1",
+        client_id="client-1",
+    )
+
+    assert calls["url"] == "https://ilink.example.test/ilink/bot/sendmessage"
+    assert '"context_token":"ctx-1"' in str(calls["data"])
+    assert '"to_user_id":"user-1"' in str(calls["data"])
+    assert calls["headers"]["Authorization"] == "Bearer wx-token"
+    assert result["ret"] == 0
+
+
+@pytest.mark.asyncio
+async def test_default_get_updates_returns_empty_payload_on_timeout() -> None:
+    from aworld_gateway.channels.wechat.connector import _default_get_updates
+
+    class _TimeoutSession:
+        def post(self, *args, **kwargs):
+            raise asyncio.TimeoutError
+
+    result = await _default_get_updates(
+        session=_TimeoutSession(),
+        base_url="https://ilink.example.test",
+        token="wx-token",
+        sync_buf="buf-1",
+        timeout_ms=1234,
+    )
+
+    assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-1"}
+
+
+@pytest.mark.asyncio
+async def test_connector_process_message_downloads_image_attachment_and_routes_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    async def fake_download_media(
+        *,
+        session,
+        cdn_base_url: str,
+        encrypted_query_param: str | None,
+        aes_key_b64: str | None,
+        full_url: str | None,
+        timeout_seconds: float,
+    ) -> bytes:
+        del session, cdn_base_url, encrypted_query_param, aes_key_b64, full_url, timeout_seconds
+        return b"image-bytes"
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(
+        config=cfg,
+        router=router,
+        storage_root=tmp_path,
+        download_media_func=fake_download_media,
+    )
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-image",
+            "from_user_id": "user-1",
+            "item_list": [
+                {
+                    "type": 2,
+                    "image_item": {
+                        "media": {
+                            "encrypt_query_param": "eqp-1",
+                            "aes_key": base64.b64encode(b"0123456789abcdef").decode("ascii"),
+                        }
+                    },
+                }
+            ],
+        }
+    )
+
+    inbound, _channel_default_agent_id = router.calls[0]
+    assert inbound.text.startswith("Attachments:")
+    assert len(inbound.metadata["attachments"]) == 1
+    attachment = inbound.metadata["attachments"][0]
+    assert attachment["type"] == "image"
+    attachment_path = Path(attachment["path"])
+    assert attachment_path.exists() is True
+    assert attachment_path.read_bytes() == b"image-bytes"
+    assert inbound.metadata["wechat_media"] == [
+        {
+            "kind": "image",
+            "local_path": str(attachment_path),
+            "file_name": "image.jpg",
+            "mime_type": "image/jpeg",
+            "size_bytes": len(b"image-bytes"),
+            "item_index": 0,
+        }
+    ]
+    assert len(inbound.metadata["multimodal_parts"]) == 1
+    assert inbound.metadata["multimodal_parts"][0]["type"] == "image_url"
+    assert str(inbound.metadata["multimodal_parts"][0]["image_url"]["url"]).startswith(
+        "data:image/jpeg;base64,"
+    )
+    assert sent == [("user-1", inbound.text.replace("Attachments:", "echo:Attachments:", 1), {})]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_process_message_builds_structured_file_metadata_without_multimodal_parts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    async def fake_download_media(
+        *,
+        session,
+        cdn_base_url: str,
+        encrypted_query_param: str | None,
+        aes_key_b64: str | None,
+        full_url: str | None,
+        timeout_seconds: float,
+    ) -> bytes:
+        del session, cdn_base_url, encrypted_query_param, aes_key_b64, full_url, timeout_seconds
+        return b"file-bytes"
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(default_agent_id="aworld"),
+        router=router,
+        storage_root=tmp_path,
+        download_media_func=fake_download_media,
+    )
+    connector.send_text = lambda **kwargs: asyncio.sleep(0, result=kwargs)  # type: ignore[method-assign]
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-file",
+            "from_user_id": "user-1",
+            "item_list": [
+                {
+                    "type": 4,
+                    "file_item": {
+                        "file_name": "report.txt",
+                        "media": {
+                            "encrypt_query_param": "eqp-1",
+                            "aes_key": base64.b64encode(b"0123456789abcdef").decode("ascii"),
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+    inbound, _channel_default_agent_id = router.calls[0]
+    assert inbound.metadata["attachments"][0]["type"] == "file"
+    assert inbound.metadata["wechat_media"] == [
+        {
+            "kind": "file",
+            "local_path": inbound.metadata["attachments"][0]["path"],
+            "file_name": "report.txt",
+            "mime_type": "text/plain",
+            "size_bytes": len(b"file-bytes"),
+            "item_index": 0,
+        }
+    ]
+    assert inbound.metadata.get("multimodal_parts") == []
+    await connector.stop()
+
+
+def test_assert_wechat_cdn_url_rejects_untrusted_host() -> None:
+    from aworld_gateway.channels.wechat.media import assert_wechat_cdn_url
+
+    with pytest.raises(ValueError, match="allowlist"):
+        assert_wechat_cdn_url("https://evil.example.test/file.bin")
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_uploads_markdown_local_image_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    image_path = tmp_path / "chart.png"
+    image_path.write_bytes(b"png-bytes")
+
+    text_messages: list[str] = []
+    media_messages: list[dict[str, object]] = []
+    upload_calls: list[dict[str, object]] = []
+    get_upload_calls: list[dict[str, object]] = []
+
+    async def fake_send_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        text: str,
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        text_messages.append(text)
+        return {"ret": 0, "client_id": client_id}
+
+    async def fake_get_upload_url(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to_user_id: str,
+        media_type: int,
+        filekey: str,
+        rawsize: int,
+        rawfilemd5: str,
+        filesize: int,
+        aeskey_hex: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to_user_id, rawfilemd5, aeskey_hex
+        get_upload_calls.append(
+            {
+                "media_type": media_type,
+                "filekey": filekey,
+                "rawsize": rawsize,
+                "filesize": filesize,
+            }
+        )
+        return {"upload_param": "upload-token"}
+
+    async def fake_upload_ciphertext(
+        *,
+        session,
+        ciphertext: bytes,
+        upload_url: str,
+    ) -> str:
+        del session
+        upload_calls.append({"ciphertext": ciphertext, "upload_url": upload_url})
+        return "encrypted-param-1"
+
+    async def fake_send_media_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        item: dict[str, object],
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        media_messages.append({"item": item, "client_id": client_id})
+        return {"ret": 0, "client_id": client_id}
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_CDN_BASE_URL", "https://cdn.example.test/c2c")
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+        send_message_func=fake_send_message,
+        get_upload_url_func=fake_get_upload_url,
+        upload_ciphertext_func=fake_upload_ciphertext,
+        send_media_message_func=fake_send_media_message,
+    )
+    await connector.start()
+    connector._token_store.set("wx-account", "user-1", "ctx-1")
+
+    result = await connector.send_text(
+        chat_id="user-1",
+        text=f"share ![chart](file://{image_path})",
+    )
+
+    assert text_messages == ["share"]
+    assert get_upload_calls[0]["media_type"] == 1
+    assert get_upload_calls[0]["rawsize"] == len(b"png-bytes")
+    assert upload_calls[0]["upload_url"] == "https://cdn.example.test/c2c/upload?encrypted_query_param=upload-token&filekey=" + str(get_upload_calls[0]["filekey"])
+    assert media_messages[0]["item"]["type"] == 2
+    assert media_messages[0]["item"]["image_item"]["media"]["encrypt_query_param"] == "encrypted-param-1"
+    assert result["client_id"] == media_messages[0]["client_id"]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_honors_force_file_attachment_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    image_path = tmp_path / "chart.png"
+    image_path.write_bytes(b"png-bytes")
+
+    text_messages: list[str] = []
+    media_messages: list[dict[str, object]] = []
+
+    async def fake_send_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        text: str,
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        text_messages.append(text)
+        return {"ret": 0, "client_id": client_id}
+
+    async def fake_get_upload_url(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to_user_id: str,
+        media_type: int,
+        filekey: str,
+        rawsize: int,
+        rawfilemd5: str,
+        filesize: int,
+        aeskey_hex: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to_user_id, media_type, filekey, rawsize, rawfilemd5, filesize, aeskey_hex
+        return {"upload_param": "upload-token"}
+
+    async def fake_upload_ciphertext(
+        *,
+        session,
+        ciphertext: bytes,
+        upload_url: str,
+    ) -> str:
+        del session, ciphertext, upload_url
+        return "encrypted-param-1"
+
+    async def fake_send_media_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        item: dict[str, object],
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        media_messages.append({"item": item, "client_id": client_id})
+        return {"ret": 0, "client_id": client_id}
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+        send_message_func=fake_send_message,
+        get_upload_url_func=fake_get_upload_url,
+        upload_ciphertext_func=fake_upload_ciphertext,
+        send_media_message_func=fake_send_media_message,
+    )
+    await connector.start()
+
+    result = await connector.send_text(
+        chat_id="user-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{image_path}", "type": "file"},
+            ]
+        },
+    )
+
+    assert text_messages == []
+    assert media_messages[0]["item"]["type"] == 4
+    assert media_messages[0]["item"]["file_item"]["file_name"] == "chart.png"
+    assert result["client_id"] == media_messages[0]["client_id"]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_honors_explicit_video_attachment_type(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    video_like_path = tmp_path / "movie.bin"
+    video_like_path.write_bytes(b"video-bytes")
+
+    media_messages: list[dict[str, object]] = []
+
+    async def fake_get_upload_url(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to_user_id: str,
+        media_type: int,
+        filekey: str,
+        rawsize: int,
+        rawfilemd5: str,
+        filesize: int,
+        aeskey_hex: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to_user_id, filekey, rawsize, rawfilemd5, filesize, aeskey_hex
+        assert media_type == 2
+        return {"upload_param": "upload-token"}
+
+    async def fake_upload_ciphertext(
+        *,
+        session,
+        ciphertext: bytes,
+        upload_url: str,
+    ) -> str:
+        del session, ciphertext, upload_url
+        return "encrypted-param-1"
+
+    async def fake_send_media_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        item: dict[str, object],
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        media_messages.append({"item": item, "client_id": client_id})
+        return {"ret": 0, "client_id": client_id}
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+        get_upload_url_func=fake_get_upload_url,
+        upload_ciphertext_func=fake_upload_ciphertext,
+        send_media_message_func=fake_send_media_message,
+    )
+    await connector.start()
+
+    result = await connector.send_text(
+        chat_id="user-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{video_like_path}", "type": "video"},
+            ]
+        },
+    )
+
+    assert media_messages[0]["item"]["type"] == 5
+    assert media_messages[0]["item"]["video_item"]["media"]["encrypt_query_param"] == "encrypted-param-1"
+    assert result["client_id"] == media_messages[0]["client_id"]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_honors_explicit_voice_attachment_type(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    voice_like_path = tmp_path / "audio.bin"
+    voice_like_path.write_bytes(b"voice-bytes")
+
+    media_messages: list[dict[str, object]] = []
+
+    async def fake_get_upload_url(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to_user_id: str,
+        media_type: int,
+        filekey: str,
+        rawsize: int,
+        rawfilemd5: str,
+        filesize: int,
+        aeskey_hex: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to_user_id, filekey, rawsize, rawfilemd5, filesize, aeskey_hex
+        assert media_type == 4
+        return {"upload_param": "upload-token"}
+
+    async def fake_upload_ciphertext(
+        *,
+        session,
+        ciphertext: bytes,
+        upload_url: str,
+    ) -> str:
+        del session, ciphertext, upload_url
+        return "encrypted-param-1"
+
+    async def fake_send_media_message(
+        *,
+        session,
+        base_url: str,
+        token: str,
+        to: str,
+        item: dict[str, object],
+        context_token: str | None,
+        client_id: str,
+    ) -> dict[str, object]:
+        del session, base_url, token, to, context_token
+        media_messages.append({"item": item, "client_id": client_id})
+        return {"ret": 0, "client_id": client_id}
+
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=WechatChannelConfig(),
+        router=None,
+        storage_root=tmp_path,
+        get_upload_url_func=fake_get_upload_url,
+        upload_ciphertext_func=fake_upload_ciphertext,
+        send_media_message_func=fake_send_media_message,
+    )
+    await connector.start()
+
+    result = await connector.send_text(
+        chat_id="user-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{voice_like_path}", "type": "voice"},
+            ]
+        },
+    )
+
+    assert media_messages[0]["item"]["type"] == 3
+    assert media_messages[0]["item"]["voice_item"]["media"]["encrypt_query_param"] == "encrypted-param-1"
+    assert result["client_id"] == media_messages[0]["client_id"]
+    await connector.stop()

--- a/tests/gateway/test_wecom_adapter.py
+++ b/tests/gateway/test_wecom_adapter.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import WecomChannelConfig
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeConnector:
+    def __init__(self, *, config, router) -> None:
+        self.config = config
+        self.router = router
+        self.started = False
+        self.stopped = False
+        self.send_calls: list[tuple[str, str, str | None, dict | None]] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def send_text(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        reply_to_message_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> dict[str, object]:
+        self.send_calls.append((chat_id, text, reply_to_message_id, metadata))
+        return {
+            "chat_id": chat_id,
+            "text": text,
+            "reply_to_message_id": reply_to_message_id,
+            "metadata": metadata or {},
+        }
+
+
+def test_wecom_adapter_metadata_reports_implemented_true() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    assert WecomChannelAdapter.metadata().implemented is True
+
+
+def test_wecom_adapter_start_builds_connector_and_starts() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    router = object()
+    config = WecomChannelConfig(default_agent_id="aworld")
+    adapter = WecomChannelAdapter(
+        config=config,
+        router=router,
+        connector_cls=_FakeConnector,
+    )
+
+    asyncio.run(adapter.start())
+
+    assert adapter._connector is not None
+    assert adapter._connector.config is config
+    assert adapter._connector.router is router
+    assert adapter._connector.started is True
+
+
+def test_wecom_adapter_send_requires_started_connector() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    adapter = WecomChannelAdapter(WecomChannelConfig(), connector_cls=_FakeConnector)
+
+    with pytest.raises(RuntimeError, match="not started"):
+        asyncio.run(
+            adapter.send(
+                OutboundEnvelope(
+                    channel="wecom",
+                    account_id="wecom",
+                    conversation_id="chat-1",
+                    text="hello",
+                )
+            )
+        )
+
+
+def test_wecom_adapter_send_delegates_to_connector() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    adapter = WecomChannelAdapter(
+        WecomChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+
+    result = asyncio.run(
+        adapter.send(
+            OutboundEnvelope(
+                channel="wecom",
+                account_id="wecom",
+                conversation_id="chat-1",
+                reply_to_message_id="msg-1",
+                text="reply text",
+                metadata={"source": "test"},
+            )
+        )
+    )
+
+    assert adapter._connector is not None
+    assert adapter._connector.send_calls == [
+        ("chat-1", "reply text", "msg-1", {"source": "test"})
+    ]
+    assert result == {
+        "chat_id": "chat-1",
+        "text": "reply text",
+        "reply_to_message_id": "msg-1",
+        "metadata": {"source": "test"},
+    }
+
+
+def test_wecom_adapter_send_translates_media_events_into_outbound_attachments() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    adapter = WecomChannelAdapter(
+        WecomChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+
+    result = asyncio.run(
+        adapter.send(
+            OutboundEnvelope(
+                channel="wecom",
+                account_id="wecom",
+                conversation_id="chat-1",
+                text="reply text",
+                metadata={"source": "test"},
+                events=[
+                    {"type": "image", "path": "/tmp/chart.png"},
+                    {"type": "file", "file_path": "/tmp/report.txt"},
+                ],
+            )
+        )
+    )
+
+    assert adapter._connector is not None
+    assert adapter._connector.send_calls == [
+        (
+            "chat-1",
+            "reply text",
+            None,
+            {
+                "source": "test",
+                "outbound_attachments": [
+                    {"path": "/tmp/chart.png", "type": "image", "force_file_attachment": False},
+                    {"path": "/tmp/report.txt", "type": "file", "force_file_attachment": True},
+                ],
+            },
+        )
+    ]
+    assert result["metadata"]["outbound_attachments"][1]["force_file_attachment"] is True
+
+
+def test_wecom_adapter_stop_delegates_to_connector() -> None:
+    from aworld_gateway.channels.wecom.adapter import WecomChannelAdapter
+
+    adapter = WecomChannelAdapter(
+        WecomChannelConfig(),
+        connector_cls=_FakeConnector,
+    )
+    asyncio.run(adapter.start())
+    asyncio.run(adapter.stop())
+
+    assert adapter._connector is not None
+    assert adapter._connector.stopped is True

--- a/tests/gateway/test_wecom_config.py
+++ b/tests/gateway/test_wecom_config.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import GatewayConfigLoader
+from aworld_gateway.config import WecomChannelConfig
+
+
+def test_wecom_config_defaults_are_text_phase_one_safe() -> None:
+    cfg = WecomChannelConfig()
+
+    assert cfg.enabled is False
+    assert cfg.bot_id_env == "AWORLD_WECOM_BOT_ID"
+    assert cfg.secret_env == "AWORLD_WECOM_SECRET"
+    assert cfg.websocket_url_env == "AWORLD_WECOM_WEBSOCKET_URL"
+    assert cfg.dm_policy == "open"
+    assert cfg.group_policy == "open"
+
+
+def test_loader_persists_wecom_defaults(tmp_path: Path) -> None:
+    base_dir = tmp_path / "project"
+    base_dir.mkdir()
+
+    config = GatewayConfigLoader(base_dir=base_dir).load_or_init()
+
+    assert config.channels.wecom.enabled is False
+    config_path = base_dir / ".aworld" / "gateway" / "config.yaml"
+    with config_path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    assert raw["channels"]["wecom"]["enabled"] is False

--- a/tests/gateway/test_wecom_connector.py
+++ b/tests/gateway/test_wecom_connector.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from aworld_gateway.config import WecomChannelConfig
+from aworld_gateway.types import OutboundEnvelope
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, str | None]] = []
+
+    async def handle_inbound(self, inbound, *, channel_default_agent_id):
+        self.calls.append((inbound, channel_default_agent_id))
+        return OutboundEnvelope(
+            channel="wecom",
+            account_id=inbound.account_id,
+            conversation_id=inbound.conversation_id,
+            reply_to_message_id=inbound.message_id,
+            text=f"echo:{inbound.text}",
+        )
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.closed = False
+        self._queue: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+
+    async def send_json(self, payload: dict[str, object]) -> None:
+        self.sent.append(payload)
+        cmd = str(payload.get("cmd") or "")
+        headers = payload.get("headers") if isinstance(payload.get("headers"), dict) else {}
+        req_id = str(headers.get("req_id") or "")
+        if cmd in {
+            "aibot_subscribe",
+            "aibot_send_msg",
+            "aibot_respond_msg",
+            "aibot_upload_media_chunk",
+            "ping",
+        } and req_id:
+            self.feed({"cmd": f"{cmd}_ack", "headers": {"req_id": req_id}, "errcode": 0, "body": {}})
+        if cmd == "aibot_upload_media_init" and req_id:
+            self.feed(
+                {
+                    "cmd": "aibot_upload_media_init_ack",
+                    "headers": {"req_id": req_id},
+                    "errcode": 0,
+                    "body": {"upload_id": "upload-1"},
+                }
+            )
+        if cmd == "aibot_upload_media_finish" and req_id:
+            self.feed(
+                {
+                    "cmd": "aibot_upload_media_finish_ack",
+                    "headers": {"req_id": req_id},
+                    "errcode": 0,
+                    "body": {"media_id": "media-1", "type": "image"},
+                }
+            )
+
+    async def receive_json(self) -> dict[str, object]:
+        return await asyncio.wait_for(self._queue.get(), timeout=1.0)
+
+    def feed(self, payload: dict[str, object]) -> None:
+        self._queue.put_nowait(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FlakyTransport(_FakeTransport):
+    def __init__(self, *, fail_after_receives: int) -> None:
+        super().__init__()
+        self._receive_count = 0
+        self._fail_after_receives = fail_after_receives
+
+    async def receive_json(self) -> dict[str, object]:
+        self._receive_count += 1
+        if self._receive_count > self._fail_after_receives:
+            self.closed = True
+            raise RuntimeError("simulated websocket close")
+        return await super().receive_json()
+
+
+@pytest.mark.asyncio
+async def test_connector_start_performs_subscribe_handshake(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+    monkeypatch.setenv("AWORLD_WECOM_WEBSOCKET_URL", "wss://wecom.example.test/ws")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+
+    assert connector.started is True
+    assert transport.sent[0]["cmd"] == "aibot_subscribe"
+    assert transport.sent[0]["body"] == {
+        "bot_id": "bot-1",
+        "secret": "secret-1",
+    }
+
+    await connector.stop()
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_connector_processes_callback_routes_text_and_uses_reply_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    router = _FakeRouter()
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(default_agent_id="aworld"),
+        router=router,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    transport.feed(
+        {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-callback-1"},
+            "body": {
+                "msgid": "msg-1",
+                "chatid": "chat-1",
+                "chattype": "single",
+                "from": {"userid": "user-1"},
+                "msgtype": "text",
+                "text": {"content": "ping"},
+            },
+        }
+    )
+
+    await asyncio.sleep(0.05)
+
+    inbound, channel_default_agent_id = router.calls[0]
+    assert inbound.text == "ping"
+    assert inbound.conversation_id == "chat-1"
+    assert inbound.conversation_type == "dm"
+    assert channel_default_agent_id == "aworld"
+    assert connector._reply_req_ids["msg-1"] == "req-callback-1"
+    assert connector._last_chat_req_ids["chat-1"] == "req-callback-1"
+    assert transport.sent[-1]["cmd"] == "aibot_respond_msg"
+
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_uses_proactive_send_without_reply_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+
+    result = await connector.send_text(chat_id="chat-1", text="pong")
+
+    assert transport.sent[-1]["cmd"] == "aibot_send_msg"
+    assert result["errcode"] == 0
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_skips_group_message_when_group_policy_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    router = _FakeRouter()
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(default_agent_id="aworld", group_policy="disabled"),
+        router=router,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    transport.feed(
+        {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-group-1"},
+            "body": {
+                "msgid": "msg-1",
+                "chatid": "group-1",
+                "chattype": "group",
+                "from": {"userid": "user-1"},
+                "msgtype": "text",
+                "text": {"content": "ping"},
+            },
+        }
+    )
+
+    await asyncio.sleep(0.05)
+
+    assert router.calls == []
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_processes_image_callback_into_structured_media_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    router = _FakeRouter()
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    image_bytes = b"\x89PNG\r\n\x1a\nfake"
+    connector = WecomConnector(
+        config=WecomChannelConfig(default_agent_id="aworld"),
+        router=router,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    transport.feed(
+        {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-image-1"},
+            "body": {
+                "msgid": "msg-image-1",
+                "chatid": "chat-1",
+                "chattype": "single",
+                "from": {"userid": "user-1"},
+                "msgtype": "image",
+                "image": {"base64": base64.b64encode(image_bytes).decode("ascii")},
+            },
+        }
+    )
+
+    await asyncio.sleep(0.05)
+
+    inbound, _channel_default_agent_id = router.calls[0]
+    assert inbound.text.startswith("Attachments:")
+    assert inbound.metadata["attachments"][0]["type"] == "image"
+    image_path = Path(inbound.metadata["attachments"][0]["path"])
+    assert image_path.read_bytes() == image_bytes
+    assert inbound.metadata["wecom_media"] == [
+        {
+            "kind": "image",
+            "local_path": str(image_path),
+            "file_name": "image.png",
+            "mime_type": "image/png",
+            "size_bytes": len(image_bytes),
+            "item_index": 0,
+        }
+    ]
+    assert inbound.metadata["multimodal_parts"][0]["type"] == "image_url"
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_processes_file_callback_into_attachment_prompt_without_multimodal_parts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    router = _FakeRouter()
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    file_bytes = b"meeting notes"
+    connector = WecomConnector(
+        config=WecomChannelConfig(default_agent_id="aworld"),
+        router=router,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    transport.feed(
+        {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-file-1"},
+            "body": {
+                "msgid": "msg-file-1",
+                "chatid": "chat-1",
+                "chattype": "single",
+                "from": {"userid": "user-1"},
+                "msgtype": "file",
+                "file": {
+                    "name": "notes.txt",
+                    "base64": base64.b64encode(file_bytes).decode("ascii"),
+                },
+            },
+        }
+    )
+
+    await asyncio.sleep(0.05)
+
+    inbound, _channel_default_agent_id = router.calls[0]
+    assert inbound.text.startswith("Attachments:")
+    assert inbound.metadata["attachments"][0]["type"] == "file"
+    assert inbound.metadata["wecom_media"] == [
+        {
+            "kind": "file",
+            "local_path": inbound.metadata["attachments"][0]["path"],
+            "file_name": "notes.txt",
+            "mime_type": "text/plain",
+            "size_bytes": len(file_bytes),
+            "item_index": 0,
+        }
+    ]
+    assert inbound.metadata["multimodal_parts"] == []
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_uploads_local_image_and_sends_followup_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    image_path = tmp_path / "chart.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    connector._last_chat_req_ids["chat-1"] = "req-chat-1"
+
+    result = await connector.send_text(
+        chat_id="chat-1",
+        text="caption text",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{image_path}", "type": "image"},
+            ]
+        },
+    )
+
+    assert [payload["cmd"] for payload in transport.sent[-5:]] == [
+        "aibot_upload_media_init",
+        "aibot_upload_media_chunk",
+        "aibot_upload_media_finish",
+        "aibot_respond_msg",
+        "aibot_respond_msg",
+    ]
+    assert transport.sent[-2]["body"]["msgtype"] == "image"
+    assert transport.sent[-1]["body"]["msgtype"] == "markdown"
+    assert result["media"]["body"]["media_id"] == "media-1"
+    assert result["caption"]["body"] == {}
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_downgrades_large_image_to_file_and_sends_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    connector._last_chat_req_ids["chat-1"] = "req-chat-1"
+
+    large_image = Path("/tmp/large-image.png")
+    connector._load_outbound_media = lambda source, file_name=None: asyncio.sleep(  # type: ignore[method-assign]
+        0,
+        result=(b"x" * (10 * 1024 * 1024 + 1), "image/png", large_image.name),
+    )
+
+    result = await connector.send_text(
+        chat_id="chat-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{large_image}", "type": "image"},
+            ]
+        },
+    )
+
+    assert transport.sent[-2]["body"]["msgtype"] == "file"
+    assert transport.sent[-1]["body"]["msgtype"] == "markdown"
+    assert "已转为文件格式发送" in transport.sent[-1]["body"]["markdown"]["content"]
+    assert result["media"]["body"]["type"] == "file"
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_downgrades_non_amr_voice_to_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    connector._last_chat_req_ids["chat-1"] = "req-chat-1"
+
+    voice_path = Path("/tmp/voice.mp3")
+    connector._load_outbound_media = lambda source, file_name=None: asyncio.sleep(  # type: ignore[method-assign]
+        0,
+        result=(b"voice-bytes", "audio/mpeg", voice_path.name),
+    )
+
+    result = await connector.send_text(
+        chat_id="chat-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{voice_path}", "type": "voice"},
+            ]
+        },
+    )
+
+    assert transport.sent[-2]["body"]["msgtype"] == "file"
+    assert "AMR" in transport.sent[-1]["body"]["markdown"]["content"]
+    assert result["media"]["body"]["type"] == "file"
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_send_text_rejects_media_over_absolute_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+    connector._last_chat_req_ids["chat-1"] = "req-chat-1"
+
+    file_path = Path("/tmp/too-large.bin")
+    connector._load_outbound_media = lambda source, file_name=None: asyncio.sleep(  # type: ignore[method-assign]
+        0,
+        result=(b"x" * (20 * 1024 * 1024 + 1), "application/octet-stream", file_path.name),
+    )
+
+    result = await connector.send_text(
+        chat_id="chat-1",
+        text="",
+        metadata={
+            "outbound_attachments": [
+                {"path": f"file://{file_path}", "type": "file"},
+            ]
+        },
+    )
+
+    assert all(payload["cmd"] != "aibot_upload_media_init" for payload in transport.sent[-2:])
+    assert transport.sent[-1]["body"]["msgtype"] == "markdown"
+    assert "20MB" in transport.sent[-1]["body"]["markdown"]["content"]
+    assert result["error"]
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_start_schedules_application_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aworld_gateway.channels.wecom.connector as wecom_connector_module
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    transport = _FakeTransport()
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+    monkeypatch.setattr(wecom_connector_module, "HEARTBEAT_INTERVAL_SECONDS", 0.01)
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(),
+        router=None,
+        connect_func=lambda url: asyncio.sleep(0, result=transport),
+    )
+    await connector.start()
+
+    await asyncio.sleep(0.03)
+
+    assert any(payload["cmd"] == "ping" for payload in transport.sent[1:])
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_reconnects_after_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aworld_gateway.channels.wecom.connector as wecom_connector_module
+    from aworld_gateway.channels.wecom.connector import WecomConnector
+
+    router = _FakeRouter()
+    first_transport = _FlakyTransport(fail_after_receives=1)
+    second_transport = _FakeTransport()
+    transports = [first_transport, second_transport]
+    connect_calls: list[str] = []
+
+    async def _connect(url: str):
+        connect_calls.append(url)
+        return transports[len(connect_calls) - 1]
+
+    monkeypatch.setenv("AWORLD_WECOM_BOT_ID", "bot-1")
+    monkeypatch.setenv("AWORLD_WECOM_SECRET", "secret-1")
+    monkeypatch.setattr(wecom_connector_module, "RECONNECT_BACKOFF_SECONDS", [0.01])
+
+    connector = WecomConnector(
+        config=WecomChannelConfig(default_agent_id="aworld"),
+        router=router,
+        connect_func=_connect,
+    )
+    await connector.start()
+
+    await asyncio.sleep(0.05)
+
+    assert len(connect_calls) >= 2
+    assert second_transport.sent[0]["cmd"] == "aibot_subscribe"
+
+    second_transport.feed(
+        {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-reconnected-1"},
+            "body": {
+                "msgid": "msg-reconnected-1",
+                "chatid": "chat-1",
+                "chattype": "single",
+                "from": {"userid": "user-1"},
+                "msgtype": "text",
+                "text": {"content": "after reconnect"},
+            },
+        }
+    )
+
+    await asyncio.sleep(0.05)
+
+    inbound, channel_default_agent_id = router.calls[0]
+    assert inbound.text == "after reconnect"
+    assert channel_default_agent_id == "aworld"
+    assert second_transport.sent[-1]["cmd"] == "aibot_respond_msg"
+
+    await connector.stop()


### PR DESCRIPTION
## Summary
- add WeChat channel support with connector, media handling, account/context token storage, and adapter wiring
- expand WeCom channel websocket connector and adapter support
- update gateway config, registry, runtime integration, OpenSpec docs, and gateway tests

## Tests
- Not run in this PR creation step