### PR TITLE
ralph plugin update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ This is the <b>AWorld Thesis</b>: A powerful harness is not enough. True AI scal
 AWorld is the platform designed for this singular purpose. We provide a complete, battle-tested Harness as the recipe for you, the expert, to forge your knowledge into a fleet of autonomous agents. Together, we move beyond AI's generic promise to create robust, precise applications that master <em>your</em> specific domain.
 </p>
 
-## Naming Convention
-
-The gateway subsystem uses **`aworld-gateway`** as its external display name in docs, service metadata, and operator-facing surfaces.
-
-Its Python import package remains **`aworld_gateway`**, because Python package imports cannot use hyphens.
-
 # From Expertise to Product
 
 See what happens when expert knowledge is encoded into reusable **Skills**. The creations below are orchestrated by the AWorld Agent, demonstrating our core scaling law: as the community contributes more expertise, the entire ecosystem becomes more powerful.

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/.aworld-plugin/plugin.json
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/.aworld-plugin/plugin.json
@@ -1,0 +1,64 @@
+{
+  "id": "ralph-session-loop",
+  "name": "ralph-session-loop",
+  "version": "1.0.0",
+  "entrypoints": {
+    "commands": [
+      {
+        "id": "ralph-loop",
+        "name": "ralph-loop",
+        "description": "Start a Ralph session loop in the current CLI session",
+        "target": "commands/ralph_loop.py",
+        "scope": "session"
+      },
+      {
+        "id": "cancel-ralph",
+        "name": "cancel-ralph",
+        "description": "Cancel the active Ralph session loop",
+        "target": "commands/cancel_ralph.py",
+        "scope": "session"
+      }
+    ],
+    "hooks": [
+      {
+        "id": "ralph-task-completed",
+        "target": "hooks/task_completed.py",
+        "scope": "session",
+        "metadata": {
+          "hook_point": "task_completed"
+        }
+      },
+      {
+        "id": "ralph-task-error",
+        "target": "hooks/task_error.py",
+        "scope": "session",
+        "metadata": {
+          "hook_point": "task_error"
+        }
+      },
+      {
+        "id": "ralph-task-interrupted",
+        "target": "hooks/task_interrupted.py",
+        "scope": "session",
+        "metadata": {
+          "hook_point": "task_interrupted"
+        }
+      },
+      {
+        "id": "ralph-stop-loop",
+        "target": "hooks/stop.py",
+        "scope": "session",
+        "metadata": {
+          "hook_point": "stop"
+        }
+      }
+    ],
+    "hud": [
+      {
+        "id": "ralph-status",
+        "target": "hud/status.py",
+        "scope": "session"
+      }
+    ]
+  }
+}

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/README.md
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/README.md
@@ -1,0 +1,84 @@
+# Ralph Session Loop Plugin
+
+Built-in interactive Ralph loop for AWorld CLI.
+
+## Scope
+
+This plugin implements the phase-1 Ralph model:
+
+- loop inside the current CLI session
+- continue on `exit` through the plugin `stop` hook
+- keep loop state in plugin session state
+- show lightweight HUD status
+
+It does **not** implement:
+
+- fresh-process orchestration
+- `--model` overrides
+- `--work-dir` overrides
+- stop-hook-executed verification commands
+
+## Commands
+
+Start a loop with an iteration cap:
+
+```text
+/ralph-loop "Build a REST API" --max-iterations 5
+```
+
+Start a loop with declarative verification:
+
+```text
+/ralph-loop "Create a CLI tool" --verify "pytest tests/cli -q" --completion-promise "COMPLETE"
+```
+
+Cancel the active loop:
+
+```text
+/cancel-ralph
+```
+
+## Manual Smoke
+
+1. Start `aworld-cli` interactive mode.
+2. Run:
+
+```text
+/ralph-loop "Build a REST API" --verify "pytest tests/cli -q" --completion-promise "COMPLETE" --max-iterations 3
+```
+
+3. Let the agent answer once.
+4. Type:
+
+```text
+exit
+```
+
+Expected:
+
+- the session does not exit
+- the stop hook prints a Ralph iteration message
+- the follow-up prompt contains `Task:`, `Verification requirements:`, and `Completion rule:`
+- the HUD shows `Ralph: active`
+
+5. To end the loop manually, run:
+
+```text
+/cancel-ralph
+```
+
+6. Type `exit` again.
+
+Expected:
+
+- the session exits normally
+
+## Completion Behavior
+
+If the active loop has `--completion-promise "COMPLETE"`, the loop stops only when the most recent final answer contains:
+
+```text
+<promise>COMPLETE</promise>
+```
+
+The match is exact and case-sensitive.

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/__init__.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in Ralph session loop plugin."""

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/cancel_ralph.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/cancel_ralph.py
@@ -1,0 +1,22 @@
+from aworld_cli.plugin_capabilities.commands import PluginBoundCommand
+
+
+class CancelRalphCommand(PluginBoundCommand):
+    @property
+    def command_type(self) -> str:
+        return "tool"
+
+    async def execute(self, context) -> str:
+        handle = self.get_state_handle(context)
+        if handle is None:
+            return "No Ralph session state is available for the current session."
+        current = handle.read()
+        if not current.get("active"):
+            handle.clear()
+            return "No active Ralph loop to cancel."
+        handle.clear()
+        return "Ralph loop cancelled."
+
+
+def build_command(plugin, entrypoint):
+    return CancelRalphCommand(plugin, entrypoint)

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/ralph_loop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/ralph_loop.py
@@ -1,0 +1,48 @@
+from aworld_cli.core.command_system import CommandContext
+from aworld_cli.plugin_capabilities.commands import PluginBoundCommand
+
+from aworld_cli.builtin_plugins.ralph_session_loop.common import (
+    build_loop_prompt,
+    parse_loop_args,
+    started_at_iso,
+)
+
+
+class RalphLoopCommand(PluginBoundCommand):
+    async def pre_execute(self, context: CommandContext):
+        try:
+            parse_loop_args(context.user_args)
+        except ValueError as exc:
+            return f"/ralph-loop error: {exc}"
+        if self.get_state_handle(context) is None:
+            return "/ralph-loop requires session-aware plugin state"
+        return None
+
+    async def get_prompt(self, context: CommandContext) -> str:
+        parsed = parse_loop_args(context.user_args)
+        prompt = build_loop_prompt(
+            parsed["prompt"],
+            parsed["verify_commands"],
+            parsed["completion_promise"],
+        )
+        handle = self.get_state_handle(context)
+        handle.write(
+            {
+                "active": True,
+                "prompt": parsed["prompt"],
+                "iteration": 1,
+                "max_iterations": parsed["max_iterations"],
+                "completion_promise": parsed["completion_promise"],
+                "verify_commands": parsed["verify_commands"],
+                "started_at": started_at_iso(),
+                "last_stop_reason": None,
+                "last_final_answer": "",
+                "last_final_answer_excerpt": None,
+                "last_task_status": "initialized",
+            }
+        )
+        return prompt
+
+
+def build_command(plugin, entrypoint):
+    return RalphLoopCommand(plugin, entrypoint)

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/ralph_loop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/ralph_loop.py
@@ -26,6 +26,8 @@ class RalphLoopCommand(PluginBoundCommand):
             parsed["completion_promise"],
         )
         handle = self.get_state_handle(context)
+        if handle is None:
+            raise ValueError("/ralph-loop requires session-aware plugin state")
         handle.write(
             {
                 "active": True,

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/common.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/common.py
@@ -1,0 +1,77 @@
+import argparse
+import re
+import shlex
+from datetime import datetime, timezone
+
+
+class RalphArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ValueError(message)
+
+
+def parse_loop_args(user_args: str) -> dict:
+    parser = RalphArgumentParser(prog="/ralph-loop", add_help=False)
+    parser.add_argument("prompt_parts", nargs="*")
+    parser.add_argument("--verify", action="append", dest="verify_commands", default=[])
+    parser.add_argument("--completion-promise", dest="completion_promise")
+    parser.add_argument("--max-iterations", dest="max_iterations", type=int)
+
+    tokens = shlex.split(user_args or "")
+    namespace = parser.parse_args(tokens)
+    prompt = " ".join(namespace.prompt_parts).strip()
+    if not prompt:
+        raise ValueError("missing task prompt")
+    if namespace.max_iterations is not None and namespace.max_iterations < 1:
+        raise ValueError("--max-iterations must be >= 1")
+
+    return {
+        "prompt": prompt,
+        "verify_commands": [str(item).strip() for item in namespace.verify_commands if str(item).strip()],
+        "completion_promise": (namespace.completion_promise or "").strip() or None,
+        "max_iterations": namespace.max_iterations,
+    }
+
+
+def started_at_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_loop_prompt(prompt: str, verify_commands: list[str] | None, completion_promise: str | None) -> str:
+    verify_commands = list(verify_commands or [])
+
+    lines = ["Task:", prompt.strip(), ""]
+    lines.append("Verification requirements:")
+    if verify_commands:
+        for index, command in enumerate(verify_commands, start=1):
+            lines.append(f"{index}. Run: {command}")
+    else:
+        lines.append("1. No explicit verification commands were declared.")
+    lines.append("")
+    lines.append("Completion rule:")
+    if completion_promise:
+        lines.append(
+            f"Only output <promise>{completion_promise}</promise> when every verification requirement passes."
+        )
+        lines.append("If verification fails, fix the issue and continue iterating.")
+    else:
+        lines.append("No completion promise is set for this loop.")
+        lines.append("Continue iterating until the work is done or the operator cancels the loop.")
+    return "\n".join(lines).strip()
+
+
+def extract_completion_promise(answer: str | None) -> str | None:
+    if not answer:
+        return None
+    match = re.search(r"<promise>(.*?)</promise>", answer, flags=re.DOTALL)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def summarize_text(text: str | None, limit: int = 160) -> str | None:
+    if text is None:
+        return None
+    normalized = " ".join(str(text).split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3] + "..."

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/common.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/common.py
@@ -3,6 +3,9 @@ import re
 import shlex
 from datetime import datetime, timezone
 
+MAX_SUMMARY_LENGTH = 160
+ELLIPSIS = "..."
+
 
 class RalphArgumentParser(argparse.ArgumentParser):
     def error(self, message):
@@ -68,10 +71,10 @@ def extract_completion_promise(answer: str | None) -> str | None:
     return match.group(1).strip()
 
 
-def summarize_text(text: str | None, limit: int = 160) -> str | None:
+def summarize_text(text: str | None, limit: int = MAX_SUMMARY_LENGTH) -> str | None:
     if text is None:
         return None
     normalized = " ".join(str(text).split())
     if len(normalized) <= limit:
         return normalized
-    return normalized[: limit - 3] + "..."
+    return normalized[: limit - len(ELLIPSIS)] + ELLIPSIS

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/stop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/stop.py
@@ -4,6 +4,22 @@ from aworld_cli.builtin_plugins.ralph_session_loop.common import (
 )
 
 
+def _coerce_iteration(value) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return parsed if parsed > 0 else 1
+
+
+def _coerce_positive_limit(value):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
 def handle_event(event, state):
     handle = state.get("__plugin_state__")
     if handle is None:
@@ -24,9 +40,9 @@ def handle_event(event, state):
             "reason": f"Ralph completion promise satisfied: {completion_promise}",
         }
 
-    iteration = int(current.get("iteration", 1) or 1)
-    max_iterations = current.get("max_iterations")
-    if max_iterations is not None and int(max_iterations) > 0 and iteration >= int(max_iterations):
+    iteration = _coerce_iteration(current.get("iteration", 1))
+    max_iterations = _coerce_positive_limit(current.get("max_iterations"))
+    if max_iterations is not None and iteration >= max_iterations:
         handle.clear()
         return {
             "action": "allow",

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/stop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/stop.py
@@ -1,0 +1,52 @@
+from aworld_cli.builtin_plugins.ralph_session_loop.common import (
+    build_loop_prompt,
+    extract_completion_promise,
+)
+
+
+def handle_event(event, state):
+    handle = state.get("__plugin_state__")
+    if handle is None:
+        if state.get("active"):
+            return {"action": "deny", "reason": "Ralph session state is unavailable."}
+        return {"action": "allow"}
+
+    current = handle.read()
+    if not current.get("active"):
+        return {"action": "allow"}
+
+    completion_promise = current.get("completion_promise")
+    answer_promise = extract_completion_promise(current.get("last_final_answer"))
+    if completion_promise and answer_promise == completion_promise:
+        handle.clear()
+        return {
+            "action": "allow",
+            "reason": f"Ralph completion promise satisfied: {completion_promise}",
+        }
+
+    iteration = int(current.get("iteration", 1) or 1)
+    max_iterations = current.get("max_iterations")
+    if max_iterations is not None and int(max_iterations) > 0 and iteration >= int(max_iterations):
+        handle.clear()
+        return {
+            "action": "allow",
+            "reason": f"Ralph max iterations reached: {max_iterations}",
+        }
+
+    next_iteration = iteration + 1
+    prompt = build_loop_prompt(
+        current.get("prompt", ""),
+        current.get("verify_commands") or [],
+        completion_promise,
+    )
+    handle.update(
+        {
+            "iteration": next_iteration,
+            "last_stop_reason": "continue",
+        }
+    )
+    return {
+        "action": "block_and_continue",
+        "follow_up_prompt": prompt,
+        "system_message": f"Ralph iteration {next_iteration}",
+    }

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_completed.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_completed.py
@@ -1,0 +1,17 @@
+from aworld_cli.builtin_plugins.ralph_session_loop.common import summarize_text
+
+
+def handle_event(event, state):
+    handle = state.get("__plugin_state__")
+    if handle is None or not state.get("active"):
+        return {"action": "allow"}
+
+    final_answer = event.get("final_answer") or ""
+    handle.update(
+        {
+            "last_task_status": event.get("task_status") or "completed",
+            "last_final_answer": final_answer,
+            "last_final_answer_excerpt": summarize_text(final_answer),
+        }
+    )
+    return {"action": "allow"}

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_error.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_error.py
@@ -1,0 +1,17 @@
+from aworld_cli.builtin_plugins.ralph_session_loop.common import summarize_text
+
+
+def handle_event(event, state):
+    handle = state.get("__plugin_state__")
+    if handle is None or not state.get("active"):
+        return {"action": "allow"}
+
+    error_text = event.get("error") or ""
+    handle.update(
+        {
+            "last_task_status": event.get("task_status") or "error",
+            "last_final_answer": "",
+            "last_final_answer_excerpt": summarize_text(error_text),
+        }
+    )
+    return {"action": "allow"}

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_interrupted.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_interrupted.py
@@ -1,0 +1,17 @@
+from aworld_cli.builtin_plugins.ralph_session_loop.common import summarize_text
+
+
+def handle_event(event, state):
+    handle = state.get("__plugin_state__")
+    if handle is None or not state.get("active"):
+        return {"action": "allow"}
+
+    partial_answer = event.get("partial_answer") or ""
+    handle.update(
+        {
+            "last_task_status": event.get("task_status") or "interrupted",
+            "last_final_answer": "",
+            "last_final_answer_excerpt": summarize_text(partial_answer),
+        }
+    )
+    return {"action": "allow"}

--- a/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hud/status.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hud/status.py
@@ -1,0 +1,23 @@
+def render_lines(context, plugin_state):
+    active = bool(plugin_state.get("active"))
+    iteration = plugin_state.get("iteration")
+    max_iterations = plugin_state.get("max_iterations")
+    promise = plugin_state.get("completion_promise") or "none"
+
+    if active:
+        limit = max_iterations if max_iterations is not None else "unbounded"
+        segments = [
+            "Ralph: active",
+            f"Iter: {iteration}/{limit}",
+            f"Promise: {promise}",
+        ]
+    else:
+        segments = ["Ralph: inactive"]
+
+    return [
+        {
+            "section": "session",
+            "priority": 30,
+            "segments": segments,
+        }
+    ]

--- a/aworld-cli/src/aworld_cli/console.py
+++ b/aworld-cli/src/aworld_cli/console.py
@@ -2730,6 +2730,7 @@ class AWorldCLI:
                                     sandbox=None,  # TODO: Pass actual sandbox if available
                                     agent_config=None,  # TODO: Pass agent config if needed
                                     runtime=runtime,
+                                    session_id=getattr(executor_instance, "session_id", None),
                                 )
 
                                 try:

--- a/aworld-cli/src/aworld_cli/core/command_system.py
+++ b/aworld-cli/src/aworld_cli/core/command_system.py
@@ -32,6 +32,7 @@ class CommandContext:
     sandbox: Optional[Any] = None
     agent_config: Optional[Any] = None
     runtime: Optional[Any] = None
+    session_id: Optional[str] = None
 
     def __post_init__(self):
         """Validate context"""

--- a/aworld-cli/src/aworld_cli/plugin_capabilities/commands.py
+++ b/aworld-cli/src/aworld_cli/plugin_capabilities/commands.py
@@ -1,14 +1,16 @@
 from pathlib import Path
+from importlib.util import module_from_spec, spec_from_file_location
 
 from aworld.plugins.resources import PluginResourceResolver
 from aworld_cli.core.command_system import Command, CommandContext, CommandRegistry
 
 
-class PluginPromptCommand(Command):
+class PluginBoundCommand(Command):
     def __init__(self, plugin, entrypoint):
         self._plugin = plugin
         self._entrypoint = entrypoint
         self._resolver = PluginResourceResolver(Path(plugin.manifest.plugin_root), plugin.manifest.plugin_id)
+        self._aworld_plugin_command = True
 
     @property
     def name(self) -> str:
@@ -28,7 +30,7 @@ class PluginPromptCommand(Command):
         if runtime is None or not hasattr(runtime, "_resolve_plugin_state_path"):
             return None
 
-        session_id = getattr(runtime, "session_id", None)
+        session_id = getattr(context, "session_id", None) or getattr(runtime, "session_id", None)
         return runtime._resolve_plugin_state_path(
             plugin_id=self._plugin.manifest.plugin_id,
             scope=self._entrypoint.scope,
@@ -36,10 +38,60 @@ class PluginPromptCommand(Command):
             workspace_path=context.cwd,
         )
 
+    def get_state_handle(self, context: CommandContext):
+        runtime = getattr(context, "runtime", None)
+        state_path = self.resolve_state_path(context)
+        if runtime is None or state_path is None:
+            return None
+        store = getattr(runtime, "_plugin_state_store", None)
+        if store is None:
+            return None
+        return store.handle(state_path)
+
+
+class PluginPromptCommand(PluginBoundCommand):
+
     async def get_prompt(self, context: CommandContext) -> str:
         prompt_path = self._resolver.resolve_asset(self._entrypoint.target)
         prompt = prompt_path.read_text(encoding="utf-8")
         return f"{prompt}\n\nUser args: {context.user_args}".strip()
+
+
+def _load_module_command(plugin, entrypoint) -> Command:
+    resolver = PluginResourceResolver(Path(plugin.manifest.plugin_root), plugin.manifest.plugin_id)
+    module_path = resolver.resolve_asset(entrypoint.target)
+    spec = spec_from_file_location(
+        f"plugin_command_{plugin.manifest.plugin_id}_{entrypoint.entrypoint_id}",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load plugin command module from {module_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    factory_name = str(entrypoint.metadata.get("factory", "build_command"))
+    factory = getattr(module, factory_name, None)
+    if factory is None:
+        raise AttributeError(
+            f"plugin command '{plugin.manifest.plugin_id}:{entrypoint.entrypoint_id}' "
+            f"must define {factory_name}(plugin, entrypoint)"
+        )
+
+    command = factory(plugin, entrypoint)
+    if not isinstance(command, Command):
+        raise TypeError(
+            f"plugin command '{plugin.manifest.plugin_id}:{entrypoint.entrypoint_id}' "
+            "factory must return a Command instance"
+        )
+    setattr(command, "_aworld_plugin_command", True)
+    return command
+
+
+def _build_plugin_command(plugin, entrypoint) -> Command:
+    target = str(entrypoint.target or "")
+    if target.endswith(".py"):
+        return _load_module_command(plugin, entrypoint)
+    return PluginPromptCommand(plugin, entrypoint)
 
 
 def register_plugin_commands(plugins) -> None:
@@ -50,12 +102,12 @@ def register_plugin_commands(plugins) -> None:
             command_name = entrypoint.name or entrypoint.entrypoint_id
             if CommandRegistry.get(command_name) is not None:
                 continue
-            CommandRegistry.register(PluginPromptCommand(plugin, entrypoint))
+            CommandRegistry.register(_build_plugin_command(plugin, entrypoint))
 
 
 def sync_plugin_commands(plugins) -> None:
     for command in list(CommandRegistry.list_commands()):
-        if isinstance(command, PluginPromptCommand):
+        if getattr(command, "_aworld_plugin_command", False):
             CommandRegistry.unregister(command.name)
 
     register_plugin_commands(plugins)

--- a/aworld-cli/src/aworld_cli/plugin_capabilities/commands.py
+++ b/aworld-cli/src/aworld_cli/plugin_capabilities/commands.py
@@ -25,16 +25,19 @@ class PluginBoundCommand(Command):
         tools = self._entrypoint.permissions.get("allowed_tools", [])
         return [str(item) for item in tools]
 
+    def _resolve_session_id(self, context: CommandContext):
+        runtime = getattr(context, "runtime", None)
+        return getattr(context, "session_id", None) or getattr(runtime, "session_id", None)
+
     def resolve_state_path(self, context: CommandContext):
         runtime = getattr(context, "runtime", None)
         if runtime is None or not hasattr(runtime, "_resolve_plugin_state_path"):
             return None
 
-        session_id = getattr(context, "session_id", None) or getattr(runtime, "session_id", None)
         return runtime._resolve_plugin_state_path(
             plugin_id=self._plugin.manifest.plugin_id,
             scope=self._entrypoint.scope,
-            session_id=session_id,
+            session_id=self._resolve_session_id(context),
             workspace_path=context.cwd,
         )
 

--- a/aworld/runners/ralph/config.py
+++ b/aworld/runners/ralph/config.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 # Copyright (c) inclusionAI.
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from aworld.config import ModelConfig, TaskConfig
 from aworld.evaluations.base import EvalCriteria, Scorer
@@ -81,18 +81,50 @@ class StateConfig:
     enable_metrics: bool = True
 
 
+@dataclass
+class RalphVerifyConfig:
+    """Configuration for Ralph verification hooks."""
+
+    enabled: bool = False
+    commands: list[str] = field(default_factory=list)
+    run_on_each_iteration: bool = False
+    run_before_completion: bool = True
+    success_policy: Literal["all", "any"] = "all"
+    max_output_chars: int = 12000
+
+
 class RalphConfig(TaskConfig):
     """Unified configuration for Ralph Loop.
 
     This configuration class combines all component configurations and provides sensible defaults for different use cases.
     """
+    model_config = {
+        **getattr(TaskConfig, "model_config", {}),
+        "validate_assignment": True,
+    }
     stop_condition: StopConditionConfig = Field(default_factory=StopConditionConfig)
     state: StateConfig = Field(default_factory=StateConfig)
+    execution_mode: Literal["reuse_context", "fresh_context"] = Field(default="reuse_context")
+    verify: RalphVerifyConfig = Field(default_factory=RalphVerifyConfig)
     reuse_context: bool = Field(default=True)
 
     workspace: str = "."
     # Global settings
     llm_config: ModelConfig = Field(default_factory=ModelConfig)
+
+    @model_validator(mode="after")
+    def _normalize_execution_mode(self) -> "RalphConfig":
+        explicit_fields = getattr(self, "model_fields_set", set())
+        if "execution_mode" in explicit_fields:
+            execution_mode = self.execution_mode
+        else:
+            execution_mode = "reuse_context" if self.reuse_context else "fresh_context"
+
+        reuse_context = execution_mode == "reuse_context"
+
+        object.__setattr__(self, "execution_mode", execution_mode)
+        object.__setattr__(self, "reuse_context", reuse_context)
+        return self
 
     @classmethod
     def create(cls, model_config: Optional[ModelConfig] = None) -> 'RalphConfig':

--- a/aworld/runners/ralph/evaluator.py
+++ b/aworld/runners/ralph/evaluator.py
@@ -1,0 +1,143 @@
+# coding: utf-8
+# Copyright (c) inclusionAI.
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+from aworld.runners.ralph.config import RalphVerifyConfig
+
+if TYPE_CHECKING:
+    from aworld.core.task import Task, TaskResponse
+    from aworld.runners.ralph.memory import LoopMemoryStore
+    from aworld.runners.ralph.state import LoopContext
+
+
+DEFAULT_VERIFY_TIMEOUT = 30
+
+
+@dataclass
+class VerifyCommandResult:
+    command: str
+    exit_code: int
+    output: str
+    passed: bool
+
+
+@dataclass
+class VerifyResult:
+    passed: bool
+    commands: list[VerifyCommandResult] = field(default_factory=list)
+    success_policy: str = "all"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "success_policy": self.success_policy,
+            "commands": [asdict(command) for command in self.commands],
+        }
+
+
+@dataclass
+class IterationEvaluationResult:
+    verify_result: Optional[VerifyResult] = None
+    reflection_feedback: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class IterationEvaluator:
+    def __init__(
+        self,
+        context: "LoopContext",
+        memory_store: "LoopMemoryStore",
+        verify_config: RalphVerifyConfig,
+    ):
+        self.context = context
+        self.memory_store = memory_store
+        self.verify_config = verify_config
+
+    async def evaluate(
+        self,
+        task: "Task",
+        iter_num: int,
+        execution_result: "TaskResponse",
+    ) -> IterationEvaluationResult:
+        if not self._should_run_verify():
+            return IterationEvaluationResult()
+
+        verify_result = await self._run_verify()
+        await self.memory_store.write_verify_result(task.id, iter_num, verify_result.to_payload())
+
+        reflection_feedback = None
+        if not verify_result.passed:
+            reflection_feedback = self._build_verify_failure_feedback(verify_result)
+            await self.memory_store.write_reflection_feedback(task.id, iter_num, reflection_feedback)
+
+        return IterationEvaluationResult(
+            verify_result=verify_result,
+            reflection_feedback=reflection_feedback,
+        )
+
+    def _should_run_verify(self) -> bool:
+        return bool(self.verify_config.enabled and self.verify_config.commands)
+
+    async def _run_verify(self) -> VerifyResult:
+        command_results: list[VerifyCommandResult] = []
+        for command in self.verify_config.commands:
+            terminal_result = await self.context.sand_box.terminal.run_code(
+                code=command,
+                timeout=getattr(self.verify_config, "timeout", DEFAULT_VERIFY_TIMEOUT),
+                output_format="markdown",
+            )
+            command_results.append(self._parse_terminal_result(command, terminal_result))
+
+        if self.verify_config.success_policy == "any":
+            passed = any(result.passed for result in command_results)
+        else:
+            passed = all(result.passed for result in command_results)
+
+        return VerifyResult(
+            passed=passed,
+            commands=command_results,
+            success_policy=self.verify_config.success_policy,
+        )
+
+    def _parse_terminal_result(self, command: str, terminal_result: dict[str, Any]) -> VerifyCommandResult:
+        terminal_data = terminal_result.get("data") or {}
+        metadata = terminal_data.get("metadata") or {}
+        exit_code = metadata.get("return_code")
+        if exit_code is None:
+            exit_code = 0 if terminal_data.get("success") else -1
+
+        output = metadata.get("output_data")
+        if output is None:
+            output = terminal_data.get("message") or terminal_result.get("error") or ""
+        output = str(output)
+        output = output[: self.verify_config.max_output_chars]
+
+        passed = exit_code == 0
+        return VerifyCommandResult(
+            command=command,
+            exit_code=exit_code,
+            output=output,
+            passed=passed,
+        )
+
+    def _build_verify_failure_feedback(self, verify_result: VerifyResult) -> str:
+        lines = [
+            "Verification failed. Fix the issues below before continuing.",
+            "",
+        ]
+
+        for command_result in verify_result.commands:
+            if command_result.passed:
+                continue
+            lines.extend(
+                [
+                    f"Command: {command_result.command}",
+                    f"Exit code: {command_result.exit_code}",
+                    "Output:",
+                    command_result.output or "(no output)",
+                    "",
+                ]
+            )
+
+        return "\n".join(lines).strip()

--- a/aworld/runners/ralph/evaluator.py
+++ b/aworld/runners/ralph/evaluator.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 # Copyright (c) inclusionAI.
+import json
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -59,8 +60,9 @@ class IterationEvaluator:
         task: "Task",
         iter_num: int,
         execution_result: "TaskResponse",
+        phase: str = "post_iteration",
     ) -> IterationEvaluationResult:
-        if not self._should_run_verify():
+        if not self._should_run_verify(phase):
             return IterationEvaluationResult()
 
         verify_result = await self._run_verify()
@@ -76,8 +78,15 @@ class IterationEvaluator:
             reflection_feedback=reflection_feedback,
         )
 
-    def _should_run_verify(self) -> bool:
-        return bool(self.verify_config.enabled and self.verify_config.commands)
+    def _should_run_verify(self, phase: str) -> bool:
+        if not (self.verify_config.enabled and self.verify_config.commands):
+            return False
+
+        if phase == "post_iteration":
+            return bool(self.verify_config.run_on_each_iteration)
+        if phase == "before_completion":
+            return bool(self.verify_config.run_before_completion)
+        return False
 
     async def _run_verify(self) -> VerifyResult:
         command_results: list[VerifyCommandResult] = []
@@ -101,8 +110,8 @@ class IterationEvaluator:
         )
 
     def _parse_terminal_result(self, command: str, terminal_result: dict[str, Any]) -> VerifyCommandResult:
-        terminal_data = terminal_result.get("data") or {}
-        metadata = terminal_data.get("metadata") or {}
+        terminal_data = self._decode_json_payload(terminal_result.get("data"))
+        metadata = self._decode_json_payload(terminal_data.get("metadata"))
         exit_code = metadata.get("return_code")
         if exit_code is None:
             exit_code = 0 if terminal_data.get("success") else -1
@@ -120,6 +129,21 @@ class IterationEvaluator:
             output=output,
             passed=passed,
         )
+
+    def _decode_json_payload(self, payload: Any) -> dict[str, Any]:
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, str):
+            try:
+                decoded = json.loads(payload)
+            except json.JSONDecodeError:
+                return {"message": payload}
+            if isinstance(decoded, dict):
+                return decoded
+            return {"message": decoded}
+        if payload is None:
+            return {}
+        return {"message": payload}
 
     def _build_verify_failure_feedback(self, verify_result: VerifyResult) -> str:
         lines = [

--- a/aworld/runners/ralph/evaluator.py
+++ b/aworld/runners/ralph/evaluator.py
@@ -62,8 +62,11 @@ class IterationEvaluator:
         execution_result: "TaskResponse",
         phase: str = "post_iteration",
     ) -> IterationEvaluationResult:
+        summary = self._build_summary(execution_result)
+        await self.memory_store.write_iteration_summary(task.id, iter_num, summary)
+
         if not self._should_run_verify(phase):
-            return IterationEvaluationResult()
+            return IterationEvaluationResult(summary=summary)
 
         verify_result = await self._run_verify()
         await self.memory_store.write_verify_result(task.id, iter_num, verify_result.to_payload())
@@ -76,6 +79,7 @@ class IterationEvaluator:
         return IterationEvaluationResult(
             verify_result=verify_result,
             reflection_feedback=reflection_feedback,
+            summary=summary,
         )
 
     def _should_run_verify(self, phase: str) -> bool:
@@ -165,3 +169,15 @@ class IterationEvaluator:
             )
 
         return "\n".join(lines).strip()
+
+    def _build_summary(self, execution_result: "TaskResponse") -> str:
+        if execution_result.answer is None:
+            return str(execution_result.msg or "")
+
+        if isinstance(execution_result.answer, str):
+            return execution_result.answer
+
+        try:
+            return json.dumps(execution_result.answer, ensure_ascii=False)
+        except TypeError:
+            return str(execution_result.answer)

--- a/aworld/runners/ralph/input_builder.py
+++ b/aworld/runners/ralph/input_builder.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+from aworld.runners.ralph.policy import RalphLoopPolicy
+
+if TYPE_CHECKING:
+    from aworld.runners.ralph.memory import LoopMemoryStore
+
+
+DEFAULT_REFLECTION_FEEDBACK = (
+    "Your previous answer was incorrect. Please read the original question carefully, "
+    "check and analyze it, and try to answer it again."
+)
+
+
+@dataclass
+class IterationInput:
+    task_input: str
+    reuse_context: bool
+
+
+class IterationInputBuilder:
+    def __init__(self, policy: RalphLoopPolicy, memory_store: "LoopMemoryStore"):
+        self.policy = policy
+        self.memory_store = memory_store
+
+    async def build(
+        self,
+        task_id: str,
+        original_task: str,
+        iteration: int,
+        previous_answer: Optional[str] = None,
+        reflection_feedback: Optional[str] = None,
+    ) -> IterationInput:
+        if iteration <= 1:
+            return IterationInput(
+                task_input=original_task,
+                reuse_context=self.policy.execution_mode == "reuse_context",
+            )
+
+        if previous_answer is None:
+            previous_answer = await self.memory_store.read_answer(task_id, iteration - 1)
+        if reflection_feedback is None:
+            reflection_feedback = await self.memory_store.read_reflection_feedback(task_id, iteration - 1)
+
+        return IterationInput(
+            task_input=self._compose_task_input(
+                original_task=original_task,
+                iteration=iteration,
+                previous_answer=previous_answer,
+                reflection_feedback=reflection_feedback,
+            ),
+            reuse_context=self.policy.execution_mode == "reuse_context",
+        )
+
+    def _compose_task_input(
+        self,
+        original_task: str,
+        iteration: int,
+        previous_answer: Optional[str],
+        reflection_feedback: Optional[str],
+    ) -> str:
+        sections: list[str] = [f"Iteration: {iteration}", ""]
+
+        if self.policy.execution_mode == "fresh_context":
+            sections[0:0] = ["Original task:", original_task, ""]
+
+        sections.extend(
+            [
+                "Previous answer summary:",
+                previous_answer or "No previous answer available.",
+                "",
+                "Reflection feedback:",
+                reflection_feedback or DEFAULT_REFLECTION_FEEDBACK,
+                "",
+                "Execution rule for the next step:",
+                self._execution_rule(),
+            ]
+        )
+        return "\n".join(sections).strip()
+
+    def _execution_rule(self) -> str:
+        if self.policy.execution_mode == "reuse_context":
+            return "Continue from the existing task context and incorporate the persisted feedback."
+        return "Start from a fresh task context and rely only on the persisted loop memory above."

--- a/aworld/runners/ralph/memory.py
+++ b/aworld/runners/ralph/memory.py
@@ -1,0 +1,103 @@
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from aworld.output import Artifact, ArtifactType
+
+if TYPE_CHECKING:
+    from aworld.runners.ralph.state import LoopContext
+
+
+class LoopMemoryStore:
+    """Thin adapter over existing workspace artifacts and sandbox file access."""
+
+    def __init__(self, context: "LoopContext"):
+        self.context = context
+
+    def iteration_summary_artifact_id(self, task_id: str, iteration: int) -> str:
+        return self._artifact_id(self.context.summary_dir(), task_id, iteration)
+
+    def reflection_feedback_artifact_id(self, task_id: str, iteration: int) -> str:
+        return self._artifact_id(self.context.reflect_dir(), task_id, iteration)
+
+    def answer_path(self, task_id: str, iteration: int) -> Path:
+        return self.context.answer_dir() / f"{task_id}_{iteration}"
+
+    async def write_iteration_summary(self, task_id: str, iteration: int, text: str) -> None:
+        await self._write_text_artifact(
+            artifact_id=self.iteration_summary_artifact_id(task_id, iteration),
+            text=text,
+            metadata={
+                "task_id": task_id,
+                "iteration": iteration,
+                "kind": "iteration_summary",
+            },
+        )
+
+    async def read_iteration_summary(self, task_id: str, iteration: int) -> Optional[str]:
+        return self._read_text_artifact(self.iteration_summary_artifact_id(task_id, iteration))
+
+    async def write_reflection_feedback(self, task_id: str, iteration: int, text: str) -> None:
+        await self._write_text_artifact(
+            artifact_id=self.reflection_feedback_artifact_id(task_id, iteration),
+            text=text,
+            metadata={
+                "task_id": task_id,
+                "iteration": iteration,
+                "kind": "reflection_feedback",
+                "timestamp": time.time(),
+            },
+        )
+
+    async def read_reflection_feedback(self, task_id: str, iteration: int) -> Optional[str]:
+        return self._read_text_artifact(self.reflection_feedback_artifact_id(task_id, iteration))
+
+    async def write_answer(self, task_id: str, iteration: int, content: Any) -> None:
+        await self.write_answer_file(f"{task_id}_{iteration}", content)
+
+    async def write_answer_file(self, filename: str, content: Any) -> None:
+        payload = self._serialize_answer_payload(content)
+        await self.context.sand_box.file.write_file(path=str(self.context.answer_dir() / filename), content=payload)
+
+    async def read_answer(self, task_id: str, iteration: int) -> Optional[Any]:
+        result = await self.context.sand_box.file.read_file(path=str(self.answer_path(task_id, iteration)))
+        data = result.get("data")
+        if data is None:
+            return None
+
+        if isinstance(data, str):
+            try:
+                parsed = json.loads(data)
+            except json.JSONDecodeError:
+                return data
+        else:
+            parsed = data
+
+        if isinstance(parsed, dict) and "content" in parsed:
+            return parsed["content"]
+        return parsed
+
+    def _artifact_id(self, base_dir: Path, task_id: str, iteration: int) -> str:
+        return f"{base_dir}_{task_id}_{iteration}"
+
+    async def _write_text_artifact(self, artifact_id: str, text: str, metadata: dict[str, Any]) -> None:
+        artifact = Artifact(
+            artifact_id=artifact_id,
+            artifact_type=ArtifactType.TEXT,
+            content=text,
+            metadata=metadata,
+        )
+        await self.context.workspace.add_artifact(artifact, index=False)
+
+    def _read_text_artifact(self, artifact_id: str) -> Optional[str]:
+        artifact_data = self.context.workspace.get_artifact_data(artifact_id)
+        if not artifact_data:
+            return None
+        return artifact_data.get("content")
+
+    def _serialize_answer_payload(self, content: Any) -> str:
+        if isinstance(content, str):
+            return content
+
+        return json.dumps({"content": content}, ensure_ascii=False)

--- a/aworld/runners/ralph/memory.py
+++ b/aworld/runners/ralph/memory.py
@@ -39,10 +39,30 @@ class LoopMemoryStore:
         return self._read_text_artifact(self.iteration_summary_artifact_id(task_id, iteration))
 
     async def write_reflection_feedback(self, task_id: str, iteration: int, text: str) -> None:
+        await self.write_reflection_feedback_artifact(
+            task_id=task_id,
+            iteration=iteration,
+            text=text,
+            metadata={
+                "task_id": task_id,
+                "iteration": iteration,
+                "kind": "reflection_feedback",
+                "timestamp": time.time(),
+            },
+        )
+
+    async def write_reflection_feedback_artifact(
+        self,
+        task_id: str,
+        iteration: int,
+        text: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
         await self._write_text_artifact(
             artifact_id=self.reflection_feedback_artifact_id(task_id, iteration),
             text=text,
-            metadata={
+            metadata=metadata
+            or {
                 "task_id": task_id,
                 "iteration": iteration,
                 "kind": "reflection_feedback",
@@ -53,12 +73,15 @@ class LoopMemoryStore:
     async def read_reflection_feedback(self, task_id: str, iteration: int) -> Optional[str]:
         return self._read_text_artifact(self.reflection_feedback_artifact_id(task_id, iteration))
 
-    async def write_answer(self, task_id: str, iteration: int, content: Any) -> None:
-        await self.write_answer_file(f"{task_id}_{iteration}", content)
+    async def write_answer(self, task_id: str, iteration: int, content: Any) -> dict[str, Any]:
+        return await self.write_answer_file(f"{task_id}_{iteration}", content)
 
-    async def write_answer_file(self, filename: str, content: Any) -> None:
+    async def write_answer_file(self, filename: str, content: Any) -> dict[str, Any]:
         payload = self._serialize_answer_payload(content)
-        await self.context.sand_box.file.write_file(path=str(self.context.answer_dir() / filename), content=payload)
+        return await self.context.sand_box.file.write_file(
+            path=str(self.context.answer_dir() / filename),
+            content=payload,
+        )
 
     async def read_answer(self, task_id: str, iteration: int) -> Optional[Any]:
         result = await self.context.sand_box.file.read_file(path=str(self.answer_path(task_id, iteration)))
@@ -70,9 +93,12 @@ class LoopMemoryStore:
             try:
                 parsed = json.loads(data)
             except json.JSONDecodeError:
-                return data
+                return None
         else:
             parsed = data
+
+        if isinstance(parsed, dict) and parsed.get("type") == "text" and "content" in parsed:
+            return parsed["content"]
 
         if isinstance(parsed, dict) and "content" in parsed:
             return parsed["content"]

--- a/aworld/runners/ralph/memory.py
+++ b/aworld/runners/ralph/memory.py
@@ -21,6 +21,9 @@ class LoopMemoryStore:
     def reflection_feedback_artifact_id(self, task_id: str, iteration: int) -> str:
         return self._artifact_id(self.context.reflect_dir(), task_id, iteration)
 
+    def verify_result_artifact_id(self, task_id: str, iteration: int) -> str:
+        return self._artifact_id(self.context.loop_dir() / "verify", task_id, iteration)
+
     def answer_path(self, task_id: str, iteration: int) -> Path:
         return self.context.answer_dir() / f"{task_id}_{iteration}"
 
@@ -73,6 +76,25 @@ class LoopMemoryStore:
     async def read_reflection_feedback(self, task_id: str, iteration: int) -> Optional[str]:
         return self._read_text_artifact(self.reflection_feedback_artifact_id(task_id, iteration))
 
+    async def write_verify_result(self, task_id: str, iteration: int, payload: dict[str, Any]) -> None:
+        await self._write_artifact(
+            artifact_id=self.verify_result_artifact_id(task_id, iteration),
+            artifact_type=ArtifactType.JSON,
+            content=payload,
+            metadata={
+                "task_id": task_id,
+                "iteration": iteration,
+                "kind": "verify_result",
+                "timestamp": time.time(),
+            },
+        )
+
+    async def read_verify_result(self, task_id: str, iteration: int) -> Optional[dict[str, Any]]:
+        artifact_data = self.context.workspace.get_artifact_data(self.verify_result_artifact_id(task_id, iteration))
+        if not artifact_data:
+            return None
+        return artifact_data.get("content")
+
     async def write_answer(self, task_id: str, iteration: int, content: Any) -> dict[str, Any]:
         return await self.write_answer_file(f"{task_id}_{iteration}", content)
 
@@ -108,10 +130,24 @@ class LoopMemoryStore:
         return f"{base_dir}_{task_id}_{iteration}"
 
     async def _write_text_artifact(self, artifact_id: str, text: str, metadata: dict[str, Any]) -> None:
-        artifact = Artifact(
+        await self._write_artifact(
             artifact_id=artifact_id,
             artifact_type=ArtifactType.TEXT,
             content=text,
+            metadata=metadata,
+        )
+
+    async def _write_artifact(
+        self,
+        artifact_id: str,
+        artifact_type: ArtifactType,
+        content: Any,
+        metadata: dict[str, Any],
+    ) -> None:
+        artifact = Artifact(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            content=content,
             metadata=metadata,
         )
         await self.context.workspace.add_artifact(artifact, index=False)

--- a/aworld/runners/ralph/policy.py
+++ b/aworld/runners/ralph/policy.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from aworld.runners.ralph.config import RalphConfig
+if TYPE_CHECKING:
+    from aworld.runners.ralph.config import RalphConfig
 
 
 @dataclass
@@ -9,7 +11,7 @@ class RalphLoopPolicy:
     verify_enabled: bool
 
     @classmethod
-    def from_config(cls, config: RalphConfig) -> "RalphLoopPolicy":
+    def from_config(cls, config: "RalphConfig") -> "RalphLoopPolicy":
         return cls(
             execution_mode=config.execution_mode,
             verify_enabled=bool(config.verify.enabled),

--- a/aworld/runners/ralph/policy.py
+++ b/aworld/runners/ralph/policy.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from aworld.runners.ralph.config import RalphConfig
+
+
+@dataclass
+class RalphLoopPolicy:
+    execution_mode: str
+    verify_enabled: bool
+
+    @classmethod
+    def from_config(cls, config: RalphConfig) -> "RalphLoopPolicy":
+        return cls(
+            execution_mode=config.execution_mode,
+            verify_enabled=bool(config.verify.enabled),
+        )

--- a/aworld/runners/ralph/state.py
+++ b/aworld/runners/ralph/state.py
@@ -13,7 +13,9 @@ from aworld.core.context.base import Context
 from aworld.core.task import Task
 from aworld.logs.util import logger
 from aworld.output import WorkSpace
+from aworld.runners.ralph.input_builder import IterationInputBuilder
 from aworld.runners.ralph.memory import LoopMemoryStore
+from aworld.runners.ralph.policy import RalphLoopPolicy
 from aworld.runners.ralph.types import CompletionCriteria
 from aworld.sandbox import Sandbox
 from aworld.utils.common import convert_to_subclass
@@ -195,37 +197,24 @@ class LoopContext(ApplicationContext):
         Returns:
             Context with injected feedback
         """
-        feedback_content = ""
-        task_answer = ''
-        if iter_num > 1:
-            # read answer
-            task_answer = await self.memory.read_answer(task.id, iter_num - 1) or ""
-            if task_answer:
-                logger.info(f"Read answer for task {task.id} iteration {iter_num - 1}")
-
-            # Read reflection/feedback from previous iteration
-            feedback_content = await self.memory.read_reflection_feedback(task.id, iter_num - 1) or ""
-
-            if feedback_content:
-                logger.info(f"Read feedback for task {task.id} iteration {iter_num}: {feedback_content[:100]}...")
-            else:
-                # Default feedback if no artifact found
-                feedback_content = "Your previous answer was incorrect. Please read the original question carefully, check and analyze it, and try to answer it again."
-                logger.info(f"No feedback artifact found, using default feedback for iteration {iter_num}")
-
-        # Inject feedback into task input
-        if feedback_content:
-            if reuse_context:
-                task_content = f"Previous answer: {task_answer}\n\n{feedback_content}"
-            else:
-                task_content = f"Previous answer: {task_answer}\n\n{feedback_content}\n\nOriginal task: {task.input}"
-        else:
-            task_content = task.input
+        builder = IterationInputBuilder(
+            policy=RalphLoopPolicy(
+                execution_mode="reuse_context" if reuse_context else "fresh_context",
+                verify_enabled=False,
+            ),
+            memory_store=self.memory,
+        )
+        iteration_input = await builder.build(
+            task_id=task.id,
+            original_task=kwargs.get("original_task", task.input),
+            iteration=iter_num,
+        )
+        task_content = iteration_input.task_input
 
         task.input = task_content
         logger.debug(f"Task input after feedback injection: {task_content[:200]}...")
 
-        if reuse_context:
+        if iteration_input.reuse_context:
             return self
         return await self.build_sub_context(sub_task_content=task_content, sub_task_id=task.id, task=task, **kwargs)
 

--- a/aworld/runners/ralph/state.py
+++ b/aworld/runners/ralph/state.py
@@ -58,7 +58,13 @@ class LoopState:
 class LoopContext(ApplicationContext):
     """Loop context records the global information of the entire process."""
 
-    def __init__(self, loop_state: LoopState = LoopState(), work_dir: str = ".", **kwargs):
+    def __init__(
+        self,
+        completion_criteria: Optional[CompletionCriteria] = None,
+        loop_state: Optional[LoopState] = None,
+        work_dir: str = ".",
+        **kwargs,
+    ):
         if "task_state" not in kwargs:
             base_context = ApplicationContext.create(task_content="")
             kwargs = {
@@ -70,15 +76,19 @@ class LoopContext(ApplicationContext):
                 **kwargs,
             }
         super().__init__(**kwargs)
-        self.loop_init(loop_state=loop_state, work_dir=work_dir)
+        self.loop_init(
+            completion_criteria=completion_criteria,
+            loop_state=loop_state,
+            work_dir=work_dir,
+        )
 
     def loop_init(self,
-                  completion_criteria: CompletionCriteria = CompletionCriteria(),
-                  loop_state: LoopState = LoopState(),
+                  completion_criteria: Optional[CompletionCriteria] = None,
+                  loop_state: Optional[LoopState] = None,
                   work_dir: str = "."):
         self._id = uuid.uuid4().hex
-        self._completion_criteria = completion_criteria
-        self.loop_state = loop_state
+        self._completion_criteria = completion_criteria or CompletionCriteria()
+        self.loop_state = loop_state or LoopState()
         self.work_dir = work_dir
         self.workspace = WorkSpace(workspace_id=self.work_dir)
         self.check_directories()
@@ -189,10 +199,9 @@ class LoopContext(ApplicationContext):
         task_answer = ''
         if iter_num > 1:
             # read answer
-            answer_path = self.memory.answer_path(task.id, iter_num - 1)
-            if answer_path.exists():
+            task_answer = await self.memory.read_answer(task.id, iter_num - 1) or ""
+            if task_answer:
                 logger.info(f"Read answer for task {task.id} iteration {iter_num - 1}")
-                task_answer = await self.memory.read_answer(task.id, iter_num - 1) or ""
 
             # Read reflection/feedback from previous iteration
             feedback_content = await self.memory.read_reflection_feedback(task.id, iter_num - 1) or ""
@@ -255,7 +264,18 @@ class LoopContext(ApplicationContext):
             logger.warning(f"Unsupported content type: {type(content)}, converting to string")
             artifact_content = str(content)
 
-        await self.memory.write_reflection_feedback(task_id, iter_num, artifact_content)
+        await self.memory.write_reflection_feedback_artifact(
+            task_id=task_id,
+            iteration=iter_num,
+            text=artifact_content,
+            metadata={
+                "context_type": content_type,
+                "iteration": iter_num,
+                "task_id": task_id,
+                "timestamp": time.time(),
+                "kind": "reflection_feedback",
+            },
+        )
         logger.info(
             f"Written {content_type} to loop context: "
             f"{self.memory.reflection_feedback_artifact_id(task_id, iter_num)} "
@@ -299,10 +319,10 @@ class LoopContext(ApplicationContext):
 
         task_key, separator, suffix = filename.rpartition("_")
         if separator and suffix.isdigit():
-            await self.memory.write_answer(task_key, int(suffix), content)
+            result = await self.memory.write_answer(task_key, int(suffix), content)
         else:
-            await self.memory.write_answer_file(filename, content)
-        res = {"success": True}
+            result = await self.memory.write_answer_file(filename, content)
+        res = result if isinstance(result, dict) else {"success": bool(result)}
         return res.get('success'), filename, content
 
 

--- a/aworld/runners/ralph/state.py
+++ b/aworld/runners/ralph/state.py
@@ -161,14 +161,15 @@ class LoopContext(ApplicationContext):
         # no need agent info to sub context
         context_config = AmniConfigFactory.create(AmniConfigLevel.NAVIGATOR)
         context_config.agent_config.neuron_names.clear()
+        sub_task_content = str(sub_task_content)
 
         task = kwargs.get("task")
         task_input = TaskInput(
             user_id=task.user_id or '',
             session_id=task.session_id or uuid.uuid4().hex,
             task_id=task.id,
-            task_content=task.input,
-            origin_user_input=task.input
+            task_content=sub_task_content,
+            origin_user_input=sub_task_content,
         )
         context_config = None
         new_context = await ApplicationContext.from_input(task_input, context_config=context_config)
@@ -181,6 +182,7 @@ class LoopContext(ApplicationContext):
 
         new_context.task_id = sub_task_id
         new_context.task_input = sub_task_content
+        new_context.origin_user_input = sub_task_content
         self.add_task_node(sub_task_id, self.task_id, caller_agent_info={}, **kwargs)
         return new_context
 

--- a/aworld/runners/ralph/state.py
+++ b/aworld/runners/ralph/state.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 # Copyright (c) inclusionAI.
-import json
-import os
 import time
 import uuid
 from copy import deepcopy
@@ -14,7 +12,8 @@ from aworld.core.context.amni.config import AmniConfigLevel
 from aworld.core.context.base import Context
 from aworld.core.task import Task
 from aworld.logs.util import logger
-from aworld.output import Artifact, ArtifactType, WorkSpace
+from aworld.output import WorkSpace
+from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.types import CompletionCriteria
 from aworld.sandbox import Sandbox
 from aworld.utils.common import convert_to_subclass
@@ -60,6 +59,16 @@ class LoopContext(ApplicationContext):
     """Loop context records the global information of the entire process."""
 
     def __init__(self, loop_state: LoopState = LoopState(), work_dir: str = ".", **kwargs):
+        if "task_state" not in kwargs:
+            base_context = ApplicationContext.create(task_content="")
+            kwargs = {
+                "task_state": base_context.task_state,
+                "workspace": getattr(base_context, "_workspace", None),
+                "parent": getattr(base_context, "_parent", None),
+                "context_config": base_context.get_config(),
+                "working_dir": getattr(base_context, "_working_dir", None),
+                **kwargs,
+            }
         super().__init__(**kwargs)
         self.loop_init(loop_state=loop_state, work_dir=work_dir)
 
@@ -72,9 +81,15 @@ class LoopContext(ApplicationContext):
         self.loop_state = loop_state
         self.work_dir = work_dir
         self.workspace = WorkSpace(workspace_id=self.work_dir)
-        self.checkpoints_dir()
+        self.check_directories()
         # use sandbox to manager file IO
-        self.sand_box = Sandbox.builder().builtin_tools(["filesystem"]).workspaces([work_dir]).build()
+        self.sand_box = (
+            Sandbox.builder()
+            .builtin_tools(["filesystem", "terminal"])
+            .workspaces([work_dir])
+            .build()
+        )
+        self.memory = LoopMemoryStore(self)
 
     @property
     def completion_criteria(self) -> CompletionCriteria:
@@ -101,6 +116,9 @@ class LoopContext(ApplicationContext):
     def summary_dir(self) -> Path:
         return self.task_dir() / "summary"
 
+    def answer_dir(self) -> Path:
+        return self.task_dir() / "answer"
+
     def reflect_dir(self) -> Path:
         return self.loop_dir() / "reflect"
 
@@ -121,6 +139,10 @@ class LoopContext(ApplicationContext):
         """Create necessary directories."""
         self.loop_dir().mkdir(parents=True, exist_ok=True)
         self.task_dir().mkdir(parents=True, exist_ok=True)
+        self.answer_dir().mkdir(parents=True, exist_ok=True)
+        self.summary_dir().mkdir(parents=True, exist_ok=True)
+        self.reflect_dir().mkdir(parents=True, exist_ok=True)
+        self.stop_dir().mkdir(parents=True, exist_ok=True)
         self.checkpoints_dir().mkdir(parents=True, exist_ok=True)
 
     async def build_sub_context(self, sub_task_content: Any, sub_task_id: str = None, **kwargs):
@@ -167,18 +189,15 @@ class LoopContext(ApplicationContext):
         task_answer = ''
         if iter_num > 1:
             # read answer
-            path = f"{self.work_dir}/{self.task_dir()}/answer/{task.id}_{iter_num - 1}"
-            if os.path.exists(path):
+            answer_path = self.memory.answer_path(task.id, iter_num - 1)
+            if answer_path.exists():
                 logger.info(f"Read answer for task {task.id} iteration {iter_num - 1}")
-                res = await self.sand_box.file.read_file(path)
-                task_answer = json.loads(res.get('data', '{}')).get('content', '')
+                task_answer = await self.memory.read_answer(task.id, iter_num - 1) or ""
 
             # Read reflection/feedback from previous iteration
-            artifact_id = f"{self.reflect_dir()}_{task.id}_{iter_num - 1}"
-            info = self.workspace.get_artifact_data(artifact_id)
+            feedback_content = await self.memory.read_reflection_feedback(task.id, iter_num - 1) or ""
 
-            if info and info.get("content"):
-                feedback_content = info.get("content")
+            if feedback_content:
                 logger.info(f"Read feedback for task {task.id} iteration {iter_num}: {feedback_content[:100]}...")
             else:
                 # Default feedback if no artifact found
@@ -222,7 +241,6 @@ class LoopContext(ApplicationContext):
             return
 
         task_id = task_context.get_task().id if task_context.get_task() else "unknown"
-        artifact_id = f"{self.reflect_dir()}_{task_id}_{iter_num}"
 
         # Handle different content types
         if isinstance(content, str):
@@ -237,20 +255,12 @@ class LoopContext(ApplicationContext):
             logger.warning(f"Unsupported content type: {type(content)}, converting to string")
             artifact_content = str(content)
 
-        artifact = Artifact(
-            artifact_id=artifact_id,
-            artifact_type=ArtifactType.TEXT,
-            content=artifact_content,
-            metadata={
-                "context_type": content_type,
-                "iteration": iter_num,
-                "task_id": task_id,
-                "timestamp": time.time()
-            }
+        await self.memory.write_reflection_feedback(task_id, iter_num, artifact_content)
+        logger.info(
+            f"Written {content_type} to loop context: "
+            f"{self.memory.reflection_feedback_artifact_id(task_id, iter_num)} "
+            f"(length: {len(artifact_content)})"
         )
-
-        await self.workspace.add_artifact(artifact, index=False)
-        logger.info(f"Written {content_type} to loop context: {artifact_id} (length: {len(artifact_content)})")
 
     def _format_dict_content(self, content: dict) -> str:
         """Format dictionary content as readable text."""
@@ -284,7 +294,15 @@ class LoopContext(ApplicationContext):
     async def add_file(self, filename: Optional[str], content: Optional[Any], mime_type: Optional[str] = "text",
                        namespace: str = "default", origin_type: str = None, origin_path: str = None,
                        refresh_workspace: bool = True) -> Tuple[bool, Optional[str], Optional[str]]:
-        res = await self.sand_box.file.write_file(path=f"{self.work_dir}/{self.task_dir()}/answer/{filename}", content=content)
+        if not filename:
+            return False, filename, content
+
+        task_key, separator, suffix = filename.rpartition("_")
+        if separator and suffix.isdigit():
+            await self.memory.write_answer(task_key, int(suffix), content)
+        else:
+            await self.memory.write_answer_file(filename, content)
+        res = {"success": True}
         return res.get('success'), filename, content
 
 

--- a/aworld/runners/ralph_runner.py
+++ b/aworld/runners/ralph_runner.py
@@ -83,8 +83,8 @@ class RalphRunner(Runner):
             original_task=self.original_task_input,
             iteration=iter_num,
         )
-        self.task_context = await self._build_iteration_context(iteration_input, task, iter_num)
         task.input = iteration_input.task_input
+        self.task_context = await self._build_iteration_context(iteration_input, task, iter_num)
         task.context = self.task_context
 
         results = await exec_tasks(tasks=[task])

--- a/aworld/runners/ralph_runner.py
+++ b/aworld/runners/ralph_runner.py
@@ -3,6 +3,8 @@
 from aworld.core.task import Runner, Task, TaskResponse
 from aworld.logs.util import logger
 from aworld.runners.event_runner import TaskEventRunner
+from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
+from aworld.runners.ralph.policy import RalphLoopPolicy
 from aworld.utils.run_util import exec_tasks
 from aworld.runners.ralph.config import RalphConfig
 from aworld.runners.ralph.detect.detector import create_stop_detector
@@ -27,10 +29,14 @@ class RalphRunner(Runner):
         self.ralph_config = self.task.conf if self.task.conf else RalphConfig.create(
             model_config=task.swarm.ordered_agents[0].conf.llm_config if task.swarm else task.agent.conf.llm_config)
         self.completion_criteria = completion_criteria or CompletionCriteria()
+        self.original_task_input = self.task.input
 
         # State management
         self.loop_context = None
         self.task_context = None
+        self.policy = RalphLoopPolicy.from_config(self.ralph_config)
+        self.memory_store = None
+        self.input_builder = None
 
         # Initialize components
         self._init_stop_detector()
@@ -40,6 +46,8 @@ class RalphRunner(Runner):
                                             completion_criteria=self.completion_criteria,
                                             loop_state=LoopState(confirmation_threshold=1),
                                             work_dir=self.ralph_config.workspace)
+        self.memory_store = self.loop_context.memory
+        self.input_builder = IterationInputBuilder(policy=self.policy, memory_store=self.memory_store)
 
     async def do_run(self):
         execution_result = TaskResponse()
@@ -70,11 +78,13 @@ class RalphRunner(Runner):
         self.stop_detector = create_stop_detector(custom_detectors=detectors)
 
     async def _execute_task(self, task: Task, iter_num: int) -> TaskResponse:
-        self.task_context = to_loop_context(
-            await self.loop_context.read_to_task_context(task=task, iter_num=iter_num,
-                                                         reuse_context=self.ralph_config.reuse_context),
-            work_dir=self.ralph_config.workspace
+        iteration_input = await self.input_builder.build(
+            task_id=task.id,
+            original_task=self.original_task_input,
+            iteration=iter_num,
         )
+        self.task_context = await self._build_iteration_context(iteration_input, task, iter_num)
+        task.input = iteration_input.task_input
         task.context = self.task_context
 
         results = await exec_tasks(tasks=[task])
@@ -85,3 +95,16 @@ class RalphRunner(Runner):
                                                       iter_num=iter_num,
                                                       reuse_context=self.ralph_config.reuse_context)
         return execution_result
+
+    async def _build_iteration_context(self, iteration_input: IterationInput, task: Task, iter_num: int):
+        if self.policy.execution_mode == "reuse_context":
+            return to_loop_context(self.loop_context, work_dir=self.ralph_config.workspace)
+
+        return to_loop_context(
+            await self.loop_context.build_sub_context(
+                sub_task_content=iteration_input.task_input,
+                sub_task_id=task.id,
+                task=task,
+            ),
+            work_dir=self.ralph_config.workspace,
+        )

--- a/aworld/runners/ralph_runner.py
+++ b/aworld/runners/ralph_runner.py
@@ -4,6 +4,7 @@ from aworld.core.task import Runner, Task, TaskResponse
 from aworld.logs.util import logger
 from aworld.runners.event_runner import TaskEventRunner
 from aworld.runners.ralph.evaluator import IterationEvaluator
+from aworld.runners.ralph.detect.types import StopType
 from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
 from aworld.runners.ralph.policy import RalphLoopPolicy
 from aworld.utils.run_util import exec_tasks
@@ -39,6 +40,9 @@ class RalphRunner(Runner):
         self.memory_store = None
         self.input_builder = None
         self.evaluator = None
+        self._last_execution_result = None
+        self._last_executed_iteration = 0
+        self._last_verified_iteration = 0
 
         # Initialize components
         self._init_stop_detector()
@@ -67,6 +71,7 @@ class RalphRunner(Runner):
             logger.info(f"Iteration {iter_num} Stop condition check...")
             stop_decision = await self.stop_detector.should_stop(self.loop_context)
             if stop_decision.should_stop:
+                await self._maybe_verify_before_completion(stop_decision)
                 logger.info(f"Loop terminated: {stop_decision.stop_type}, Reason: {stop_decision.reason}")
                 break
 
@@ -74,11 +79,14 @@ class RalphRunner(Runner):
             logger.info(f"Iteration {iter_num} Executing task...")
             try:
                 execution_result = await self._execute_task(cur_task, iter_num=iter_num)
-                if self.evaluator is not None:
-                    await self.evaluator.evaluate(
+                self._last_execution_result = execution_result
+                self._last_executed_iteration = iter_num
+                if self._should_verify_after_iteration():
+                    await self._evaluate_iteration(
                         task=cur_task,
                         iter_num=iter_num,
                         execution_result=execution_result,
+                        phase="post_iteration",
                     )
             except:
                 logger.error(f"Error executing task: {cur_task.id}")
@@ -89,6 +97,44 @@ class RalphRunner(Runner):
     def _init_stop_detector(self):
         detectors = self.ralph_config.stop_condition.stop_detectors or []
         self.stop_detector = create_stop_detector(custom_detectors=detectors)
+
+    def _should_verify_after_iteration(self) -> bool:
+        return bool(
+            self.evaluator is not None
+            and self.ralph_config.verify.enabled
+            and self.ralph_config.verify.run_on_each_iteration
+        )
+
+    def _should_verify_before_completion(self, stop_decision) -> bool:
+        return bool(
+            self.evaluator is not None
+            and self.ralph_config.verify.enabled
+            and self.ralph_config.verify.run_before_completion
+            and self._last_execution_result is not None
+            and self._last_executed_iteration > 0
+            and self._last_verified_iteration != self._last_executed_iteration
+            and stop_decision.stop_type in {StopType.COMPLETION, StopType.CUSTOM_STOPPED}
+        )
+
+    async def _maybe_verify_before_completion(self, stop_decision) -> None:
+        if not self._should_verify_before_completion(stop_decision):
+            return
+
+        await self._evaluate_iteration(
+            task=self.task,
+            iter_num=self._last_executed_iteration,
+            execution_result=self._last_execution_result,
+            phase="before_completion",
+        )
+
+    async def _evaluate_iteration(self, task: Task, iter_num: int, execution_result: TaskResponse, phase: str) -> None:
+        await self.evaluator.evaluate(
+            task=task,
+            iter_num=iter_num,
+            execution_result=execution_result,
+            phase=phase,
+        )
+        self._last_verified_iteration = iter_num
 
     async def _execute_task(self, task: Task, iter_num: int) -> TaskResponse:
         iteration_input = await self.input_builder.build(

--- a/aworld/runners/ralph_runner.py
+++ b/aworld/runners/ralph_runner.py
@@ -3,6 +3,7 @@
 from aworld.core.task import Runner, Task, TaskResponse
 from aworld.logs.util import logger
 from aworld.runners.event_runner import TaskEventRunner
+from aworld.runners.ralph.evaluator import IterationEvaluator
 from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
 from aworld.runners.ralph.policy import RalphLoopPolicy
 from aworld.utils.run_util import exec_tasks
@@ -37,6 +38,7 @@ class RalphRunner(Runner):
         self.policy = RalphLoopPolicy.from_config(self.ralph_config)
         self.memory_store = None
         self.input_builder = None
+        self.evaluator = None
 
         # Initialize components
         self._init_stop_detector()
@@ -48,6 +50,11 @@ class RalphRunner(Runner):
                                             work_dir=self.ralph_config.workspace)
         self.memory_store = self.loop_context.memory
         self.input_builder = IterationInputBuilder(policy=self.policy, memory_store=self.memory_store)
+        self.evaluator = IterationEvaluator(
+            context=self.loop_context,
+            memory_store=self.memory_store,
+            verify_config=self.ralph_config.verify,
+        )
 
     async def do_run(self):
         execution_result = TaskResponse()
@@ -67,6 +74,12 @@ class RalphRunner(Runner):
             logger.info(f"Iteration {iter_num} Executing task...")
             try:
                 execution_result = await self._execute_task(cur_task, iter_num=iter_num)
+                if self.evaluator is not None:
+                    await self.evaluator.evaluate(
+                        task=cur_task,
+                        iter_num=iter_num,
+                        execution_result=execution_result,
+                    )
             except:
                 logger.error(f"Error executing task: {cur_task.id}")
                 # error process

--- a/aworld/runners/ralph_runner.py
+++ b/aworld/runners/ralph_runner.py
@@ -71,9 +71,10 @@ class RalphRunner(Runner):
             logger.info(f"Iteration {iter_num} Stop condition check...")
             stop_decision = await self.stop_detector.should_stop(self.loop_context)
             if stop_decision.should_stop:
-                await self._maybe_verify_before_completion(stop_decision)
-                logger.info(f"Loop terminated: {stop_decision.stop_type}, Reason: {stop_decision.reason}")
-                break
+                should_terminate = await self._maybe_verify_before_completion(stop_decision)
+                if should_terminate:
+                    logger.info(f"Loop terminated: {stop_decision.stop_type}, Reason: {stop_decision.reason}")
+                    break
 
             # 2. Execute task
             logger.info(f"Iteration {iter_num} Executing task...")
@@ -81,13 +82,12 @@ class RalphRunner(Runner):
                 execution_result = await self._execute_task(cur_task, iter_num=iter_num)
                 self._last_execution_result = execution_result
                 self._last_executed_iteration = iter_num
-                if self._should_verify_after_iteration():
-                    await self._evaluate_iteration(
-                        task=cur_task,
-                        iter_num=iter_num,
-                        execution_result=execution_result,
-                        phase="post_iteration",
-                    )
+                await self._evaluate_iteration(
+                    task=cur_task,
+                    iter_num=iter_num,
+                    execution_result=execution_result,
+                    phase="post_iteration",
+                )
             except:
                 logger.error(f"Error executing task: {cur_task.id}")
                 # error process
@@ -97,13 +97,6 @@ class RalphRunner(Runner):
     def _init_stop_detector(self):
         detectors = self.ralph_config.stop_condition.stop_detectors or []
         self.stop_detector = create_stop_detector(custom_detectors=detectors)
-
-    def _should_verify_after_iteration(self) -> bool:
-        return bool(
-            self.evaluator is not None
-            and self.ralph_config.verify.enabled
-            and self.ralph_config.verify.run_on_each_iteration
-        )
 
     def _should_verify_before_completion(self, stop_decision) -> bool:
         return bool(
@@ -116,25 +109,37 @@ class RalphRunner(Runner):
             and stop_decision.stop_type in {StopType.COMPLETION, StopType.CUSTOM_STOPPED}
         )
 
-    async def _maybe_verify_before_completion(self, stop_decision) -> None:
+    async def _maybe_verify_before_completion(self, stop_decision) -> bool:
         if not self._should_verify_before_completion(stop_decision):
-            return
+            return True
 
-        await self._evaluate_iteration(
+        evaluation = await self._evaluate_iteration(
             task=self.task,
             iter_num=self._last_executed_iteration,
             execution_result=self._last_execution_result,
             phase="before_completion",
         )
+        if evaluation.verify_result is not None and not evaluation.verify_result.passed:
+            logger.info("Pre-completion verification failed; continuing Ralph loop for another repair iteration.")
+            return False
+        return True
 
-    async def _evaluate_iteration(self, task: Task, iter_num: int, execution_result: TaskResponse, phase: str) -> None:
-        await self.evaluator.evaluate(
+    async def _evaluate_iteration(
+        self,
+        task: Task,
+        iter_num: int,
+        execution_result: TaskResponse,
+        phase: str,
+    ):
+        evaluation = await self.evaluator.evaluate(
             task=task,
             iter_num=iter_num,
             execution_result=execution_result,
             phase=phase,
         )
-        self._last_verified_iteration = iter_num
+        if evaluation.verify_result is not None:
+            self._last_verified_iteration = iter_num
+        return evaluation
 
     async def _execute_task(self, task: Task, iter_num: int) -> TaskResponse:
         iteration_input = await self.input_builder.build(

--- a/docs/features/ralph-runner-dual-mode.md
+++ b/docs/features/ralph-runner-dual-mode.md
@@ -1,0 +1,181 @@
+# RalphRunner Dual-Mode
+
+**Version:** 1.0  
+**Status:** Production Ready  
+**Feature Type:** Framework Runner
+
+---
+
+## Overview
+
+`RalphRunner` is the framework-level Ralph execution capability in AWorld.
+
+It is designed for agents or swarms that need iterative convergence inside a single AWorld runtime. It is separate from the CLI `ralph-session-loop` plugin:
+
+- `RalphRunner` handles inner task convergence
+- the CLI plugin handles outer interactive session continuation
+
+The two layers are intentionally independent.
+
+---
+
+## When To Use It
+
+Use `RalphRunner` when you want:
+
+- programmatic Ralph execution from Python
+- a bounded inner loop with explicit completion criteria
+- iteration memory persisted through AWorld workspace and sandbox primitives
+- framework-managed verification before accepting completion
+
+Do not use it for:
+
+- fresh process spawning
+- CLI session continuation
+- operator-driven `exit` / resume control
+
+Those belong to the CLI plugin or future external orchestration.
+
+---
+
+## Public Entry Points
+
+You can use either:
+
+```python
+from aworld.runner import Runners
+```
+
+or:
+
+```python
+from aworld.runners.ralph_runner import RalphRunner
+```
+
+The compatibility goal is unchanged:
+
+- `Runners.ralph_run(task, completion_criteria)`
+- `RalphRunner(task=task, completion_criteria=...)`
+
+---
+
+## Quick Start
+
+```python
+from aworld.agents.llm_agent import Agent
+from aworld.core.task import Task
+from aworld.runner import Runners
+from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.types import CompletionCriteria
+
+agent = Agent(name="builder", conf=...)
+
+ralph_config = RalphConfig.create(model_config=agent.conf.llm_config)
+ralph_config.execution_mode = "reuse_context"
+
+task = Task(
+    input="Build a REST API with tests",
+    agent=agent,
+    conf=ralph_config,
+)
+
+result = await Runners.ralph_run(
+    task=task,
+    completion_criteria=CompletionCriteria(max_iterations=5),
+)
+```
+
+---
+
+## Execution Modes
+
+### `reuse_context`
+
+Use this when each iteration should continue in the same task/runtime context.
+
+Characteristics:
+
+- preserves running context across iterations
+- best when the agent benefits from accumulated context
+- remains the default for backward compatibility
+
+### `fresh_context`
+
+Use this when each iteration should rebuild from persisted loop memory instead of reusing runtime context.
+
+Characteristics:
+
+- each iteration starts from a fresh sub-context
+- loop continuity comes from persisted memory, not prior in-memory context
+- useful when you want tighter iteration isolation
+
+Example:
+
+```python
+ralph_config.execution_mode = "fresh_context"
+```
+
+`reuse_context` is still supported as a compatibility field, but `execution_mode` is now the preferred internal and external knob.
+
+---
+
+## Verification
+
+`RalphRunner` can execute real verification commands through the sandbox terminal.
+
+```python
+from aworld.runners.ralph.config import RalphVerifyConfig
+
+ralph_config.verify = RalphVerifyConfig(
+    enabled=True,
+    commands=[
+        "pytest tests/api -q",
+        "ruff check .",
+    ],
+    run_on_each_iteration=False,
+    run_before_completion=True,
+)
+```
+
+Behavior:
+
+- verification can run after each iteration and/or before final completion
+- failed pre-completion verification keeps the Ralph loop alive for another repair round
+- verify outputs and feedback are persisted into loop memory
+
+---
+
+## Iteration Limits And Boundary With The CLI Plugin
+
+Framework and CLI iteration controls are separate:
+
+- `CompletionCriteria(max_iterations=...)` controls the inner `RalphRunner` loop
+- `/ralph-loop --max-iterations ...` controls the outer CLI session continuation loop
+
+Neither overrides the other automatically.
+
+This is the intended boundary:
+
+- outer plugin decides whether the current CLI session should continue
+- inner runner decides whether the current task execution has converged
+
+---
+
+## Memory Model
+
+`RalphRunner` does not introduce a new storage system. It reuses existing AWorld primitives:
+
+- workspace artifacts for structured iteration memory
+- sandbox file access for file-shaped intermediate state
+- sandbox terminal for verification execution
+
+This gives `fresh_context` mode a durable memory contract without coupling the runner to CLI-only orchestration.
+
+---
+
+## Compatibility Notes
+
+- Existing callers using `Runners.ralph_run(...)` still work.
+- Existing callers using `reuse_context` still work.
+- Prefer `execution_mode` for new code.
+- `RalphRunner` remains a framework capability, not a CLI-only mechanism.

--- a/docs/plugins/plugin-sdk.md
+++ b/docs/plugins/plugin-sdk.md
@@ -56,6 +56,74 @@ Resolution is deterministic and follows plugin discovery order.
 Host-owned plugin capability helpers live under `aworld_cli.plugin_capabilities`.
 Legacy alias namespaces `aworld_cli.plugin_runtime.*` and `aworld_cli.plugin_framework.*` have been removed.
 
+## Interactive Slash Command Contract
+
+Framework plugins may contribute interactive slash commands through manifest `entrypoints.commands`.
+
+Minimal markdown-backed manifest example:
+
+```json
+{
+  "id": "example-command-plugin",
+  "version": "1.0.0",
+  "entrypoints": {
+    "commands": [
+      {
+        "id": "review-loop",
+        "name": "review-loop",
+        "target": "commands/review-loop.md",
+        "scope": "workspace"
+      }
+    ]
+  }
+}
+```
+
+Markdown-backed command behavior:
+
+- the target file is loaded as prompt text
+- the CLI appends `User args: ...`
+- the generated prompt is executed through the active agent session
+
+Framework plugins may also contribute Python-backed interactive commands.
+
+Minimal Python-backed manifest example:
+
+```json
+{
+  "id": "example-command-plugin",
+  "version": "1.0.0",
+  "entrypoints": {
+    "commands": [
+      {
+        "id": "ralph-loop",
+        "name": "ralph-loop",
+        "target": "commands/ralph_loop.py",
+        "scope": "session",
+        "metadata": {
+          "factory": "build_command"
+        }
+      }
+    ]
+  }
+}
+```
+
+Python target module contract:
+
+- default factory name is `build_command`
+- the factory is called as `build_command(plugin, entrypoint)`
+- the factory must return an `aworld_cli.core.command_system.Command` instance
+
+Useful host integration points for Python-backed commands:
+
+- `CommandContext.cwd`
+- `CommandContext.user_args`
+- `CommandContext.runtime`
+- `CommandContext.session_id`
+
+If a command needs access to plugin-scoped persisted state, it should resolve state through the runtime-owned plugin state store rather than creating ad hoc dotfiles.
+
 ## CLI Command Contract
 
 Framework plugins may contribute top-level CLI commands through manifest `entrypoints.cli_commands`.

--- a/docs/plugins/ralph-session-loop-plugin.md
+++ b/docs/plugins/ralph-session-loop-plugin.md
@@ -1,0 +1,205 @@
+# Ralph Session Loop Plugin
+
+This document explains how to use the built-in Ralph session-loop plugin in AWorld CLI.
+
+## What It Does
+
+The Ralph plugin keeps a task running inside the **current interactive CLI session**.
+
+The flow is:
+
+1. Start a loop with `/ralph-loop`
+2. Let the agent work on the task
+3. Type `exit`
+4. The plugin `stop` hook intercepts the exit
+5. If the loop is not finished, the same task is fed back as a follow-up prompt
+6. The loop continues until completion, cancellation, or iteration limit
+
+This is the phase-1 interactive Ralph model. It is **not** the fresh-process orchestration model.
+
+## Commands
+
+Start a Ralph loop:
+
+```text
+/ralph-loop "Build a REST API" --max-iterations 5
+```
+
+Start a Ralph loop with declarative verification:
+
+```text
+/ralph-loop "Create a CLI tool" --verify "pytest tests/cli -q" --completion-promise "COMPLETE"
+```
+
+Cancel the active loop:
+
+```text
+/cancel-ralph
+```
+
+## Supported Arguments
+
+`/ralph-loop` supports:
+
+- prompt text
+- repeatable `--verify`
+- optional `--completion-promise`
+- optional `--max-iterations`
+
+Examples:
+
+```text
+/ralph-loop "Build a Python course"
+```
+
+```text
+/ralph-loop "Build a REST API" --max-iterations 5
+```
+
+```text
+/ralph-loop "Create a CLI tool" --verify "pytest tests/cli -q" --verify "ruff check ." --completion-promise "COMPLETE"
+```
+
+## How Verification Works
+
+Phase 1 uses **declarative verification**, not stop-hook-executed verification.
+
+That means:
+
+- `--verify` values are stored in plugin state
+- they are injected into the effective task prompt
+- the agent is instructed to run them before claiming completion
+- the plugin itself does not execute those commands inside the stop hook
+
+For example:
+
+```text
+/ralph-loop "Create a CLI tool" --verify "pytest tests/cli -q" --completion-promise "COMPLETE"
+```
+
+The follow-up prompt will include sections similar to:
+
+```text
+Task:
+Create a CLI tool
+
+Verification requirements:
+1. Run: pytest tests/cli -q
+
+Completion rule:
+Only output <promise>COMPLETE</promise> when every verification requirement passes.
+```
+
+## Completion Behavior
+
+If you set a completion promise, the loop stops only when the latest final answer contains the exact promise tag.
+
+Example:
+
+```text
+/ralph-loop "Create a CLI tool" --completion-promise "COMPLETE"
+```
+
+Required completion output:
+
+```text
+<promise>COMPLETE</promise>
+```
+
+The match is exact and case-sensitive.
+
+## Iteration Limit Behavior
+
+If you set `--max-iterations`, the loop stops once the recorded iteration reaches that value.
+
+Example:
+
+```text
+/ralph-loop "Build a REST API" --max-iterations 5
+```
+
+Expected behavior:
+
+- first few `exit` attempts continue the loop
+- once iteration `5` is reached, `exit` is allowed
+
+## Typical Workflow
+
+1. Start `aworld-cli`
+2. Run a Ralph command
+3. Let the agent complete one pass
+4. Type `exit`
+5. If the task is incomplete, the loop continues
+6. Repeat until:
+   - the completion promise is satisfied
+   - the iteration limit is reached
+   - you run `/cancel-ralph`
+
+## HUD
+
+When the loop is active, the HUD can show summary state such as:
+
+- `Ralph: active`
+- `Iter: 2/5`
+- `Promise: COMPLETE`
+
+If no loop is active, the HUD shows `Ralph: inactive`.
+
+## Current Limits
+
+The current phase-1 plugin does **not** support:
+
+- fresh-process Ralph orchestration
+- `--model`
+- `--work-dir`
+- stop-hook-executed verification commands
+- advanced multi-branch planning artifacts like `prd.json` and `progress.txt`
+
+Those belong to a later phase.
+
+## Manual Smoke Check
+
+Try this:
+
+```text
+/ralph-loop "Build a REST API" --verify "pytest tests/cli -q" --completion-promise "COMPLETE" --max-iterations 3
+```
+
+Then:
+
+1. let the agent answer once
+2. type `exit`
+
+Expected:
+
+- the session does not exit immediately
+- a Ralph iteration message is shown
+- the task is continued with a follow-up prompt
+
+Then cancel:
+
+```text
+/cancel-ralph
+```
+
+Type `exit` again.
+
+Expected:
+
+- the session exits normally
+
+## Troubleshooting
+
+If `exit` does not continue the task:
+
+- confirm that `/ralph-loop` was started in the current session
+- confirm that the loop was not already cancelled
+- confirm that `--max-iterations` was not already reached
+- confirm that the completion promise was not already satisfied
+
+If the loop never completes:
+
+- use a smaller task
+- add one or more `--verify` commands
+- add an explicit `--completion-promise`
+- set a reasonable `--max-iterations`

--- a/docs/plugins/ralph-session-loop-plugin.md
+++ b/docs/plugins/ralph-session-loop-plugin.md
@@ -17,6 +17,22 @@ The flow is:
 
 This is the phase-1 interactive Ralph model. It is **not** the fresh-process orchestration model.
 
+## Boundary With RalphRunner
+
+The Ralph session-loop plugin and `RalphRunner` are intentionally different layers.
+
+- the Ralph plugin is an `aworld-cli` capability for continuing work across an interactive session
+- `RalphRunner` is an `aworld` framework capability for running Ralph-style convergence inside task execution
+
+The phase-1 plugin does **not** call `RalphRunner`, wrap `RalphRunner`, or depend on `RalphRunner`.
+
+The intended boundary is:
+
+- outer plugin controls whether the current CLI session should continue into another round
+- inner runner controls whether a single task execution has converged
+
+That means Ralph support in AWorld is **not** limited to the CLI plugin. Framework users can still use Ralph through runner-level APIs, while CLI users can use the session-loop plugin as a separate interaction model.
+
 ## Commands
 
 Start a Ralph loop:
@@ -122,6 +138,12 @@ Expected behavior:
 
 - first few `exit` attempts continue the loop
 - once iteration `5` is reached, `exit` is allowed
+
+Important:
+
+- plugin `--max-iterations` applies only to the outer session loop
+- it does not override or configure `RalphRunner` internal `max_iterations`
+- if a task is ever executed by a runner with its own internal iteration cap, that cap remains an inner execution concern
 
 ## Typical Workflow
 

--- a/docs/superpowers/plans/2026-04-27-ralph-runner-dual-mode.md
+++ b/docs/superpowers/plans/2026-04-27-ralph-runner-dual-mode.md
@@ -1,0 +1,517 @@
+# RalphRunner Dual-Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade `RalphRunner` into a framework-level dual-mode Ralph loop that preserves the current public API, adds explicit `reuse_context` and `fresh_context` execution modes, introduces a thin loop memory abstraction over existing AWorld persistence primitives, and wires real verification into the framework loop.
+
+**Architecture:** Keep `RalphRunner` and `aworld.runner.ralph_run(...)` as the public entrypoints, but refactor the internal loop into explicit policy, memory, iteration-input, and evaluation components. Reuse `LoopContext`, `WorkSpace`, and sandbox file/terminal capabilities rather than inventing a parallel storage or orchestration layer. Stage the work so compatibility and structural seams land before behavior changes such as `fresh_context` reconstruction and verification execution.
+
+**Tech Stack:** Python 3.12, pytest, existing AWorld runner/context/workspace/sandbox stack, `Sandbox.builder()` filesystem and terminal namespaces.
+
+---
+
+## File Structure
+
+### Existing files to modify
+
+- Modify: `aworld/runners/ralph/config.py`
+- Modify: `aworld/runners/ralph/state.py`
+- Modify: `aworld/runners/ralph_runner.py`
+- Modify: `aworld/runner.py`
+
+Responsibilities:
+
+- `config.py`: explicit execution mode and verify config, plus compatibility mapping from `reuse_context`
+- `state.py`: move ad hoc read/write behavior behind structured loop memory helpers and enable optional terminal-backed verification
+- `ralph_runner.py`: orchestrate the loop via policy, input builder, and evaluator instead of inline mode branching
+- `runner.py`: preserve the public `ralph_run(...)` entrypoint while allowing config-driven dual-mode behavior
+
+### New internal modules to create
+
+- Create: `aworld/runners/ralph/policy.py`
+- Create: `aworld/runners/ralph/memory.py`
+- Create: `aworld/runners/ralph/input_builder.py`
+- Create: `aworld/runners/ralph/evaluator.py`
+
+Responsibilities:
+
+- `policy.py`: normalize effective Ralph config, execution mode, and compatibility behavior
+- `memory.py`: thin `LoopMemoryStore` over existing artifact/file persistence
+- `input_builder.py`: build per-iteration task input for both `reuse_context` and `fresh_context`
+- `evaluator.py`: run verify/summary/reflection after each iteration and persist results back into loop memory
+
+### Tests to add or modify
+
+- Add: `tests/runners/test_ralph_runner_dual_mode.py`
+- Add: `tests/runners/test_ralph_loop_memory_store.py`
+- Add: `tests/runners/test_ralph_iteration_evaluator.py`
+- Modify: `tests/runners/__init__.py` only if test package imports require it
+
+Responsibilities:
+
+- `test_ralph_runner_dual_mode.py`: compatibility mapping, runner mode behavior, public API preservation
+- `test_ralph_loop_memory_store.py`: artifact-first and file-assisted loop memory persistence
+- `test_ralph_iteration_evaluator.py`: verify result shaping and post-iteration feedback behavior
+
+---
+
+### Task 1: Freeze Public Ralph API and Config Compatibility Before Refactor
+
+**Files:**
+- Add: `tests/runners/test_ralph_runner_dual_mode.py`
+- Modify: `aworld/runners/ralph/config.py`
+
+- [ ] **Step 1: Add a failing test for the new explicit execution mode while preserving old `reuse_context` behavior**
+
+```python
+from aworld.runners.ralph.config import RalphConfig
+
+
+def test_ralph_config_defaults_to_reuse_context_execution_mode():
+    config = RalphConfig()
+
+    assert config.execution_mode == "reuse_context"
+    assert config.reuse_context is True
+```
+
+- [ ] **Step 2: Add a failing test for compatibility mapping when `reuse_context=False` is still used**
+
+```python
+from aworld.runners.ralph.policy import RalphLoopPolicy
+from aworld.runners.ralph.config import RalphConfig
+
+
+def test_ralph_loop_policy_maps_reuse_context_false_to_fresh_context():
+    config = RalphConfig()
+    config.reuse_context = False
+
+    policy = RalphLoopPolicy.from_config(config)
+
+    assert policy.execution_mode == "fresh_context"
+```
+
+- [ ] **Step 3: Add the minimal config surface to make those tests pass**
+
+```python
+@dataclass
+class RalphVerifyConfig:
+    enabled: bool = False
+    commands: list[str] = field(default_factory=list)
+    run_on_each_iteration: bool = False
+    run_before_completion: bool = True
+    success_policy: str = "all"
+    max_output_chars: int = 12000
+
+
+class RalphConfig(TaskConfig):
+    execution_mode: str = Field(default="reuse_context")
+    verify: RalphVerifyConfig = Field(default_factory=RalphVerifyConfig)
+    reuse_context: bool = Field(default=True)
+```
+
+- [ ] **Step 4: Run the new compatibility tests**
+
+Run:
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit the config-compatibility slice**
+
+```bash
+git add aworld/runners/ralph/config.py tests/runners/test_ralph_runner_dual_mode.py
+git commit -m "feat: add explicit ralph execution mode config"
+```
+
+---
+
+### Task 2: Extract `RalphLoopPolicy` and `LoopMemoryStore` Over Existing AWorld Persistence
+
+**Files:**
+- Create: `aworld/runners/ralph/policy.py`
+- Create: `aworld/runners/ralph/memory.py`
+- Modify: `aworld/runners/ralph/state.py`
+- Add: `tests/runners/test_ralph_loop_memory_store.py`
+
+- [ ] **Step 1: Add failing tests for artifact-first and file-assisted memory storage**
+
+```python
+import pytest
+
+from aworld.runners.ralph.memory import LoopMemoryStore
+from aworld.runners.ralph.state import LoopContext, LoopState
+from aworld.runners.ralph.types import CompletionCriteria
+
+
+@pytest.mark.asyncio
+async def test_loop_memory_store_round_trips_iteration_summary(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    store = LoopMemoryStore(context)
+
+    await store.write_iteration_summary("task-1", 1, "summary text")
+
+    assert await store.read_iteration_summary("task-1", 1) == "summary text"
+```
+
+- [ ] **Step 2: Add the policy object that centralizes effective mode resolution**
+
+```python
+from dataclasses import dataclass
+
+from aworld.runners.ralph.config import RalphConfig
+
+
+@dataclass
+class RalphLoopPolicy:
+    execution_mode: str
+    verify_enabled: bool
+
+    @classmethod
+    def from_config(cls, config: RalphConfig) -> "RalphLoopPolicy":
+        mode = config.execution_mode
+        if "execution_mode" not in config.__dict__:
+            mode = "reuse_context" if config.reuse_context else "fresh_context"
+        return cls(execution_mode=mode, verify_enabled=bool(config.verify.enabled))
+```
+
+- [ ] **Step 3: Add `LoopMemoryStore` as a thin adapter on top of `workspace` and `sandbox.file`**
+
+```python
+class LoopMemoryStore:
+    def __init__(self, context: LoopContext):
+        self.context = context
+
+    async def write_iteration_summary(self, task_id: str, iteration: int, text: str) -> None:
+        artifact = Artifact(
+            artifact_id=f"{self.context.summary_dir()}_{task_id}_{iteration}",
+            artifact_type=ArtifactType.TEXT,
+            content=text,
+            metadata={"task_id": task_id, "iteration": iteration, "kind": "summary"},
+        )
+        await self.context.workspace.add_artifact(artifact, index=False)
+```
+
+- [ ] **Step 4: Update `LoopContext` so sandbox tools can support both file memory and later verify execution**
+
+```python
+self.sand_box = (
+    Sandbox.builder()
+    .builtin_tools(["filesystem", "terminal"])
+    .workspaces([work_dir])
+    .build()
+)
+```
+
+- [ ] **Step 5: Run the loop-memory tests**
+
+Run:
+```bash
+pytest tests/runners/test_ralph_loop_memory_store.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the policy and memory extraction slice**
+
+```bash
+git add aworld/runners/ralph/policy.py aworld/runners/ralph/memory.py aworld/runners/ralph/state.py tests/runners/test_ralph_loop_memory_store.py tests/runners/test_ralph_runner_dual_mode.py
+git commit -m "refactor: extract ralph loop policy and memory store"
+```
+
+---
+
+### Task 3: Replace Ad Hoc Prompt Injection With `IterationInputBuilder`
+
+**Files:**
+- Create: `aworld/runners/ralph/input_builder.py`
+- Modify: `aworld/runners/ralph/state.py`
+- Modify: `aworld/runners/ralph_runner.py`
+- Modify: `tests/runners/test_ralph_runner_dual_mode.py`
+
+- [ ] **Step 1: Add a failing test that distinguishes `reuse_context` from `fresh_context`**
+
+```python
+import pytest
+
+from aworld.runners.ralph.input_builder import IterationInputBuilder
+
+
+@pytest.mark.asyncio
+async def test_iteration_input_builder_fresh_context_includes_original_task_and_memory(tmp_path):
+    builder = IterationInputBuilder(...)
+
+    payload = await builder.build(
+        task_input="Build a REST API",
+        iteration=2,
+        previous_answer="Created app.py",
+        reflection_feedback="Add tests next",
+    )
+
+    assert "Original task:" in payload.task_input
+    assert "Previous answer summary:" in payload.task_input
+    assert "Add tests next" in payload.task_input
+```
+
+- [ ] **Step 2: Add a normalized input builder contract**
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass
+class IterationInput:
+    task_input: str
+    reuse_context: bool
+
+
+class IterationInputBuilder:
+    async def build(... ) -> IterationInput:
+        ...
+```
+
+- [ ] **Step 3: Move the current `read_to_task_context(...)` string assembly into the new builder**
+
+```python
+sections = [
+    "Original task:",
+    original_task,
+    "",
+    f"Iteration: {iteration}",
+    "",
+    "Previous answer summary:",
+    previous_answer or "No previous answer available.",
+    "",
+    "Reflection feedback:",
+    reflection_feedback or "No reflection feedback available.",
+]
+```
+
+- [ ] **Step 4: Update `RalphRunner._execute_task(...)` to ask the builder for the next iteration input**
+
+```python
+iteration_input = await self.input_builder.build(...)
+self.task_context = await self._build_iteration_context(iteration_input, task, iter_num)
+task.input = iteration_input.task_input
+task.context = self.task_context
+```
+
+- [ ] **Step 5: Run runner-mode tests**
+
+Run:
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the input-builder slice**
+
+```bash
+git add aworld/runners/ralph/input_builder.py aworld/runners/ralph/state.py aworld/runners/ralph_runner.py tests/runners/test_ralph_runner_dual_mode.py
+git commit -m "refactor: add ralph iteration input builder"
+```
+
+---
+
+### Task 4: Refactor `RalphRunner` Into an Explicit Dual-Mode Loop While Preserving Entry Points
+
+**Files:**
+- Modify: `aworld/runners/ralph_runner.py`
+- Modify: `aworld/runner.py`
+- Modify: `tests/runners/test_ralph_runner_dual_mode.py`
+
+- [ ] **Step 1: Add a failing test that `aworld.runner.ralph_run(...)` still works with the new config path**
+
+```python
+import pytest
+
+from aworld.core.task import Task
+from aworld.runner import Runner
+from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.types import CompletionCriteria
+
+
+@pytest.mark.asyncio
+async def test_runner_ralph_run_preserves_public_api(monkeypatch):
+    task = Task(input="Build API", conf=RalphConfig())
+
+    result = await Runner.ralph_run(task, CompletionCriteria(max_iterations=1))
+
+    assert result is not None
+```
+
+- [ ] **Step 2: Add runner seams for explicit mode-based context construction**
+
+```python
+async def _build_iteration_context(self, iteration_input, task, iter_num):
+    if self.policy.execution_mode == "reuse_context":
+        return to_loop_context(self.loop_context, work_dir=self.ralph_config.workspace)
+    return to_loop_context(
+        await self.loop_context.build_sub_context(
+            sub_task_content=iteration_input.task_input,
+            sub_task_id=task.id,
+            task=task,
+        ),
+        work_dir=self.ralph_config.workspace,
+    )
+```
+
+- [ ] **Step 3: Keep the public constructor unchanged while initializing new internal collaborators**
+
+```python
+self.policy = RalphLoopPolicy.from_config(self.ralph_config)
+self.memory_store = LoopMemoryStore(self.loop_context)
+self.input_builder = IterationInputBuilder(self.policy, self.memory_store)
+```
+
+- [ ] **Step 4: Make `runner.py` pass through the same config without adding a second public API**
+
+```python
+runner = RalphRunner(task=task, completion_criteria=completion_criteria)
+return await runner.run()
+```
+
+- [ ] **Step 5: Run runner compatibility tests**
+
+Run:
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the dual-mode runner slice**
+
+```bash
+git add aworld/runners/ralph_runner.py aworld/runner.py tests/runners/test_ralph_runner_dual_mode.py
+git commit -m "feat: add dual-mode execution to ralph runner"
+```
+
+---
+
+### Task 5: Add Framework-Level Verification Via `IterationEvaluator`
+
+**Files:**
+- Create: `aworld/runners/ralph/evaluator.py`
+- Modify: `aworld/runners/ralph/config.py`
+- Modify: `aworld/runners/ralph_runner.py`
+- Modify: `aworld/runners/ralph/state.py`
+- Add: `tests/runners/test_ralph_iteration_evaluator.py`
+- Modify: `tests/runners/test_ralph_runner_dual_mode.py`
+
+- [ ] **Step 1: Add a failing test for verify-command execution and persisted failure feedback**
+
+```python
+import pytest
+
+from aworld.runners.ralph.evaluator import IterationEvaluator
+
+
+@pytest.mark.asyncio
+async def test_iteration_evaluator_persists_failed_verify_output(tmp_path):
+    evaluator = IterationEvaluator(...)
+
+    result = await evaluator.evaluate(
+        task_id="task-1",
+        iteration=1,
+        answer="Created API handlers",
+    )
+
+    assert result.verify_result.passed is False
+    assert "pytest -q" in result.verify_result.commands[0]["command"]
+```
+
+- [ ] **Step 2: Add the evaluator result shape**
+
+```python
+from dataclasses import dataclass, field
+
+
+@dataclass
+class VerifyCommandResult:
+    command: str
+    exit_code: int
+    output: str
+
+
+@dataclass
+class IterationEvaluationResult:
+    verify_passed: bool
+    reflection_feedback: str | None = None
+    summary: str | None = None
+    command_results: list[VerifyCommandResult] = field(default_factory=list)
+```
+
+- [ ] **Step 3: Execute verify commands through sandbox terminal when verify is enabled**
+
+```python
+terminal_result = await self.context.sand_box.terminal.run_code(
+    code=command,
+    timeout=self.verify_config.timeout,
+    output_format="markdown",
+)
+```
+
+- [ ] **Step 4: Persist evaluator output through `LoopMemoryStore` and feed failures into the next iteration**
+
+```python
+await self.memory_store.write_verify_result(task_id, iteration, verify_payload)
+await self.memory_store.write_reflection_feedback(task_id, iteration, feedback_text)
+```
+
+- [ ] **Step 5: Call the evaluator from `RalphRunner.do_run()` after each task execution**
+
+```python
+evaluation = await self.evaluator.evaluate(
+    task=self.task,
+    iter_num=iter_num,
+    execution_result=execution_result,
+)
+```
+
+- [ ] **Step 6: Run the full Ralph runner test slice**
+
+Run:
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py tests/runners/test_ralph_loop_memory_store.py tests/runners/test_ralph_iteration_evaluator.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 7: Commit the framework verification slice**
+
+```bash
+git add aworld/runners/ralph/evaluator.py aworld/runners/ralph/config.py aworld/runners/ralph/state.py aworld/runners/ralph_runner.py tests/runners/test_ralph_iteration_evaluator.py tests/runners/test_ralph_runner_dual_mode.py tests/runners/test_ralph_loop_memory_store.py
+git commit -m "feat: add ralph verification pipeline"
+```
+
+---
+
+## Self-Review Checklist
+
+- [ ] `execution_mode` is the internal source of truth; `reuse_context` remains compatibility-only.
+- [ ] `RalphRunner` does not take on CLI session-loop or fresh-process orchestration responsibilities.
+- [ ] `LoopMemoryStore` reuses `WorkSpace`, artifacts, and sandbox file/terminal capabilities rather than creating a new storage subsystem.
+- [ ] `fresh_context` rebuilds task context from persisted memory instead of reusing runtime state.
+- [ ] `aworld.runner.ralph_run(...)` still works without new required parameters.
+
+## Final Verification
+
+Run:
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py tests/runners/test_ralph_loop_memory_store.py tests/runners/test_ralph_iteration_evaluator.py -q
+```
+
+Expected:
+- PASS

--- a/docs/superpowers/plans/2026-04-27-ralph-runner-dual-mode.md
+++ b/docs/superpowers/plans/2026-04-27-ralph-runner-dual-mode.md
@@ -8,6 +8,33 @@
 
 **Tech Stack:** Python 3.12, pytest, existing AWorld runner/context/workspace/sandbox stack, `Sandbox.builder()` filesystem and terminal namespaces.
 
+## Execution Status
+
+Status: Implemented on April 27, 2026.
+
+Delivered commits:
+
+- `053c43aa` `feat: add explicit ralph execution mode config`
+- `4a69a74f` `refactor: extract ralph loop memory store`
+- `74bdc286` `fix: restore ralph loop memory compatibility`
+- `b70d3042` `refactor: add dual-mode ralph iteration input builder`
+- `03112a6e` `fix: seed fresh ralph contexts from iteration input`
+- `28ade7ea` `feat: add ralph verification pipeline`
+- `4db0b847` `fix: gate ralph verification scheduling`
+- `3ba5731e` `fix: persist ralph iteration evaluation state`
+
+Verification executed on the final integrated branch:
+
+```bash
+pytest tests/runners/test_ralph_runner_dual_mode.py tests/runners/test_ralph_loop_memory_store.py tests/runners/test_ralph_iteration_evaluator.py tests/runners/test_tool_reset_compat.py -q
+```
+
+Expected/actual result:
+
+- PASS (`32 passed`)
+
+All implementation tasks below are complete. The checkbox steps are preserved as execution history for the delivery sequence.
+
 ---
 
 ## File Structure
@@ -500,11 +527,11 @@ git commit -m "feat: add ralph verification pipeline"
 
 ## Self-Review Checklist
 
-- [ ] `execution_mode` is the internal source of truth; `reuse_context` remains compatibility-only.
-- [ ] `RalphRunner` does not take on CLI session-loop or fresh-process orchestration responsibilities.
-- [ ] `LoopMemoryStore` reuses `WorkSpace`, artifacts, and sandbox file/terminal capabilities rather than creating a new storage subsystem.
-- [ ] `fresh_context` rebuilds task context from persisted memory instead of reusing runtime state.
-- [ ] `aworld.runner.ralph_run(...)` still works without new required parameters.
+- [x] `execution_mode` is the internal source of truth; `reuse_context` remains compatibility-only.
+- [x] `RalphRunner` does not take on CLI session-loop or fresh-process orchestration responsibilities.
+- [x] `LoopMemoryStore` reuses `WorkSpace`, artifacts, and sandbox file/terminal capabilities rather than creating a new storage subsystem.
+- [x] `fresh_context` rebuilds task context from persisted memory instead of reusing runtime state.
+- [x] `aworld.runner.ralph_run(...)` still works without new required parameters.
 
 ## Final Verification
 

--- a/docs/superpowers/plans/2026-04-27-ralph-runner-fresh-context-verify-example.md
+++ b/docs/superpowers/plans/2026-04-27-ralph-runner-fresh-context-verify-example.md
@@ -1,0 +1,282 @@
+# RalphRunner Fresh-Context Verify Example Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a realistic quick-start example that demonstrates `RalphRunner` with `fresh_context` execution and terminal-backed verification on a business-oriented coding task.
+
+**Architecture:** Add a new `examples/aworld_quick_start/ralph_runner/` example with a small deterministic setup helper that seeds a business-rules workspace, then build `run.py` on top of that helper using `Runners.ralph_run(...)`. Keep tests focused on deterministic setup and config behavior so the example stays reliable without depending on live model execution.
+
+**Tech Stack:** Python 3.12, pytest, existing `Agent`/`Task`/`Runners.ralph_run(...)` APIs, `RalphConfig`, `RalphVerifyConfig`.
+
+---
+
+## File Structure
+
+### New files
+
+- Create: `examples/aworld_quick_start/ralph_runner/__init__.py`
+- Create: `examples/aworld_quick_start/ralph_runner/example_setup.py`
+- Create: `examples/aworld_quick_start/ralph_runner/run.py`
+- Create: `examples/aworld_quick_start/ralph_runner/README.md`
+- Create: `tests/examples/test_ralph_runner_example_setup.py`
+
+### Existing files to modify
+
+- Modify: `examples/aworld_quick_start/README.md`
+- Modify: `examples/aworld_quick_start/README_zh.md`
+
+Responsibilities:
+
+- `example_setup.py`: isolated workspace paths, reset behavior, seeded business files, example config helpers
+- `run.py`: runnable entrypoint that wires the seeded workspace into a real `RalphRunner` task
+- `README.md`: explains the scenario, behavior, and run steps
+- `test_ralph_runner_example_setup.py`: deterministic regression coverage for setup/config helpers
+- quick-start indexes: add the new example to the curated list
+
+---
+
+### Task 1: Add Failing Tests For Ralph Example Setup And Config
+
+**Files:**
+- Create: `tests/examples/test_ralph_runner_example_setup.py`
+
+- [ ] **Step 1: Write the failing tests for workspace creation, reset, and Ralph config**
+
+```python
+from pathlib import Path
+
+from aworld.runners.ralph.config import RalphConfig
+from examples.aworld_quick_start.ralph_runner.example_setup import (
+    RalphExamplePaths,
+    build_ralph_runner_example_config,
+    build_ralph_runner_example_criteria,
+    ensure_ralph_runner_example_workspace,
+)
+
+
+def test_ensure_ralph_runner_example_workspace_creates_seed_files(tmp_path: Path) -> None:
+    paths = RalphExamplePaths.from_root(tmp_path / "ralph-runner-example")
+
+    ensure_ralph_runner_example_workspace(paths)
+
+    assert paths.root.is_dir()
+    assert paths.src_dir.is_dir()
+    assert paths.tests_dir.is_dir()
+    assert paths.rules_file.is_file()
+    assert paths.module_file.is_file()
+    assert paths.test_file.is_file()
+
+
+def test_build_ralph_runner_example_config_uses_fresh_context_and_verify(tmp_path: Path) -> None:
+    config = build_ralph_runner_example_config(workspace=str(tmp_path))
+
+    assert isinstance(config, RalphConfig)
+    assert config.execution_mode == "fresh_context"
+    assert config.reuse_context is False
+    assert config.verify.enabled is True
+    assert config.verify.run_before_completion is True
+    assert config.verify.commands == ["PYTHONPATH=. pytest -q"]
+
+
+def test_build_ralph_runner_example_criteria_sets_reasonable_iteration_budget() -> None:
+    criteria = build_ralph_runner_example_criteria()
+
+    assert criteria.max_iterations == 5
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+pytest tests/examples/test_ralph_runner_example_setup.py -q
+```
+
+Expected:
+- FAIL because `examples.aworld_quick_start.ralph_runner.example_setup` does not exist yet
+
+- [ ] **Step 3: Commit only after the task is green**
+
+```bash
+git add tests/examples/test_ralph_runner_example_setup.py examples/aworld_quick_start/ralph_runner/example_setup.py
+git commit -m "test: add ralph runner example setup coverage"
+```
+
+---
+
+### Task 2: Implement The Example Setup Helper
+
+**Files:**
+- Create: `examples/aworld_quick_start/ralph_runner/example_setup.py`
+- Modify: `tests/examples/test_ralph_runner_example_setup.py`
+
+- [ ] **Step 1: Implement the path model and safe workspace initializer**
+
+```python
+@dataclass(frozen=True)
+class RalphExamplePaths:
+    root: Path
+    src_dir: Path
+    tests_dir: Path
+    rules_file: Path
+    module_file: Path
+    test_file: Path
+    marker_file: Path
+
+    @classmethod
+    def from_root(cls, root: Path | str) -> "RalphExamplePaths":
+        root_path = Path(root).expanduser().resolve()
+        return cls(
+            root=root_path,
+            src_dir=root_path / "src",
+            tests_dir=root_path / "tests",
+            rules_file=root_path / "business_rules.md",
+            module_file=root_path / "src" / "order_pricing.py",
+            test_file=root_path / "tests" / "test_order_pricing.py",
+            marker_file=root_path / ".ralph_runner_example_root",
+        )
+```
+
+- [ ] **Step 2: Seed the business-rules files**
+
+```python
+def ensure_ralph_runner_example_workspace(paths: RalphExamplePaths, reset: bool = False) -> None:
+    ...
+    paths.module_file.write_text(
+        "def calculate_quote(items, customer_tier):\n"
+        "    raise NotImplementedError('Implement me')\n",
+        encoding="utf-8",
+    )
+```
+
+- [ ] **Step 3: Add config and completion helper builders**
+
+```python
+def build_ralph_runner_example_config(workspace: str, model_config=None) -> RalphConfig:
+    config = RalphConfig.create(model_config=model_config)
+    config.workspace = workspace
+    config.execution_mode = "fresh_context"
+    config.verify = RalphVerifyConfig(
+        enabled=True,
+        commands=["PYTHONPATH=. pytest -q"],
+        run_before_completion=True,
+    )
+    return config
+```
+
+- [ ] **Step 4: Re-run the focused tests**
+
+Run:
+```bash
+pytest tests/examples/test_ralph_runner_example_setup.py -q
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit the setup helper**
+
+```bash
+git add examples/aworld_quick_start/ralph_runner/example_setup.py tests/examples/test_ralph_runner_example_setup.py
+git commit -m "feat: add ralph runner example workspace setup"
+```
+
+---
+
+### Task 3: Add The Runnable RalphRunner Example
+
+**Files:**
+- Create: `examples/aworld_quick_start/ralph_runner/__init__.py`
+- Create: `examples/aworld_quick_start/ralph_runner/run.py`
+- Create: `examples/aworld_quick_start/ralph_runner/README.md`
+
+- [ ] **Step 1: Add the runnable example entrypoint**
+
+```python
+paths = RalphExamplePaths.from_root(Path(__file__).resolve().parent / ".workdir")
+ensure_ralph_runner_example_workspace(paths, reset=True)
+
+builder = Agent(...)
+task = Task(
+    input=(
+        "Implement the order pricing module in src/order_pricing.py "
+        "so the seeded business tests pass. "
+        "Read business_rules.md before editing code."
+    ),
+    agent=builder,
+    conf=build_ralph_runner_example_config(
+        workspace=str(paths.root),
+        model_config=agent_config.llm_config,
+    ),
+)
+result = await Runners.ralph_run(task=task, completion_criteria=build_ralph_runner_example_criteria())
+```
+
+- [ ] **Step 2: Add the example README with run instructions and behavior**
+
+```markdown
+This example demonstrates framework-level Ralph execution with:
+
+- `fresh_context`
+- verification via `PYTHONPATH=. pytest -q`
+- a seeded business-rules workspace
+```
+
+- [ ] **Step 3: Smoke-check the example syntax**
+
+Run:
+```bash
+python -m py_compile examples/aworld_quick_start/ralph_runner/run.py
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 4: Commit the runnable example**
+
+```bash
+git add examples/aworld_quick_start/ralph_runner/__init__.py examples/aworld_quick_start/ralph_runner/run.py examples/aworld_quick_start/ralph_runner/README.md
+git commit -m "feat: add ralph runner fresh-context example"
+```
+
+---
+
+### Task 4: Update Quick-Start Index Documentation
+
+**Files:**
+- Modify: `examples/aworld_quick_start/README.md`
+- Modify: `examples/aworld_quick_start/README_zh.md`
+
+- [ ] **Step 1: Add the new example to the quick-start indexes**
+
+```markdown
+- [RalphRunner iterative convergence](ralph_runner) \
+  Example of framework-level Ralph execution with `fresh_context` and `verify`.
+```
+
+- [ ] **Step 2: Run targeted verification**
+
+Run:
+```bash
+pytest tests/examples/test_ralph_runner_example_setup.py -q
+python -m py_compile examples/aworld_quick_start/ralph_runner/run.py
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 3: Commit the documentation index update**
+
+```bash
+git add examples/aworld_quick_start/README.md examples/aworld_quick_start/README_zh.md
+git commit -m "docs: add ralph runner quick-start example"
+```
+
+---
+
+## Self-Review Checklist
+
+- [ ] The example uses `fresh_context`, not `reuse_context`.
+- [ ] Verification is shown through a real pytest command.
+- [ ] Tests cover deterministic setup/config logic only.
+- [ ] The runnable example uses `Runners.ralph_run(...)`.
+- [ ] The quick-start indexes point users to the new example.

--- a/docs/superpowers/specs/2026-04-27-ralph-runner-dual-mode-design.md
+++ b/docs/superpowers/specs/2026-04-27-ralph-runner-dual-mode-design.md
@@ -1,0 +1,370 @@
+# RalphRunner Dual-Mode Design
+
+## Context
+
+`RalphRunner` should remain a framework-level Ralph capability for agents built on AWorld. It should not be treated as a CLI-only feature, and it should not absorb process-level orchestration concerns that belong to `aworld-cli` plugins or future external orchestrators.
+
+The current implementation already has useful foundations:
+
+- a runner-level Ralph loop
+- `CompletionCriteria`-based stop detection
+- `LoopContext` as loop-scoped state
+- workspace/artifact persistence
+- sandbox-backed filesystem access
+
+However, it currently exposes only one practical execution style and leaves several intended Ralph capabilities only partially connected:
+
+- `reuse_context` is a boolean instead of an explicit execution mode
+- loop memory is implicit and spread across files and artifacts
+- verification is not a first-class part of the loop
+- reflection/planning configs exist but are not cleanly integrated into the main loop path
+
+At the same time, the `deepagents/examples/ralph_mode` reference highlights an important Ralph idea worth adopting at the framework layer: each iteration can start from fresh task context while the filesystem and persisted artifacts carry memory across iterations.
+
+## Goals
+
+- Keep `RalphRunner` as a framework-level execution capability.
+- Support two explicit Ralph execution modes:
+  - `reuse_context`
+  - `fresh_context`
+- Preserve backward compatibility for existing `RalphRunner` and `aworld.runner.ralph_run(...)` callers.
+- Reuse existing AWorld persistence primitives instead of inventing a separate storage system.
+- Make loop memory, iteration input construction, and verification explicit framework concepts.
+- Leave CLI session looping and fresh-process orchestration outside `RalphRunner`.
+
+## Non-Goals
+
+- Do not make `RalphRunner` depend on the `ralph-session-loop` CLI plugin.
+- Do not make `RalphRunner` responsible for fresh-process or fresh-session orchestration.
+- Do not make the framework-level Ralph capability available only through `aworld-cli`.
+- Do not replace existing workspace/artifact/sandbox file infrastructure with a new storage subsystem.
+- Do not force an immediate breaking change on current `reuse_context` callers.
+
+## Design Summary
+
+The recommended design is to keep the public `RalphRunner` surface compatible while introducing explicit internal loop policy and execution mode abstractions.
+
+The framework should treat Ralph as two related but distinct concerns:
+
+- **outer orchestration**
+  This includes interactive session continuation, fresh process spawning, and operator-driven loop control. This stays outside `RalphRunner`.
+
+- **inner framework loop**
+  This includes iteration execution, loop memory, verification, reflection, and stop detection inside a single AWorld runtime. This remains the responsibility of `RalphRunner`.
+
+Under this design, `RalphRunner` becomes a dual-mode framework loop:
+
+- `reuse_context`: continue iterating with reused task/application context
+- `fresh_context`: rebuild task context each iteration and inject only persisted loop memory
+
+Both modes share the same completion criteria, loop memory contract, verification pipeline, and stop detector.
+
+## API Shape
+
+### Backward-compatible public entrypoints
+
+The following existing surfaces remain valid:
+
+- `RalphRunner(task, completion_criteria=..., **kwargs)`
+- `aworld.runner.ralph_run(task, completion_criteria)`
+
+### RalphConfig changes
+
+`RalphConfig` should become the main place for mode and loop behavior.
+
+Recommended additions:
+
+- `execution_mode: Literal["reuse_context", "fresh_context"] = "reuse_context"`
+- `memory_mode: Literal["artifacts_only", "artifacts_plus_history"] = "artifacts_only"`
+- `iteration_prompt_template: Optional[str] = None`
+- `verify: RalphVerifyConfig`
+- `summary: RalphSummaryConfig`
+
+Compatibility behavior:
+
+- keep `reuse_context: bool` during a migration window
+- if `execution_mode` is explicitly set, it wins
+- otherwise map `reuse_context=True` to `execution_mode="reuse_context"`
+- map `reuse_context=False` to `execution_mode="fresh_context"`
+- mark `reuse_context` as compatibility-only in docs before later deprecation
+
+### CompletionCriteria stays narrow
+
+`CompletionCriteria` should continue to mean stop policy only:
+
+- max iterations
+- timeout
+- max cost
+- max failures
+- answer/custom stop criteria
+
+It should not be overloaded with verification, memory, or prompt-shaping behavior.
+
+## Internal Architecture
+
+### 1. RalphLoopPolicy
+
+`RalphLoopPolicy` becomes the internal source of truth for how a Ralph iteration should behave.
+
+Responsibilities:
+
+- resolve effective `execution_mode`
+- resolve memory behavior
+- resolve verify behavior
+- resolve summary/reflection behavior
+- provide iteration prompt shaping instructions
+
+`RalphRunner` should depend on this object instead of scattering mode decisions across the loop body.
+
+### 2. IterationInputBuilder
+
+`IterationInputBuilder` builds the effective input for each iteration.
+
+For `reuse_context`:
+
+- read structured memory from loop storage
+- append prior answer/reflection/verify feedback to the ongoing context
+- keep the existing application/task context alive
+
+For `fresh_context`:
+
+- create a fresh sub-context for the iteration
+- do not reuse the previous conversational/runtime context
+- inject only structured loop memory into the new iteration input
+
+Recommended normalized iteration input sections:
+
+- original task
+- current iteration number
+- previous answer summary
+- reflection or failure feedback
+- verification requirements
+- execution rule for the next step
+
+This makes framework-side Ralph behavior more predictable than the current string concatenation path.
+
+### 3. LoopMemoryStore
+
+`LoopMemoryStore` should be introduced as a thin Ralph abstraction over existing AWorld persistence primitives.
+
+It should not invent a new storage backend. It should reuse:
+
+- `WorkSpace.add_artifact(...)` for small structured artifacts
+- `workspace.get_artifact_data(...)` for retrieval
+- `sandbox.file.write_file(...)` and `sandbox.file.read_file(...)` for file-based intermediate state
+
+Recommended storage split:
+
+- **artifact-first**
+  Store structured, relatively small loop memory here:
+  - `iteration_summary`
+  - `reflection_feedback`
+  - `verify_result`
+  - `iteration_metadata`
+
+- **file-assisted**
+  Store larger or naturally file-shaped content here:
+  - full answer payloads
+  - generated summaries when large
+  - command outputs/logs from verification
+  - any operator-inspectable loop artifacts
+
+This matches current AWorld capabilities and avoids parallel file management systems.
+
+### 4. IterationEvaluator
+
+`IterationEvaluator` should run after each task execution and produce structured post-iteration memory.
+
+Responsibilities:
+
+- evaluate verification
+- produce summary
+- produce reflection feedback
+- emit completion-related signals for the next stop check
+
+This is the point where currently disconnected config concepts become real runtime behavior.
+
+## Loop Memory Contract
+
+The loop should use a fixed memory contract across both modes.
+
+Recommended fields:
+
+- `previous_answer`
+- `iteration_summary`
+- `reflection_feedback`
+- `verify_result`
+- `iteration_metadata`
+
+Recommended minimum `iteration_metadata`:
+
+- iteration number
+- start/end timestamp
+- execution mode
+- task id
+- success/failure flag
+- failure category if known
+
+This contract matters most for `fresh_context`, where loop continuity depends on persisted memory rather than runtime context reuse.
+
+## Verification Design
+
+Framework-level Ralph should support real verification, not only prompt-declared verification.
+
+Recommended `RalphVerifyConfig`:
+
+- `enabled: bool = False`
+- `commands: list[str] = []`
+- `run_on_each_iteration: bool = False`
+- `run_before_completion: bool = True`
+- `success_policy: Literal["all", "any"] = "all"`
+- `max_output_chars: int = 12000`
+
+Verification execution model:
+
+- run commands in the Ralph workspace
+- capture stdout/stderr/exit status
+- persist result via `LoopMemoryStore`
+- if verification fails, feed a structured failure summary into the next iteration input
+
+This is a framework-level upgrade beyond the CLI plugin's phase-1 declarative verify model.
+
+## Execution Mode Semantics
+
+### reuse_context
+
+Use when the agent benefits from runtime continuity.
+
+Behavior:
+
+- preserve the active task/application context
+- inject prior memory as additional guidance
+- use persisted memory mainly as reinforcement and traceability
+
+Best for:
+
+- agent workflows that benefit from growing conversational state
+- toolchains where context reconstruction is expensive
+
+### fresh_context
+
+Use when each iteration should restart cleanly from persisted outputs.
+
+Behavior:
+
+- build a fresh task context per iteration
+- do not carry forward full runtime/conversation state
+- reconstruct continuity from persisted loop memory and workspace files
+
+Best for:
+
+- long-running Ralph loops
+- tasks sensitive to context drift
+- agent implementations that should behave more like external Ralph fresh-run patterns without becoming process orchestrators
+
+## Data Flow
+
+### Common loop flow
+
+1. `RalphRunner` resolves effective config and builds `RalphLoopPolicy`.
+2. Stop detector checks `CompletionCriteria`.
+3. `IterationInputBuilder` builds the next iteration input.
+4. Runner executes the task.
+5. Runner stores primary output via `LoopMemoryStore`.
+6. `IterationEvaluator` runs verification/summary/reflection.
+7. Evaluator writes structured loop memory.
+8. Next stop check uses `CompletionCriteria` and evaluator-produced signals.
+
+### fresh_context-specific difference
+
+The critical difference is step 3:
+
+- `reuse_context` updates the running context
+- `fresh_context` creates a new sub-context and repopulates it from memory
+
+The rest of the loop stays consistent.
+
+## Error Handling
+
+The dual-mode design should make failures explicit instead of hiding them in prompt text.
+
+Recommended handling:
+
+- task execution failure increments loop failure metrics
+- verification failure is stored distinctly from execution failure
+- corrupted or unreadable loop memory should degrade gracefully by:
+  - logging the issue
+  - falling back to minimal memory reconstruction
+  - continuing if safe
+- only `CompletionCriteria` and fatal runtime errors should terminate the framework loop
+
+This keeps the loop resilient while preserving debuggability.
+
+## Migration Strategy
+
+### Phase A: structural compatibility
+
+- add `execution_mode`
+- keep `reuse_context`
+- introduce `RalphLoopPolicy`
+- wrap existing answer/reflection persistence behind `LoopMemoryStore`
+
+### Phase B: real dual-mode behavior
+
+- make `fresh_context` a first-class path
+- move iteration input building out of ad hoc `read_to_task_context(...)`
+- normalize iteration input structure
+
+### Phase C: verification integration
+
+- add `RalphVerifyConfig`
+- run real verification commands
+- persist verification outputs
+- use verification failures as structured feedback
+
+### Phase D: reflection and summary integration
+
+- connect `ReflectionConfig` and summary generation into the main post-iteration path
+- preserve planning as optional future work rather than mandatory first-slice scope
+
+## Testing Strategy
+
+The upgrade should be covered at three levels.
+
+### Unit tests
+
+- config compatibility mapping from `reuse_context` to `execution_mode`
+- `IterationInputBuilder` behavior in both modes
+- `LoopMemoryStore` read/write behavior for artifacts and files
+- `IterationEvaluator` verify result shaping
+
+### Runner integration tests
+
+- `reuse_context` mode preserves context and loops correctly
+- `fresh_context` mode rebuilds context while preserving memory continuity
+- stop conditions behave identically across both modes
+- verification failures feed the next iteration correctly
+
+### Regression tests
+
+- existing `RalphRunner` callers continue to work without configuration changes
+- `aworld.runner.ralph_run(...)` remains valid
+- workspace file outputs and reflection artifacts remain readable across versions
+
+## Recommendation
+
+Implement this as a framework-focused internal refactor with explicit dual-mode semantics, not as a CLI-inspired orchestration layer.
+
+The key idea to borrow from external Ralph implementations is:
+
+- fresh context can be a first-class iteration mode
+- persisted workspace state is the loop memory
+
+The key idea not to borrow is:
+
+- process-level orchestration as the runner's responsibility
+
+That separation keeps AWorld with two clean Ralph adoption paths:
+
+- framework/programmatic Ralph via `RalphRunner`
+- CLI session Ralph via plugin-hosted session looping

--- a/docs/superpowers/specs/2026-04-27-ralph-runner-fresh-context-verify-example-design.md
+++ b/docs/superpowers/specs/2026-04-27-ralph-runner-fresh-context-verify-example-design.md
@@ -1,0 +1,114 @@
+# RalphRunner Fresh-Context Verify Example Design
+
+## Context
+
+`RalphRunner` now supports explicit dual-mode execution and framework-level verification, but the repository does not yet include a realistic quick-start example that shows how to use:
+
+- `execution_mode="fresh_context"`
+- terminal-backed `verify`
+- a real business task with persisted iteration memory
+
+The existing `examples/aworld_quick_start/mcp_tool/ralph_demo_run.py` is useful as a compatibility smoke example, but it does not demonstrate the new framework behavior clearly enough. It also does not show a verify-driven repair loop.
+
+## Goal
+
+Add a runnable quick-start example that demonstrates `RalphRunner` in `fresh_context` mode with `verify` enabled, using a realistic business-oriented coding task.
+
+## Non-Goals
+
+- Do not add new `RalphRunner` framework features.
+- Do not introduce CLI plugin behavior into the example.
+- Do not make tests depend on live model calls.
+- Do not add external service dependencies beyond the existing repository test/runtime environment.
+
+## Recommended Example Shape
+
+The example should model a small but realistic internal business coding task:
+
+- the agent receives a task to implement an order-pricing module
+- the workspace is pre-seeded with business-rule tests
+- `RalphRunner` runs in `fresh_context`
+- verification runs `PYTHONPATH=. pytest -q`
+- failed verification feeds the next repair iteration
+
+This gives a concrete example of framework-level Ralph convergence without requiring web servers, databases, or third-party app dependencies.
+
+## Why This Case
+
+This case balances realism and operability:
+
+- it is business-oriented rather than toy arithmetic
+- it has clear correctness criteria expressed as tests
+- it uses only Python and pytest, which already fit the repository environment
+- it demonstrates why `fresh_context` matters: each repair round must rely on persisted memory and verification feedback, not accumulated in-memory conversation state
+
+## User-Facing Structure
+
+Add a new quick-start example directory:
+
+- `examples/aworld_quick_start/ralph_runner/`
+
+Recommended files:
+
+- `run.py`
+  Entry point for the example.
+- `example_setup.py`
+  Creates and resets the isolated work directory and seeds the business tests.
+- `README.md`
+  Explains what the example demonstrates and how to run it.
+- `__init__.py`
+  Keeps the example importable and consistent with the rest of `aworld_quick_start`.
+
+## Example Behavior
+
+The example should:
+
+1. Create or reset an isolated work directory
+2. Seed files such as:
+   - `src/order_pricing.py`
+   - `tests/test_order_pricing.py`
+   - a short business-rules markdown file
+3. Build a standard `Agent`
+4. Create `RalphConfig` with:
+   - `execution_mode="fresh_context"`
+   - `verify.enabled=True`
+   - `verify.commands=["PYTHONPATH=. pytest -q"]`
+   - `verify.run_before_completion=True`
+5. Call `Runners.ralph_run(...)`
+6. Print the final answer and the example workspace path
+
+## Testing Strategy
+
+Do not test the live LLM run.
+
+Instead, test deterministic example support code:
+
+- isolated workspace creation
+- reset safety
+- seeded file contents
+- `RalphConfig` defaults for this example
+- completion criteria for the example
+
+This keeps the example operational while still giving the repository a reliable regression harness.
+
+## Documentation Changes
+
+Update:
+
+- `examples/aworld_quick_start/README.md`
+- `examples/aworld_quick_start/README_zh.md`
+
+Add:
+
+- `examples/aworld_quick_start/ralph_runner/README.md`
+
+The quick-start index should describe this as the `RalphRunner` example for framework-level iterative convergence with `fresh_context + verify`.
+
+## Success Criteria
+
+- A new quick-start example exists under `examples/aworld_quick_start/ralph_runner/`
+- The example uses `RalphRunner` through `Runners.ralph_run(...)`
+- The example config explicitly uses `fresh_context`
+- Verification is enabled with a pytest command
+- Repository tests cover deterministic setup/config logic
+- Example index docs mention the new example

--- a/examples/aworld_quick_start/README.md
+++ b/examples/aworld_quick_start/README.md
@@ -65,6 +65,10 @@ The prerequisite for running is to copy the .env_template file to a .env file an
 - [Run by CLI](cli)\
   Example of CLI. Used for scenarios where the AWorld framework is used through the command line interface.
 
+
+- [RalphRunner iterative convergence](ralph_runner) \
+  Example of framework-level Ralph execution with `fresh_context` and terminal-backed `verify`.
+
 ### Examples of using independent modules
 
 - [Use Sandbox](env)\

--- a/examples/aworld_quick_start/README_zh.md
+++ b/examples/aworld_quick_start/README_zh.md
@@ -61,6 +61,10 @@ AWorld中有较多的概念，如Sandbox, LLModel等，
 - [CLI运行](cli)\
   使用CLI示例。用于通过命令行交互的场景。
 
+
+- [RalphRunner 迭代收敛](ralph_runner) \
+  基于框架级 RalphRunner 的示例，展示 `fresh_context` 与终端 `verify` 的配合。
+
 ### 模块使用示例
 
 - [使用Sandbox](env)\

--- a/examples/aworld_quick_start/mcp_tool/ralph_demo_run.py
+++ b/examples/aworld_quick_start/mcp_tool/ralph_demo_run.py
@@ -6,8 +6,8 @@ from threading import Thread
 
 from aworld.agents.llm_agent import Agent
 from aworld.core.task import Task
-from aworld.ralph_loop.config import RalphConfig
-from aworld.ralph_loop.types import CompletionCriteria
+from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.types import CompletionCriteria
 from aworld.runner import Runners
 from examples.aworld_quick_start.common import agent_config
 
@@ -53,7 +53,9 @@ async def main():
 
     # Run
     question = "30,000 divided by 1.2 "
-    task = Task(input=question, agent=search, conf=RalphConfig.create(model_config=agent_config.llm_config))
+    ralph_config = RalphConfig.create(model_config=agent_config.llm_config)
+    ralph_config.execution_mode = "reuse_context"
+    task = Task(input=question, agent=search, conf=ralph_config)
     completion_criteria = CompletionCriteria(answer="25000")
     res = await Runners.ralph_run(task=task, completion_criteria=completion_criteria)
     print(res.answer)

--- a/examples/aworld_quick_start/ralph_runner/README.md
+++ b/examples/aworld_quick_start/ralph_runner/README.md
@@ -1,0 +1,34 @@
+# RalphRunner Fresh Context Example
+
+This quick-start shows framework-level `RalphRunner` execution with:
+
+- `execution_mode="fresh_context"`
+- terminal-backed verification via `PYTHONPATH=. pytest -q`
+- a seeded business workspace that persists files across iterations
+- a verify-driven repair loop that stops when the latest verification passes
+
+## Scenario
+
+The example seeds a small internal order-pricing task:
+
+- `business_rules.md` defines the pricing rules
+- `src/order_pricing.py` starts as an unfinished module
+- `tests/test_order_pricing.py` defines the expected behavior
+
+Each Ralph iteration starts from fresh task context, but the workspace and loop memory persist. Verification runs after every iteration, and failed test output becomes repair feedback for the next round.
+
+## Run
+
+From the project root:
+
+```bash
+python examples/aworld_quick_start/ralph_runner/run.py
+```
+
+The script resets `examples/aworld_quick_start/ralph_runner/.workdir`, runs `Runners.ralph_run(...)`, then prints the final answer and the example workspace path.
+
+## Files
+
+- `run.py`: runnable entrypoint
+- `example_setup.py`: deterministic workspace seeding and config helpers
+- `.workdir/`: generated workspace used by the demo at runtime

--- a/examples/aworld_quick_start/ralph_runner/__init__.py
+++ b/examples/aworld_quick_start/ralph_runner/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+# Copyright (c) 2026 inclusionAI.

--- a/examples/aworld_quick_start/ralph_runner/example_setup.py
+++ b/examples/aworld_quick_start/ralph_runner/example_setup.py
@@ -1,0 +1,168 @@
+# coding: utf-8
+# Copyright (c) 2026 inclusionAI.
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+
+from aworld.runners.ralph.config import RalphConfig, RalphVerifyConfig
+from aworld.runners.ralph.types import CompletionCriteria
+
+
+EXAMPLE_ROOT_MARKER = ".ralph_runner_example_root"
+RULES_TEXT = """# Order Pricing Business Rules
+
+Implement order pricing for an internal sales team.
+
+The pricing function must:
+
+1. Accept a list of item dictionaries with `sku`, `unit_price`, and `quantity`.
+2. Reject empty orders with `ValueError`.
+3. Compute the subtotal as the sum of `unit_price * quantity`.
+4. Apply a tier discount:
+   - `standard`: 0%
+   - `silver`: 5%
+   - `gold`: 10%
+5. Apply an additional 5% bulk discount when total quantity is 10 units or more.
+6. Return a dictionary with `subtotal`, `discount`, and `total`, rounded to 2 decimals.
+"""
+MODULE_TEXT = """def calculate_quote(items, customer_tier):
+    raise NotImplementedError("Implement me")
+"""
+TEST_TEXT = """import pytest
+
+from src.order_pricing import calculate_quote
+
+
+def test_calculate_quote_applies_tier_discount():
+    quote = calculate_quote(
+        [
+            {"sku": "A-100", "unit_price": 20.0, "quantity": 2},
+            {"sku": "B-200", "unit_price": 15.0, "quantity": 1},
+        ],
+        customer_tier="silver",
+    )
+
+    assert quote == {
+        "subtotal": 55.0,
+        "discount": 2.75,
+        "total": 52.25,
+    }
+
+
+def test_calculate_quote_stacks_bulk_discount_with_tier_discount():
+    quote = calculate_quote(
+        [
+            {"sku": "A-100", "unit_price": 10.0, "quantity": 5},
+            {"sku": "B-200", "unit_price": 5.0, "quantity": 5},
+        ],
+        customer_tier="gold",
+    )
+
+    assert quote == {
+        "subtotal": 75.0,
+        "discount": 11.25,
+        "total": 63.75,
+    }
+
+
+def test_calculate_quote_rejects_empty_orders():
+    with pytest.raises(ValueError, match="at least one item"):
+        calculate_quote([], customer_tier="standard")
+"""
+
+
+def _validate_example_path_invariants(paths: "RalphExamplePaths") -> None:
+    root = paths.root.resolve()
+    src_dir = paths.src_dir.resolve()
+    tests_dir = paths.tests_dir.resolve()
+    rules_file = paths.rules_file.resolve()
+    module_file = paths.module_file.resolve()
+    test_file = paths.test_file.resolve()
+    marker_file = paths.marker_file.resolve()
+
+    if src_dir != root / "src":
+        raise ValueError("src_dir must equal root/src")
+    if tests_dir != root / "tests":
+        raise ValueError("tests_dir must equal root/tests")
+    if rules_file != root / "business_rules.md":
+        raise ValueError("rules_file must equal root/business_rules.md")
+    if module_file != src_dir / "order_pricing.py":
+        raise ValueError("module_file must equal src_dir/order_pricing.py")
+    if test_file != tests_dir / "test_order_pricing.py":
+        raise ValueError("test_file must equal tests_dir/test_order_pricing.py")
+    if marker_file != root / EXAMPLE_ROOT_MARKER:
+        raise ValueError("marker_file must equal root/.ralph_runner_example_root")
+
+
+@dataclass(frozen=True)
+class RalphExamplePaths:
+    root: Path
+    src_dir: Path
+    tests_dir: Path
+    rules_file: Path
+    module_file: Path
+    test_file: Path
+    marker_file: Path
+
+    @classmethod
+    def from_root(cls, root: Path | str) -> "RalphExamplePaths":
+        root_path = Path(root).expanduser().resolve()
+        return cls(
+            root=root_path,
+            src_dir=root_path / "src",
+            tests_dir=root_path / "tests",
+            rules_file=root_path / "business_rules.md",
+            module_file=root_path / "src" / "order_pricing.py",
+            test_file=root_path / "tests" / "test_order_pricing.py",
+            marker_file=root_path / EXAMPLE_ROOT_MARKER,
+        )
+
+
+def ensure_ralph_runner_example_workspace(paths: RalphExamplePaths, reset: bool = False) -> None:
+    _validate_example_path_invariants(paths)
+
+    if reset and paths.root.exists():
+        if not paths.marker_file.is_file():
+            raise ValueError("reset=True requires an initialized example root marker")
+        shutil.rmtree(paths.root)
+
+    paths.root.mkdir(parents=True, exist_ok=True)
+    paths.src_dir.mkdir(parents=True, exist_ok=True)
+    paths.tests_dir.mkdir(parents=True, exist_ok=True)
+
+    paths.marker_file.write_text("aworld-ralph-runner-example\n", encoding="utf-8")
+    (paths.src_dir / "__init__.py").write_text("", encoding="utf-8")
+    paths.rules_file.write_text(RULES_TEXT, encoding="utf-8")
+    paths.module_file.write_text(MODULE_TEXT, encoding="utf-8")
+    paths.test_file.write_text(TEST_TEXT, encoding="utf-8")
+
+
+def build_ralph_runner_example_config(workspace: str, model_config=None) -> RalphConfig:
+    config = RalphConfig.create(model_config=model_config)
+    config.workspace = workspace
+    config.execution_mode = "fresh_context"
+    config.verify = RalphVerifyConfig(
+        enabled=True,
+        commands=["PYTHONPATH=. pytest -q"],
+        run_on_each_iteration=True,
+        run_before_completion=True,
+    )
+    return config
+
+
+def build_ralph_runner_example_criteria(task_id: str | None = None) -> CompletionCriteria:
+    criteria = CompletionCriteria(max_iterations=5)
+
+    if not task_id:
+        return criteria
+
+    async def stop_when_latest_verify_passes(state) -> bool:
+        latest_completed_iteration = state.loop_state.iteration - 1
+        if latest_completed_iteration <= 0:
+            return False
+
+        verify_result = await state.memory.read_verify_result(task_id, latest_completed_iteration)
+        return bool(verify_result and verify_result.get("passed"))
+
+    criteria.custom_stop = stop_when_latest_verify_passes
+    return criteria

--- a/examples/aworld_quick_start/ralph_runner/run.py
+++ b/examples/aworld_quick_start/ralph_runner/run.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+# Copyright (c) 2026 inclusionAI.
+import asyncio
+from pathlib import Path
+
+from aworld.agents.llm_agent import Agent
+from aworld.core.task import Task
+from aworld.runner import Runners
+from examples.aworld_quick_start.common import agent_config
+from examples.aworld_quick_start.ralph_runner.example_setup import (
+    RalphExamplePaths,
+    build_ralph_runner_example_config,
+    build_ralph_runner_example_criteria,
+    ensure_ralph_runner_example_workspace,
+)
+
+
+async def main() -> None:
+    paths = RalphExamplePaths.from_root(Path(__file__).resolve().parent / ".workdir")
+    ensure_ralph_runner_example_workspace(paths, reset=True)
+
+    builder = Agent(
+        conf=agent_config,
+        name="pricing_builder",
+        system_prompt=(
+            "You are implementing a small Python business module. "
+            "Read the seeded workspace files, edit code conservatively, and use verification results to repair failures."
+        ),
+    )
+
+    task = Task(
+        input=(
+            "Implement src/order_pricing.py so the seeded tests pass. "
+            "Read business_rules.md first. "
+            "When you finish an iteration, explain what changed and what verification result you expect."
+        ),
+        agent=builder,
+        conf=build_ralph_runner_example_config(
+            workspace=str(paths.root),
+            model_config=agent_config.llm_config,
+        ),
+    )
+
+    result = await Runners.ralph_run(
+        task=task,
+        completion_criteria=build_ralph_runner_example_criteria(task_id=task.id),
+    )
+
+    print("Final answer:")
+    print(result.answer)
+    print(f"Workspace: {paths.root}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/.openspec.yaml
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/README.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/README.md
@@ -1,0 +1,3 @@
+# 2026-04-27-ralph-session-loop-plugin
+
+Track the phase-1 design for introducing a standalone Ralph session-loop plugin in AWorld.

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/design.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/design.md
@@ -68,6 +68,31 @@ Rejected alternative:
 - Build the phase-1 interactive loop directly on `RalphRunner`.
   Rejected because `RalphRunner` is a task-execution loop, not a session-lifecycle controller.
 
+### Decision: Ralph plugin and RalphRunner remain parallel abstractions
+
+Phase 1 must preserve a clear layer boundary between the CLI Ralph plugin and framework-level `RalphRunner`.
+
+Boundary definition:
+
+- the Ralph plugin is an `aworld-cli` interaction-layer capability
+- `RalphRunner` is an `aworld` framework execution-layer capability
+- the plugin controls whether the current session continues into another round
+- the runner controls whether a single task execution has converged
+
+Implications:
+
+- the phase-1 plugin must not invoke `RalphRunner` implicitly
+- the plugin must not treat `RalphRunner` as the only way AWorld can expose Ralph semantics
+- plugin `--max-iterations` applies only to session continuation
+- runner `completion_criteria.max_iterations` applies only to inner task execution
+- phase 1 does not define a priority or override relationship between those two limits
+
+Why:
+
+- This keeps the CLI interaction model independent from framework runtime choices.
+- It avoids hidden coupling between session control and task execution.
+- It preserves two valid adoption paths: interactive CLI Ralph and framework/programmatic Ralph.
+
 ### Decision: The stop hook is the only loop controller
 
 The phase-1 control path should be:

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/design.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/design.md
@@ -1,0 +1,288 @@
+## Context
+
+The external Ralph references show two distinct execution models that should not be conflated in the same first implementation slice:
+
+1. In-session continuation loop
+   - same interactive session
+   - same conversational surface
+   - loop continuation triggered by an exit interception point
+   - persistence carried by workspace files, transcript, and lightweight loop state
+
+2. Fresh-run orchestration loop
+   - every iteration launches a new agent/tool process
+   - continuity is carried by explicit artifacts such as `prd.json`, `progress.txt`, and git history
+   - orchestration becomes its own runtime concern instead of an interactive CLI concern
+
+The requested AWorld capability is explicitly the first model. The current AWorld plugin framework already supports the required host primitives:
+
+- slash-style prompt commands
+- `stop` hooks with `block_and_continue`
+- session- or workspace-scoped plugin state
+- HUD providers
+
+The current `RalphRunner` is not the right primary abstraction for this phase because it is shaped as a runner-level loop executor, not as a CLI session control layer.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Add a phase-1 Ralph capability as a standalone plugin.
+- Keep the implementation in the CLI/plugin host layer.
+- Reuse existing plugin `commands`, `hooks`, `state`, and `hud` contracts instead of introducing a Ralph-specific kernel API.
+- Support explicit completion promises and iteration limits.
+- Support declarative verification requirements that are stored structurally and injected into the agent prompt.
+- Keep the plugin implementation compatible with future phase-2 evolution.
+
+**Non-Goals**
+
+- Do not build phase-1 on top of `RalphRunner`.
+- Do not change `aworld/core` for phase 1.
+- Do not implement fresh-process or fresh-session orchestration in phase 1.
+- Do not execute verification commands inside the stop hook in phase 1.
+- Do not add phase-1 loop-local runtime overrides such as `--model` or `--work-dir`.
+- Do not introduce Claude-specific state files such as `.claude/ralph-loop.local.md`.
+- Do not redesign the general plugin framework as part of this change.
+
+## Decisions
+
+### Decision: Phase 1 is a standalone plugin-hosted session loop
+
+The first AWorld Ralph capability should be implemented as a normal plugin, not as a core runner feature.
+
+The plugin should own these entrypoints:
+
+- `commands/ralph-loop.md`
+- `commands/cancel-ralph.md`
+- `hooks/stop_hook.py`
+- `hud/status.py`
+- `.aworld-plugin/plugin.json`
+
+Why:
+
+- This matches the current requirement exactly: keep looping inside the current CLI session.
+- The AWorld CLI already has the host behavior needed for continuation on `exit`.
+- This keeps the phase-1 change focused, testable, and independent of runner internals.
+
+Rejected alternative:
+
+- Build the phase-1 interactive loop directly on `RalphRunner`.
+  Rejected because `RalphRunner` is a task-execution loop, not a session-lifecycle controller.
+
+### Decision: The stop hook is the only loop controller
+
+The phase-1 control path should be:
+
+1. `/ralph-loop` initializes loop state.
+2. The current session executes the task.
+3. When the operator attempts to exit, the `stop` hook evaluates whether the loop should continue.
+4. If unfinished, the hook returns `block_and_continue` with a follow-up prompt.
+
+The stop hook should be the only component allowed to decide whether the loop continues or exits.
+
+Why:
+
+- It keeps loop control in one place.
+- It aligns with the current plugin hook contract.
+- It avoids splitting continuation rules between command code, HUD code, and ad hoc session logic.
+
+### Decision: Phase-1 state lives in plugin-scoped persisted state
+
+The Ralph loop should persist through AWorld's plugin state store instead of writing a host-specific state file.
+
+Recommended minimum state shape:
+
+```json
+{
+  "active": true,
+  "prompt": "Implement feature X",
+  "iteration": 1,
+  "max_iterations": 20,
+  "completion_promise": "COMPLETE",
+  "verify_commands": [
+    "pytest tests/api -q",
+    "ruff check ."
+  ],
+  "started_at": "2026-04-27T10:00:00Z",
+  "last_stop_reason": null,
+  "last_final_answer_excerpt": null
+}
+```
+
+Scope:
+
+- session scope is the default for the active loop controller
+- no Claude-specific dotfile should be part of the stable phase-1 contract
+
+Why:
+
+- This keeps the plugin host-agnostic inside AWorld.
+- The plugin framework already exposes persisted state APIs.
+- It avoids introducing a second state persistence model just for Ralph.
+
+### Decision: `/ralph-loop` stores structured verify requirements, but the hook does not run them
+
+Phase-1 verification requirements should be declared structurally and then injected into the effective prompt.
+
+Recommended user-facing contract:
+
+```text
+/ralph-loop "Implement the todo API" \
+  --verify "pytest tests/api -q" \
+  --verify "ruff check ." \
+  --completion-promise "COMPLETE" \
+  --max-iterations 20
+```
+
+The plugin should persist these `verify_commands` in plugin state and normalize the working prompt into a task package similar to:
+
+```text
+Task:
+Implement the todo API
+
+Verification requirements:
+1. Run: pytest tests/api -q
+2. Run: ruff check .
+
+Completion rule:
+Only output <promise>COMPLETE</promise> when every verification requirement passes.
+If verification fails, fix the issue and continue iterating.
+```
+
+Why:
+
+- It gives the operator a structured way to express machine-checkable expectations without turning the stop hook into a mini-runner.
+- It preserves a clean migration path to phase-2 orchestrated verification.
+- It keeps phase-1 aligned with the interactive session-loop boundary.
+
+Rejected alternative:
+
+- Have the stop hook execute verification commands itself.
+  Rejected because it would blur the line between loop control and task execution orchestration.
+
+### Decision: Phase-1 stop conditions remain intentionally small
+
+The stop hook should only enforce these phase-1 conditions:
+
+1. no active loop -> allow exit
+2. `max_iterations` reached -> allow exit and clear state
+3. `<promise>...</promise>` matches `completion_promise` exactly -> allow exit and clear state
+4. otherwise -> `block_and_continue`
+
+The hook may record diagnostic metadata such as the last final answer excerpt, but it should not accumulate richer policy in phase 1.
+
+Why:
+
+- Minimal policy is easier to trust and debug.
+- The operator prompt and verify contract remain the main behavior driver.
+- Larger policy surfaces belong in a later orchestration phase if needed.
+
+### Decision: HUD is observational only
+
+HUD should display status but never own control flow.
+
+Recommended fields:
+
+- `Ralph: active` or `inactive`
+- `Iter: 3/20` or `3/unbounded`
+- `Promise: COMPLETE` or `none`
+
+Why:
+
+- HUD should help the operator understand the loop state at a glance.
+- Control decisions already belong to the stop hook.
+
+### Decision: Phase 2 fresh-run orchestration stays separate from this change
+
+This change should explicitly defer fresh-run orchestration.
+
+Phase 2 may later evaluate:
+
+- a standalone orchestrator under `aworld-cli`
+- selective reuse of shared Ralph concepts
+- selective reuse of parts of `RalphRunner`
+
+But phase 2 should not be implied as a guaranteed `RalphRunner` integration.
+
+Why:
+
+- The current `RalphRunner` and the desired fresh-run orchestrator are related but not identical abstractions.
+- Prematurely promising a runner dependency would constrain the later design before real requirements are documented.
+
+## Plugin Contract
+
+### Command Contract
+
+`/ralph-loop`
+
+- accepts task prompt text
+- accepts repeatable `--verify`
+- accepts optional `--completion-promise`
+- accepts optional `--max-iterations`
+- initializes or replaces the active Ralph session state
+- emits a confirmation message describing the active loop policy
+
+Explicitly deferred from the phase-1 command surface:
+
+- `--model`
+- `--work-dir`
+
+`/cancel-ralph`
+
+- clears the active Ralph loop state
+- emits a confirmation message describing that the loop has been cancelled
+
+### Hook Contract
+
+The stop hook:
+
+- reads the plugin state
+- reads current stop-related event payload and available transcript context
+- updates iteration and diagnostic fields when continuing
+- returns one of:
+  - `allow`
+  - `block_and_continue`
+  - `deny` only for exceptional corruption or invalid-state cases
+
+### HUD Contract
+
+The HUD provider reads plugin state and renders status lines only.
+
+## Risks / Trade-offs
+
+- **Prompt-only verification can be gamed by the model**
+  This is accepted in phase 1 because the goal is an interactive loop plugin, not a hardened orchestrator.
+
+- **Transcript-driven completion detection may be approximate**
+  Phase 1 should keep the completion rule intentionally narrow and explicit to reduce ambiguity.
+
+- **Standalone plugin logic may later want shared helpers**
+  This is acceptable as long as the first change keeps those helpers in the CLI/plugin host layer rather than forcing runner coupling.
+
+## Validation Approach
+
+Phase-1 validation should cover:
+
+- command registration and manifest loading
+- `/ralph-loop` state initialization
+- `/cancel-ralph` state clearing
+- stop-hook `block_and_continue` behavior
+- exact completion-promise match behavior
+- max-iteration stop behavior
+- HUD rendering from plugin state
+- verify requirement normalization into the effective follow-up prompt
+
+Recommended simple acceptance cases for phase 1:
+
+- default unbounded loop:
+  `/ralph-loop "Build a Python course"`
+- explicit iteration cap:
+  `/ralph-loop "Build a REST API" --max-iterations 5`
+- declarative verification:
+  `/ralph-loop "Create a CLI tool" --verify "pytest tests/cli -q" --completion-promise "COMPLETE"`
+
+Examples intentionally not adopted as phase-1 acceptance cases:
+
+- model override cases such as `--model claude-sonnet-4-6`
+- working-directory override cases such as `--work-dir ./my-project`
+
+Those cases belong to a later orchestration/runtime-configuration phase, not to the standalone session-loop plugin slice.

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/implementation-plan.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/implementation-plan.md
@@ -1,0 +1,254 @@
+# Ralph Session Loop Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone phase-1 Ralph plugin for the interactive AWorld CLI that loops within the current session using plugin commands, plugin state, and stop hooks.
+
+**Architecture:** Extend plugin commands so a plugin can contribute Python-backed slash commands in addition to markdown prompt commands. Implement a built-in Ralph plugin with a prompt command for `/ralph-loop`, a tool command for `/cancel-ralph`, task-state hooks for final-answer diagnostics, a stop hook for continuation, and a HUD provider for loop status.
+
+**Tech Stack:** Python, pytest, AWorld CLI plugin framework, plugin state store, command registry, plugin hooks, HUD providers
+
+---
+
+### Task 1: Command Loader Foundation
+
+**Files:**
+- Modify: `aworld-cli/src/aworld_cli/core/command_system.py`
+- Modify: `aworld-cli/src/aworld_cli/console.py`
+- Modify: `aworld-cli/src/aworld_cli/plugin_capabilities/commands.py`
+- Test: `tests/plugins/test_plugin_commands.py`
+
+- [ ] **Step 1: Write the failing tests for Python-backed plugin commands and session-aware command context**
+
+Add tests that require:
+
+```python
+def test_register_python_backed_plugin_command_from_manifest():
+    ...
+    command = CommandRegistry.get("ralph-loop")
+    assert command is not None
+    assert command.command_type == "prompt"
+
+def test_command_context_carries_executor_session_id():
+    ...
+    context = CommandContext(cwd="/tmp", user_args="", runtime=runtime, session_id="session-1")
+    assert context.session_id == "session-1"
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `pytest tests/plugins/test_plugin_commands.py -k "python_backed or session_id" -v`
+Expected: FAIL because plugin commands only support markdown prompts and `CommandContext` has no `session_id`.
+
+- [ ] **Step 3: Implement the minimal loader and context support**
+
+Required behavior:
+
+```python
+@dataclass
+class CommandContext:
+    cwd: str
+    user_args: str
+    sandbox: Optional[Any] = None
+    agent_config: Optional[Any] = None
+    runtime: Optional[Any] = None
+    session_id: Optional[str] = None
+```
+
+And in plugin command loading:
+
+```python
+if target_suffix == ".py":
+    command = build_command(plugin, entrypoint)
+else:
+    command = PluginPromptCommand(plugin, entrypoint)
+```
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `pytest tests/plugins/test_plugin_commands.py -k "python_backed or session_id" -v`
+Expected: PASS
+
+### Task 2: Built-in Ralph Plugin Commands
+
+**Files:**
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/.aworld-plugin/plugin.json`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/__init__.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/ralph_loop.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/commands/cancel_ralph.py`
+- Test: `tests/plugins/test_plugin_commands.py`
+
+- [ ] **Step 1: Write the failing tests for `/ralph-loop` and `/cancel-ralph` state behavior**
+
+Add tests that require:
+
+```python
+async def test_ralph_loop_command_initializes_session_state(tmp_path):
+    ...
+    payload = json.loads(state_path.read_text())
+    assert payload["active"] is True
+    assert payload["iteration"] == 1
+    assert payload["verify_commands"] == ["pytest tests/api -q"]
+
+async def test_cancel_ralph_clears_session_state(tmp_path):
+    ...
+    result = await command.execute(context)
+    assert "cancelled" in result.lower()
+    assert handle.read() == {}
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `pytest tests/plugins/test_plugin_commands.py -k "ralph_loop_command or cancel_ralph" -v`
+Expected: FAIL because the built-in plugin and command modules do not exist yet.
+
+- [ ] **Step 3: Implement the built-in plugin commands with minimal argument parsing**
+
+Required behavior:
+
+```python
+state = {
+    "active": True,
+    "prompt": prompt_text,
+    "iteration": 1,
+    "max_iterations": max_iterations,
+    "completion_promise": completion_promise,
+    "verify_commands": verify_commands,
+    "started_at": started_at,
+    "last_stop_reason": None,
+    "last_final_answer_excerpt": None,
+}
+```
+
+And normalized prompt content must include:
+
+```text
+Task:
+...
+
+Verification requirements:
+...
+
+Completion rule:
+...
+```
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `pytest tests/plugins/test_plugin_commands.py -k "ralph_loop_command or cancel_ralph" -v`
+Expected: PASS
+
+### Task 3: Ralph Hooks And HUD
+
+**Files:**
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_completed.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_error.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/task_interrupted.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hooks/stop.py`
+- Create: `aworld-cli/src/aworld_cli/builtin_plugins/ralph_session_loop/hud/status.py`
+- Test: `tests/plugins/test_plugin_hooks.py`
+- Test: `tests/plugins/test_plugin_hud.py`
+
+- [ ] **Step 1: Write the failing tests for completion detection, max-iteration exit, and HUD lines**
+
+Add tests that require:
+
+```python
+async def test_ralph_stop_hook_blocks_and_continues_when_active(...):
+    assert result.action == "block_and_continue"
+    assert "Task:" in result.follow_up_prompt
+
+async def test_ralph_stop_hook_allows_exit_on_exact_completion_promise(...):
+    assert result.action == "allow"
+
+async def test_ralph_stop_hook_allows_exit_when_max_iterations_reached(...):
+    assert result.action == "allow"
+
+def test_ralph_hud_renders_active_state(...):
+    assert any("Ralph: active" in segment for segment in lines[0].segments + lines[1].segments)
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `pytest tests/plugins/test_plugin_hooks.py tests/plugins/test_plugin_hud.py -k "ralph" -v`
+Expected: FAIL because the hook and HUD modules do not exist yet.
+
+- [ ] **Step 3: Implement task-state hooks, stop hook, and HUD provider**
+
+Required behavior:
+
+```python
+def handle_event(event, state):
+    handle = state["__plugin_state__"]
+    ...
+    return {"action": "allow"}
+```
+
+Stop hook policy:
+
+```python
+if not active:
+    return {"action": "allow"}
+if completion promise matched:
+    handle.clear()
+    return {"action": "allow"}
+if max iterations reached:
+    handle.clear()
+    return {"action": "allow"}
+handle.update({"iteration": next_iteration, ...})
+return {"action": "block_and_continue", "follow_up_prompt": normalized_prompt}
+```
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `pytest tests/plugins/test_plugin_hooks.py tests/plugins/test_plugin_hud.py -k "ralph" -v`
+Expected: PASS
+
+### Task 4: Runtime Integration
+
+**Files:**
+- Test: `tests/plugins/test_plugin_end_to_end.py`
+- Modify: `aworld-cli/src/aworld_cli/console.py` if needed for command context/session propagation only
+
+- [ ] **Step 1: Write the failing integration test for command initialization plus stop-hook continuation**
+
+Add a test that:
+
+```python
+1. loads the built-in Ralph plugin
+2. executes `/ralph-loop ...`
+3. simulates a completed task hook update without promise match
+4. runs the stop hook
+5. asserts `block_and_continue` and iteration increment
+```
+
+- [ ] **Step 2: Run the focused integration test to verify it fails**
+
+Run: `pytest tests/plugins/test_plugin_end_to_end.py -k "ralph" -v`
+Expected: FAIL until the full plugin surface is wired together.
+
+- [ ] **Step 3: Implement any missing glue and keep scope minimal**
+
+Only fill gaps required to make the built-in plugin work through the existing plugin framework. Do not introduce `RalphRunner` dependencies.
+
+- [ ] **Step 4: Run the focused integration test to verify it passes**
+
+Run: `pytest tests/plugins/test_plugin_end_to_end.py -k "ralph" -v`
+Expected: PASS
+
+### Task 5: Final Verification
+
+**Files:**
+- Modify: `openspec/changes/2026-04-27-ralph-session-loop-plugin/tasks.md`
+
+- [ ] **Step 1: Mark completed OpenSpec tasks that were actually implemented**
+
+- [ ] **Step 2: Run the complete Ralph-related verification suite**
+
+Run: `pytest tests/plugins/test_plugin_commands.py tests/plugins/test_plugin_hooks.py tests/plugins/test_plugin_hud.py tests/plugins/test_plugin_end_to_end.py -k "ralph or python_backed or session_id" -v`
+Expected: PASS
+
+- [ ] **Step 3: Run manifest and runtime regression checks around the touched plugin framework paths**
+
+Run: `pytest tests/plugins/test_plugin_framework_manifest.py tests/plugins/test_plugin_framework_state.py -v`
+Expected: PASS

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/proposal.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+AWorld already has two relevant but different pieces of Ralph-adjacent capability:
+
+- `aworld-cli` has a plugin framework with `commands`, `stop` hooks, plugin state, and HUD surfaces that can control an interactive CLI session.
+- `aworld/runners/ralph_runner.py` is a core runner-oriented loop executor designed around `Task -> exec_tasks -> stop detector -> workspace artifacts`.
+
+The desired phase-1 capability is not a core task runner. It is an interactive Ralph loop that stays inside the current CLI session and continues execution when the operator attempts to exit. That shape matches the plugin host surface much more closely than the existing `RalphRunner`.
+
+The repository also has two external Ralph references with different strategies:
+
+- `claude_plugin/plugins/ralph-wiggum` implements an in-session loop using a stop hook and session-local state.
+- `amp` implements a fresh-process orchestration loop through `ralph.sh`, `prd.json`, and append-only progress artifacts.
+
+For AWorld, phase 1 should optimize for the smallest clean integration boundary:
+
+- keep the implementation independent from `aworld/core`
+- reuse the existing plugin and CLI session lifecycle
+- avoid coupling interactive session control to `RalphRunner`
+- leave fresh-run orchestration to a later phase
+
+## What Changes
+
+- Introduce a standalone AWorld plugin that provides a Ralph-style in-session loop for the interactive CLI.
+- Define the phase-1 plugin shape around:
+  - prompt commands
+  - `stop` hook continuation
+  - plugin-scoped persisted state
+  - optional HUD status lines
+- Freeze the phase-1 boundary so the plugin does not depend on `RalphRunner`.
+- Freeze the phase-1 verify model so verification requirements are declared and injected into the task prompt, but are not executed by the stop hook itself.
+- Reserve phase 2 for fresh-run orchestration, where reuse of shared Ralph concepts or selected `RalphRunner` concepts can be evaluated separately.
+
+## Capabilities
+
+### New Capabilities
+
+- `ralph-session-loop-plugin`: Adds a standalone plugin-hosted Ralph interaction model for the AWorld interactive CLI.
+
+### Modified Capabilities
+
+- `plugins`: Extends the plugin contract with a concrete design target for a self-looping interactive workflow built from existing `commands`, `hooks`, `state`, and `hud` surfaces.
+
+## Impact
+
+- Affects plugin manifests and plugin entrypoint usage under the AWorld CLI plugin framework.
+- Affects the interactive CLI experience by adding Ralph-specific slash commands and a stop-hook-controlled continuation path.
+- Does not require `aworld/core` changes for phase 1.
+- Does not require `RalphRunner` changes for phase 1.
+- Creates an explicit future seam for phase-2 fresh-run orchestration without prematurely hard-binding that work to the current runner implementation.

--- a/openspec/changes/2026-04-27-ralph-session-loop-plugin/tasks.md
+++ b/openspec/changes/2026-04-27-ralph-session-loop-plugin/tasks.md
@@ -1,0 +1,37 @@
+## 1. Change Skeleton
+
+- [x] 1.1 Create a standalone Ralph plugin fixture or built-in plugin directory with manifest, commands, stop hook, and HUD provider.
+- [x] 1.2 Keep the phase-1 implementation fully inside the CLI/plugin host layer and do not add a dependency on `RalphRunner`.
+
+## 2. State And Command Flow
+
+- [x] 2.1 Define the plugin state schema for active loop state, iteration data, completion promise, and declarative verification commands.
+- [x] 2.2 Implement `/ralph-loop` argument handling for prompt text, repeatable `--verify`, optional `--completion-promise`, and optional `--max-iterations`, while keeping `--model` and `--work-dir` out of scope for phase 1.
+- [x] 2.3 Implement `/cancel-ralph` state clearing.
+- [x] 2.4 Normalize stored loop state into the effective follow-up prompt contract used for continuation.
+
+## 3. Stop Hook
+
+- [x] 3.1 Implement stop-hook continuation logic using plugin state as the single source of truth.
+- [x] 3.2 Enforce the phase-1 stop-condition set only: inactive loop, max iterations reached, or exact completion-promise match.
+- [x] 3.3 Ensure loop continuation increments iteration and preserves operator-visible diagnostics needed by the HUD.
+- [x] 3.4 Ensure invalid or corrupted state fails predictably without leaving the CLI in an ambiguous continuation state.
+
+## 4. HUD
+
+- [x] 4.1 Add a HUD provider that exposes loop-active state, iteration count, and completion-promise summary.
+- [x] 4.2 Keep HUD observational only and verify that no control logic depends on HUD rendering.
+
+## 5. Validation
+
+- [x] 5.1 Add tests for plugin discovery and command registration.
+- [x] 5.2 Add tests for `/ralph-loop` state initialization and `/cancel-ralph` cleanup.
+- [x] 5.3 Add stop-hook tests for `block_and_continue`, completion-promise success, and max-iteration termination.
+- [x] 5.4 Add tests proving `--verify` values are preserved structurally and injected into the effective follow-up prompt.
+- [x] 5.5 Add HUD tests for active and inactive loop rendering.
+- [x] 5.6 Use only simple high-signal acceptance cases for phase 1, centered on unbounded loops, explicit iteration caps, and declarative verification; defer model/work-dir override cases.
+
+## 6. Future Boundary
+
+- [x] 6.1 Document in code and tests that phase 1 is a standalone session-loop plugin and not a `RalphRunner` wrapper.
+- [x] 6.2 Leave a narrow future seam for phase-2 fresh-run orchestration without committing that work to `RalphRunner` integration.

--- a/tests/examples/test_ralph_runner_example_setup.py
+++ b/tests/examples/test_ralph_runner_example_setup.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import pytest
+
+from aworld.runners.ralph.config import RalphConfig
+from examples.aworld_quick_start.ralph_runner.example_setup import (
+    RalphExamplePaths,
+    build_ralph_runner_example_config,
+    build_ralph_runner_example_criteria,
+    ensure_ralph_runner_example_workspace,
+)
+
+
+def test_ensure_ralph_runner_example_workspace_creates_seed_files(tmp_path: Path) -> None:
+    paths = RalphExamplePaths.from_root(tmp_path / "ralph-runner-example")
+
+    ensure_ralph_runner_example_workspace(paths)
+
+    assert paths.root == (tmp_path / "ralph-runner-example").resolve()
+    assert paths.root.is_dir()
+    assert paths.src_dir.is_dir()
+    assert paths.tests_dir.is_dir()
+    assert paths.rules_file.is_file()
+    assert paths.module_file.is_file()
+    assert paths.test_file.is_file()
+    assert paths.marker_file.is_file()
+    assert "order pricing" in paths.rules_file.read_text(encoding="utf-8").lower()
+    assert "NotImplementedError" in paths.module_file.read_text(encoding="utf-8")
+    assert "calculate_quote" in paths.test_file.read_text(encoding="utf-8")
+
+
+def test_ensure_ralph_runner_example_workspace_reset_clears_existing_content(tmp_path: Path) -> None:
+    paths = RalphExamplePaths.from_root(tmp_path / "ralph-runner-example")
+    ensure_ralph_runner_example_workspace(paths)
+
+    stale_file = paths.root / "stale.txt"
+    stale_file.write_text("old-data", encoding="utf-8")
+    assert stale_file.exists()
+
+    ensure_ralph_runner_example_workspace(paths, reset=True)
+
+    assert paths.root.is_dir()
+    assert not stale_file.exists()
+    assert paths.marker_file.is_file()
+
+
+def test_ensure_ralph_runner_example_workspace_reset_requires_marker(tmp_path: Path) -> None:
+    paths = RalphExamplePaths.from_root(tmp_path / "ralph-runner-example")
+    paths.root.mkdir(parents=True)
+    paths.src_dir.mkdir()
+    paths.tests_dir.mkdir()
+
+    with pytest.raises(ValueError, match="marker"):
+        ensure_ralph_runner_example_workspace(paths, reset=True)
+
+
+def test_build_ralph_runner_example_config_uses_fresh_context_and_verify(tmp_path: Path) -> None:
+    config = build_ralph_runner_example_config(workspace=str(tmp_path))
+
+    assert isinstance(config, RalphConfig)
+    assert config.workspace == str(tmp_path)
+    assert config.execution_mode == "fresh_context"
+    assert config.reuse_context is False
+    assert config.verify.enabled is True
+    assert config.verify.run_on_each_iteration is True
+    assert config.verify.run_before_completion is True
+    assert config.verify.commands == ["PYTHONPATH=. pytest -q"]
+
+
+def test_build_ralph_runner_example_criteria_sets_reasonable_iteration_budget() -> None:
+    criteria = build_ralph_runner_example_criteria()
+
+    assert criteria.max_iterations == 5
+    assert criteria.custom_stop is None
+
+
+def test_build_ralph_runner_example_criteria_can_add_verify_based_stop() -> None:
+    criteria = build_ralph_runner_example_criteria(task_id="task-1")
+
+    assert criteria.max_iterations == 5
+    assert callable(criteria.custom_stop)

--- a/tests/plugins/test_plugin_commands.py
+++ b/tests/plugins/test_plugin_commands.py
@@ -9,6 +9,36 @@ from aworld_cli.plugin_capabilities.state import PluginStateStore
 from aworld_cli.runtime.base import BaseCliRuntime
 
 
+def _build_dummy_runtime(tmp_path):
+    class DummyRuntime(BaseCliRuntime):
+        async def _load_agents(self):
+            return []
+
+        async def _create_executor(self, agent):
+            return None
+
+        def _get_source_type(self):
+            return "TEST"
+
+        def _get_source_location(self):
+            return "test://commands"
+
+    runtime = DummyRuntime(agent_name="Aworld")
+    runtime._plugin_state_store = PluginStateStore(tmp_path / "state")
+    return runtime
+
+
+def _get_builtin_ralph_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "ralph_session_loop"
+    )
+
+
 def test_register_plugin_command_from_manifest():
     plugin_root = Path("tests/fixtures/plugins/code_review_like").resolve()
     plugin = discover_plugins([plugin_root])[0]
@@ -58,6 +88,74 @@ def test_sync_plugin_commands_removes_stale_plugin_commands():
         assert CommandRegistry.get("code-review") is None
     finally:
         CommandRegistry.restore(snapshot)
+
+
+def test_register_python_backed_plugin_command_from_manifest(tmp_path):
+    plugin_root = tmp_path / "python_plugin"
+    (plugin_root / ".aworld-plugin").mkdir(parents=True)
+    (plugin_root / "commands").mkdir()
+    (plugin_root / ".aworld-plugin" / "plugin.json").write_text(
+        (
+            "{"
+            "\"id\": \"python-plugin\", "
+            "\"name\": \"python-plugin\", "
+            "\"version\": \"1.0.0\", "
+            "\"entrypoints\": {"
+            "\"commands\": ["
+            "{"
+            "\"id\": \"python-backed\", "
+            "\"name\": \"python-backed\", "
+            "\"target\": \"commands/python_backed.py\""
+            "}"
+            "]"
+            "}"
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    (plugin_root / "commands" / "python_backed.py").write_text(
+        "from aworld_cli.core.command_system import Command\n"
+        "class PythonBackedCommand(Command):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        "        return 'python-backed'\n"
+        "    @property\n"
+        "    def description(self):\n"
+        "        return 'Python backed command'\n"
+        "    async def get_prompt(self, context):\n"
+        "        return f'hello {context.user_args}'\n"
+        "def build_command(plugin, entrypoint):\n"
+        "    return PythonBackedCommand()\n",
+        encoding="utf-8",
+    )
+
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+
+        command = CommandRegistry.get("python-backed")
+        assert command is not None
+        assert command.command_type == "prompt"
+        prompt = __import__("asyncio").run(
+            command.get_prompt(CommandContext(cwd=str(plugin_root), user_args="world"))
+        )
+        assert prompt == "hello world"
+    finally:
+        CommandRegistry.restore(snapshot)
+
+
+def test_command_context_carries_executor_session_id():
+    context = CommandContext(
+        cwd="/tmp",
+        user_args="--flag",
+        runtime=SimpleNamespace(),
+        session_id="session-123",
+    )
+
+    assert context.session_id == "session-123"
 
 
 def test_plugin_command_workspace_state_is_shared_with_hook_runtime(tmp_path):
@@ -122,3 +220,85 @@ def test_plugin_command_workspace_state_is_shared_with_hook_runtime(tmp_path):
     )
 
     assert hook_state["iteration"] == 2
+
+
+async def test_ralph_loop_command_initializes_session_state(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+        command = CommandRegistry.get("ralph-loop")
+        runtime = _build_dummy_runtime(tmp_path)
+        workspace_path = str(tmp_path / "workspace")
+
+        prompt = await command.get_prompt(
+            CommandContext(
+                cwd=workspace_path,
+                user_args='"Build a REST API" --verify "pytest tests/api -q" --completion-promise "COMPLETE" --max-iterations 5',
+                runtime=runtime,
+                session_id="session-1",
+            )
+        )
+
+        state_path = runtime._resolve_plugin_state_path(
+            plugin_id=plugin.manifest.plugin_id,
+            scope="session",
+            session_id="session-1",
+            workspace_path=workspace_path,
+        )
+        payload = runtime._plugin_state_store.handle(state_path).read()
+
+        assert payload["active"] is True
+        assert payload["prompt"] == "Build a REST API"
+        assert payload["iteration"] == 1
+        assert payload["max_iterations"] == 5
+        assert payload["completion_promise"] == "COMPLETE"
+        assert payload["verify_commands"] == ["pytest tests/api -q"]
+        assert "Task:" in prompt
+        assert "Verification requirements:" in prompt
+        assert "Only output <promise>COMPLETE</promise>" in prompt
+    finally:
+        CommandRegistry.restore(snapshot)
+
+
+async def test_cancel_ralph_clears_session_state(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+        runtime = _build_dummy_runtime(tmp_path)
+        workspace_path = str(tmp_path / "workspace")
+        state_path = runtime._resolve_plugin_state_path(
+            plugin_id=plugin.manifest.plugin_id,
+            scope="session",
+            session_id="session-1",
+            workspace_path=workspace_path,
+        )
+        runtime._plugin_state_store.handle(state_path).write(
+            {
+                "active": True,
+                "prompt": "Build a REST API",
+                "iteration": 2,
+            }
+        )
+
+        command = CommandRegistry.get("cancel-ralph")
+        result = await command.execute(
+            CommandContext(
+                cwd=workspace_path,
+                user_args="",
+                runtime=runtime,
+                session_id="session-1",
+            )
+        )
+
+        assert "cancel" in result.lower()
+        assert runtime._plugin_state_store.handle(state_path).read() == {}
+    finally:
+        CommandRegistry.restore(snapshot)

--- a/tests/plugins/test_plugin_commands.py
+++ b/tests/plugins/test_plugin_commands.py
@@ -2,7 +2,14 @@ from types import SimpleNamespace
 
 from pathlib import Path
 
+import pytest
+
 from aworld_cli.core.command_system import CommandContext, CommandRegistry
+from aworld_cli.builtin_plugins.ralph_session_loop.common import (
+    extract_completion_promise,
+    parse_loop_args,
+    summarize_text,
+)
 from aworld.plugins.discovery import discover_plugins
 from aworld_cli.plugin_capabilities.commands import PluginPromptCommand, register_plugin_commands, sync_plugin_commands
 from aworld_cli.plugin_capabilities.state import PluginStateStore
@@ -37,6 +44,35 @@ def _get_builtin_ralph_plugin_root() -> Path:
         / "builtin_plugins"
         / "ralph_session_loop"
     )
+
+
+@pytest.mark.parametrize("user_args", ['"Build API" --max-iterations 0', '"Build API" --max-iterations -5'])
+def test_parse_loop_args_rejects_non_positive_max_iterations(user_args):
+    with pytest.raises(ValueError, match="--max-iterations must be >= 1"):
+        parse_loop_args(user_args)
+
+
+def test_parse_loop_args_rejects_malformed_quotes():
+    with pytest.raises(ValueError, match="quotation"):
+        parse_loop_args('"Build API --verify unclosed')
+
+
+def test_extract_completion_promise_strips_multiline_content():
+    answer = "Done\n<promise>\nCOMPLETE\n</promise>"
+
+    assert extract_completion_promise(answer) == "COMPLETE"
+
+
+def test_extract_completion_promise_strips_surrounding_whitespace():
+    assert extract_completion_promise("<promise>  COMPLETE  </promise>") == "COMPLETE"
+
+
+def test_summarize_text_handles_edge_cases():
+    assert summarize_text("") == ""
+    assert summarize_text("a" * 160) == "a" * 160
+    assert summarize_text("a" * 161) == "a" * 157 + "..."
+    assert summarize_text("Hello 🎉 World", limit=10) == "Hello 🎉..."
+    assert summarize_text(None) is None
 
 
 def test_register_plugin_command_from_manifest():
@@ -258,8 +294,35 @@ async def test_ralph_loop_command_initializes_session_state(tmp_path):
         assert payload["completion_promise"] == "COMPLETE"
         assert payload["verify_commands"] == ["pytest tests/api -q"]
         assert "Task:" in prompt
+        assert "Build a REST API" in prompt
         assert "Verification requirements:" in prompt
+        assert "1. Run: pytest tests/api -q" in prompt
+        assert "Completion rule:" in prompt
         assert "Only output <promise>COMPLETE</promise>" in prompt
+    finally:
+        CommandRegistry.restore(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_command_rejects_missing_state_handle_at_prompt_time(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+        command = CommandRegistry.get("ralph-loop")
+
+        with pytest.raises(ValueError, match="session-aware plugin state"):
+            await command.get_prompt(
+                CommandContext(
+                    cwd=str(tmp_path / "workspace"),
+                    user_args='"Build API"',
+                    runtime=None,
+                    session_id=None,
+                )
+            )
     finally:
         CommandRegistry.restore(snapshot)
 

--- a/tests/plugins/test_plugin_end_to_end.py
+++ b/tests/plugins/test_plugin_end_to_end.py
@@ -19,6 +19,17 @@ def _set_isolated_plugin_dir(monkeypatch, tmp_path: Path) -> Path:
     return plugin_dir
 
 
+def _get_builtin_ralph_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "ralph_session_loop"
+    )
+
+
 def test_code_review_like_plugin_registers_command_and_assets(tmp_path):
     manager = PluginManager(plugin_dir=tmp_path / "plugins")
     plugin_root = Path("tests/fixtures/plugins/code_review_like").resolve()
@@ -67,6 +78,22 @@ def test_runtime_initialization_registers_enabled_plugin_commands(tmp_path):
         runtime._initialize_plugin_framework()
 
         assert CommandRegistry.get("code-review") is not None
+    finally:
+        CommandRegistry.restore(snapshot)
+
+
+def test_builtin_ralph_plugin_registers_commands_and_hook_capability():
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+
+        assert CommandRegistry.get("ralph-loop") is not None
+        assert CommandRegistry.get("cancel-ralph") is not None
+        assert plugin.manifest.capabilities == {"commands", "hooks", "hud"}
     finally:
         CommandRegistry.restore(snapshot)
 

--- a/tests/plugins/test_plugin_hooks.py
+++ b/tests/plugins/test_plugin_hooks.py
@@ -302,6 +302,78 @@ async def test_ralph_stop_hook_blocks_and_continues_when_active(tmp_path):
     assert result.action == "block_and_continue"
     assert "Task:" in result.follow_up_prompt
     assert "Verification requirements:" in result.follow_up_prompt
+    assert "pytest tests/api -q" in result.follow_up_prompt
+    assert handle.read()["iteration"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ralph_stop_hook_denies_when_handle_is_missing_for_active_state(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"active": True},
+    )
+
+    assert result.action == "deny"
+    assert "unavailable" in result.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_ralph_stop_hook_handles_missing_prompt_field(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    store = PluginStateStore(tmp_path / "plugin-state")
+    state_path = store.session_state("ralph-session-loop", "session-1")
+    handle = store.handle(state_path)
+    handle.write(
+        {
+            "active": True,
+            "iteration": 1,
+            "max_iterations": 5,
+        }
+    )
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    assert result.action == "block_and_continue"
+    assert "Task:" in result.follow_up_prompt
+    assert handle.read()["iteration"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("iteration_value", [None, -3, "oops"])
+async def test_ralph_stop_hook_handles_invalid_iteration_value(tmp_path, iteration_value):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    store = PluginStateStore(tmp_path / "plugin-state")
+    state_path = store.session_state("ralph-session-loop", "session-1")
+    handle = store.handle(state_path)
+    handle.write(
+        {
+            "active": True,
+            "prompt": "Build a REST API",
+            "iteration": iteration_value,
+            "max_iterations": 5,
+            "verify_commands": [],
+        }
+    )
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    assert result.action == "block_and_continue"
     assert handle.read()["iteration"] == 2
 
 

--- a/tests/plugins/test_plugin_hooks.py
+++ b/tests/plugins/test_plugin_hooks.py
@@ -12,6 +12,17 @@ from aworld_cli.plugin_capabilities.state import PluginStateStore
 from aworld_cli.runtime.base import BaseCliRuntime
 
 
+def _get_builtin_ralph_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "ralph_session_loop"
+    )
+
+
 def test_load_plugin_hook_entrypoints():
     plugin_root = Path("tests/fixtures/plugins/ralph_like").resolve()
     plugin = discover_plugins([plugin_root])[0]
@@ -260,3 +271,98 @@ async def test_plugin_hook_adapter_caches_loaded_handler_module(tmp_path):
     await hook.run(event={}, state={})
 
     assert import_log.read_text(encoding="utf-8") == "x"
+
+
+@pytest.mark.asyncio
+async def test_ralph_stop_hook_blocks_and_continues_when_active(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    store = PluginStateStore(tmp_path / "plugin-state")
+    state_path = store.session_state("ralph-session-loop", "session-1")
+    handle = store.handle(state_path)
+    handle.write(
+        {
+            "active": True,
+            "prompt": "Build a REST API",
+            "iteration": 1,
+            "max_iterations": 5,
+            "completion_promise": "COMPLETE",
+            "verify_commands": ["pytest tests/api -q"],
+            "last_final_answer": "not done yet",
+        }
+    )
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    assert result.action == "block_and_continue"
+    assert "Task:" in result.follow_up_prompt
+    assert "Verification requirements:" in result.follow_up_prompt
+    assert handle.read()["iteration"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ralph_stop_hook_allows_exit_on_exact_completion_promise(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    store = PluginStateStore(tmp_path / "plugin-state")
+    state_path = store.session_state("ralph-session-loop", "session-1")
+    handle = store.handle(state_path)
+    handle.write(
+        {
+            "active": True,
+            "prompt": "Build a REST API",
+            "iteration": 1,
+            "completion_promise": "COMPLETE",
+            "verify_commands": [],
+        }
+    )
+
+    await hooks["task_completed"][0].run(
+        event={"final_answer": "All done.\n<promise>COMPLETE</promise>", "task_status": "completed"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    assert result.action == "allow"
+    assert handle.read() == {}
+
+
+@pytest.mark.asyncio
+async def test_ralph_stop_hook_allows_exit_when_max_iterations_reached(tmp_path):
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+    hooks = load_plugin_hooks([plugin])
+
+    store = PluginStateStore(tmp_path / "plugin-state")
+    state_path = store.session_state("ralph-session-loop", "session-1")
+    handle = store.handle(state_path)
+    handle.write(
+        {
+            "active": True,
+            "prompt": "Build a REST API",
+            "iteration": 5,
+            "max_iterations": 5,
+            "completion_promise": "COMPLETE",
+            "verify_commands": [],
+            "last_final_answer": "still failing",
+        }
+    )
+
+    result = await hooks["stop"][0].run(
+        event={"session_id": "session-1"},
+        state={"__plugin_state__": handle, **handle.read()},
+    )
+
+    assert result.action == "allow"
+    assert handle.read() == {}

--- a/tests/plugins/test_plugin_hud.py
+++ b/tests/plugins/test_plugin_hud.py
@@ -19,6 +19,13 @@ def _get_builtin_aworld_hud_root() -> Path:
     raise AssertionError("built-in aworld_hud plugin root not found")
 
 
+def _get_builtin_ralph_plugin_root() -> Path:
+    for root in get_builtin_plugin_roots():
+        if root.name == "ralph_session_loop":
+            return root
+    raise AssertionError("built-in ralph_session_loop plugin root not found")
+
+
 def test_collect_hud_lines_orders_by_section_and_priority():
     plugin_root = _get_builtin_aworld_hud_root()
     plugin = discover_plugins([plugin_root])[0]
@@ -639,3 +646,29 @@ def test_status_bar_renders_multiline_html(monkeypatch):
 
     assert "\n" in rendered
     assert "Task: task_001" in rendered
+
+
+def test_ralph_hud_renders_active_loop_state():
+    plugin_root = _get_builtin_ralph_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    lines = collect_hud_lines(
+        plugins=[plugin],
+        context={
+            "workspace": {"name": "aworld"},
+            "session": {"agent": "Aworld", "mode": "Chat", "session_id": "session-1"},
+        },
+        plugin_state_provider=lambda plugin_id, scope, context: {
+            "active": True,
+            "iteration": 2,
+            "max_iterations": 5,
+            "completion_promise": "COMPLETE",
+        },
+    )
+
+    assert [line.section for line in lines] == ["session"]
+    assert lines[0].segments == (
+        "Ralph: active",
+        "Iter: 2/5",
+        "Promise: COMPLETE",
+    )

--- a/tests/runners/test_ralph_iteration_evaluator.py
+++ b/tests/runners/test_ralph_iteration_evaluator.py
@@ -1,0 +1,148 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aworld.core.task import Task, TaskResponse
+from aworld.runners.ralph.config import RalphVerifyConfig
+from aworld.runners.ralph.evaluator import IterationEvaluator
+from aworld.runners.ralph.input_builder import IterationInputBuilder
+from aworld.runners.ralph.memory import LoopMemoryStore
+from aworld.runners.ralph.policy import RalphLoopPolicy
+from aworld.runners.ralph.state import LoopContext, LoopState
+from aworld.runners.ralph.types import CompletionCriteria
+
+
+@pytest.mark.asyncio
+async def test_iteration_evaluator_persists_failed_verify_output(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    task = Task(input="Build an API")
+    evaluator = IterationEvaluator(
+        context=context,
+        memory_store=LoopMemoryStore(context),
+        verify_config=RalphVerifyConfig(
+            enabled=True,
+            commands=["pytest -q"],
+            run_on_each_iteration=True,
+        ),
+    )
+    context.sand_box.terminal.run_code = AsyncMock(
+        return_value={
+            "success": True,
+            "data": {
+                "success": False,
+                "metadata": {
+                    "return_code": 1,
+                    "output_data": "FAILED tests/test_api.py::test_handlers",
+                },
+            },
+            "error": None,
+        }
+    )
+
+    result = await evaluator.evaluate(
+        task=task,
+        iter_num=1,
+        execution_result=TaskResponse(id=task.id, answer="Created API handlers", success=True),
+    )
+
+    assert result.verify_result is not None
+    assert result.verify_result.passed is False
+    assert result.verify_result.commands[0].command == "pytest -q"
+    assert result.verify_result.commands[0].exit_code == 1
+    assert "FAILED tests/test_api.py::test_handlers" in result.verify_result.commands[0].output
+
+    persisted_verify = await context.memory.read_verify_result(task.id, 1)
+    assert persisted_verify is not None
+    assert persisted_verify["passed"] is False
+    assert persisted_verify["commands"][0]["command"] == "pytest -q"
+
+    persisted_feedback = await context.memory.read_reflection_feedback(task.id, 1)
+    assert persisted_feedback is not None
+    assert "Verification failed" in persisted_feedback
+    assert "pytest -q" in persisted_feedback
+
+
+@pytest.mark.asyncio
+async def test_iteration_evaluator_feeds_verify_failure_into_next_iteration_input(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    task = Task(input="Build an API")
+    evaluator = IterationEvaluator(
+        context=context,
+        memory_store=LoopMemoryStore(context),
+        verify_config=RalphVerifyConfig(
+            enabled=True,
+            commands=["pytest -q"],
+            run_on_each_iteration=True,
+        ),
+    )
+    context.sand_box.terminal.run_code = AsyncMock(
+        return_value={
+            "success": True,
+            "data": {
+                "success": False,
+                "metadata": {
+                    "return_code": 1,
+                    "output_data": "FAILED tests/test_api.py::test_handlers",
+                },
+            },
+            "error": None,
+        }
+    )
+
+    await evaluator.evaluate(
+        task=task,
+        iter_num=1,
+        execution_result=TaskResponse(id=task.id, answer="Created API handlers", success=True),
+    )
+
+    builder = IterationInputBuilder(
+        policy=RalphLoopPolicy(execution_mode="fresh_context", verify_enabled=True),
+        memory_store=context.memory,
+    )
+    payload = await builder.build(
+        task_id=task.id,
+        original_task="Build an API",
+        iteration=2,
+        previous_answer="Created API handlers",
+    )
+
+    assert "Verification failed" in payload.task_input
+    assert "pytest -q" in payload.task_input
+
+
+@pytest.mark.asyncio
+async def test_iteration_evaluator_skips_verify_when_disabled(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    task = Task(input="Build an API")
+    evaluator = IterationEvaluator(
+        context=context,
+        memory_store=LoopMemoryStore(context),
+        verify_config=RalphVerifyConfig(
+            enabled=False,
+            commands=["pytest -q"],
+            run_on_each_iteration=True,
+        ),
+    )
+    context.sand_box.terminal.run_code = AsyncMock(side_effect=AssertionError("verify should be skipped"))
+
+    result = await evaluator.evaluate(
+        task=task,
+        iter_num=1,
+        execution_result=TaskResponse(id=task.id, answer="Created API handlers", success=True),
+    )
+
+    assert result.verify_result is None
+    assert await context.memory.read_verify_result(task.id, 1) is None
+    assert await context.memory.read_reflection_feedback(task.id, 1) is None

--- a/tests/runners/test_ralph_iteration_evaluator.py
+++ b/tests/runners/test_ralph_iteration_evaluator.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -32,13 +33,16 @@ async def test_iteration_evaluator_persists_failed_verify_output(tmp_path):
     context.sand_box.terminal.run_code = AsyncMock(
         return_value={
             "success": True,
-            "data": {
-                "success": False,
-                "metadata": {
-                    "return_code": 1,
-                    "output_data": "FAILED tests/test_api.py::test_handlers",
-                },
-            },
+            "data": json.dumps(
+                {
+                    "success": False,
+                    "message": "Command failed",
+                    "metadata": {
+                        "return_code": 1,
+                        "output_data": "FAILED tests/test_api.py::test_handlers",
+                    },
+                }
+            ),
             "error": None,
         }
     )
@@ -86,13 +90,16 @@ async def test_iteration_evaluator_feeds_verify_failure_into_next_iteration_inpu
     context.sand_box.terminal.run_code = AsyncMock(
         return_value={
             "success": True,
-            "data": {
-                "success": False,
-                "metadata": {
-                    "return_code": 1,
-                    "output_data": "FAILED tests/test_api.py::test_handlers",
-                },
-            },
+            "data": json.dumps(
+                {
+                    "success": False,
+                    "message": "Command failed",
+                    "metadata": {
+                        "return_code": 1,
+                        "output_data": "FAILED tests/test_api.py::test_handlers",
+                    },
+                }
+            ),
             "error": None,
         }
     )
@@ -146,3 +153,34 @@ async def test_iteration_evaluator_skips_verify_when_disabled(tmp_path):
     assert result.verify_result is None
     assert await context.memory.read_verify_result(task.id, 1) is None
     assert await context.memory.read_reflection_feedback(task.id, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_iteration_evaluator_skips_iteration_verify_when_run_on_each_iteration_is_disabled(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    task = Task(input="Build an API")
+    evaluator = IterationEvaluator(
+        context=context,
+        memory_store=LoopMemoryStore(context),
+        verify_config=RalphVerifyConfig(
+            enabled=True,
+            commands=["pytest -q"],
+            run_on_each_iteration=False,
+            run_before_completion=False,
+        ),
+    )
+    context.sand_box.terminal.run_code = AsyncMock(side_effect=AssertionError("iteration verify should be skipped"))
+
+    result = await evaluator.evaluate(
+        task=task,
+        iter_num=1,
+        execution_result=TaskResponse(id=task.id, answer="Created API handlers", success=True),
+        phase="post_iteration",
+    )
+
+    assert result.verify_result is None
+    assert await context.memory.read_verify_result(task.id, 1) is None

--- a/tests/runners/test_ralph_iteration_evaluator.py
+++ b/tests/runners/test_ralph_iteration_evaluator.py
@@ -151,8 +151,10 @@ async def test_iteration_evaluator_skips_verify_when_disabled(tmp_path):
     )
 
     assert result.verify_result is None
+    assert result.summary == "Created API handlers"
     assert await context.memory.read_verify_result(task.id, 1) is None
     assert await context.memory.read_reflection_feedback(task.id, 1) is None
+    assert await context.memory.read_iteration_summary(task.id, 1) == "Created API handlers"
 
 
 @pytest.mark.asyncio
@@ -183,4 +185,6 @@ async def test_iteration_evaluator_skips_iteration_verify_when_run_on_each_itera
     )
 
     assert result.verify_result is None
+    assert result.summary == "Created API handlers"
     assert await context.memory.read_verify_result(task.id, 1) is None
+    assert await context.memory.read_iteration_summary(task.id, 1) == "Created API handlers"

--- a/tests/runners/test_ralph_loop_memory_store.py
+++ b/tests/runners/test_ralph_loop_memory_store.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from aworld.runners.ralph.memory import LoopMemoryStore
+from aworld.runners.ralph.state import LoopContext, LoopState
+from aworld.runners.ralph.types import CompletionCriteria
+
+
+@pytest.mark.asyncio
+async def test_loop_memory_store_round_trips_iteration_summary(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    store = LoopMemoryStore(context)
+
+    await store.write_iteration_summary("task-1", 1, "summary text")
+
+    assert await store.read_iteration_summary("task-1", 1) == "summary text"
+
+
+@pytest.mark.asyncio
+async def test_loop_memory_store_uses_file_storage_for_answer_payloads(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    store = LoopMemoryStore(context)
+
+    await store.write_answer("task-1", 2, "answer text")
+
+    assert await store.read_answer("task-1", 2) == "answer text"
+    assert Path(tmp_path, "task", "answer", "task-1_2").exists()
+
+
+def test_loop_context_enables_filesystem_and_terminal_sandbox_tools(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    assert set(context.sand_box.mcp_config.get("mcpServers", {})) >= {"filesystem", "terminal"}

--- a/tests/runners/test_ralph_loop_memory_store.py
+++ b/tests/runners/test_ralph_loop_memory_store.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from aworld.core.task import Task
 from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.state import LoopContext, LoopState
 from aworld.runners.ralph.types import CompletionCriteria
@@ -44,3 +46,91 @@ def test_loop_context_enables_filesystem_and_terminal_sandbox_tools(tmp_path):
     )
 
     assert set(context.sand_box.mcp_config.get("mcpServers", {})) >= {"filesystem", "terminal"}
+
+
+def test_loop_context_direct_construction_preserves_completion_criteria(tmp_path):
+    criteria = CompletionCriteria(max_iterations=7)
+
+    context = LoopContext(
+        completion_criteria=criteria,
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    assert context.completion_criteria is criteria
+    assert context.completion_criteria.max_iterations == 7
+
+
+@pytest.mark.asyncio
+async def test_loop_context_add_file_reports_failed_answer_persistence(tmp_path, monkeypatch):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    async def fail_write_answer(task_id, iteration, content):
+        return {"success": False, "error": "write failed"}
+
+    monkeypatch.setattr(context.memory, "write_answer", fail_write_answer)
+
+    success, _, _ = await context.add_file(filename="task-1_2", content="answer text")
+
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_read_to_task_context_reads_answer_via_memory_store_without_direct_path_check(tmp_path, monkeypatch):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    async def fake_read_answer(task_id, iteration):
+        return "persisted answer"
+
+    async def fake_read_feedback(task_id, iteration):
+        return "try again"
+
+    def fail_answer_path(task_id, iteration):
+        raise AssertionError("read_to_task_context should not inspect answer_path directly")
+
+    monkeypatch.setattr(context.memory, "read_answer", fake_read_answer)
+    monkeypatch.setattr(context.memory, "read_reflection_feedback", fake_read_feedback)
+    monkeypatch.setattr(context.memory, "answer_path", fail_answer_path)
+
+    task = Task(input="original task")
+    task.id = "task-1"
+
+    result = await context.read_to_task_context(task=task, iter_num=2, reuse_context=True)
+
+    assert result is context
+    assert "persisted answer" in task.input
+    assert "try again" in task.input
+
+
+@pytest.mark.asyncio
+async def test_write_to_loop_context_preserves_feedback_artifact_metadata(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    task_context = SimpleNamespace(get_task=lambda: SimpleNamespace(id="task-1"))
+
+    await context.write_to_loop_context(
+        content="reflection text",
+        task_context=task_context,
+        iter_num=2,
+        content_type="reflect",
+    )
+
+    artifact = context.workspace.get_artifact_data(context.memory.reflection_feedback_artifact_id("task-1", 2))
+
+    assert artifact is not None
+    assert artifact["content"] == "reflection text"
+    assert artifact["metadata"]["context_type"] == "reflect"
+    assert artifact["metadata"]["task_id"] == "task-1"
+    assert artifact["metadata"]["iteration"] == 2

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -158,6 +158,65 @@ async def test_ralph_runner_build_iteration_context_uses_fresh_sub_context(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_ralph_runner_build_iteration_context_seeds_real_fresh_context_from_iteration_payload(tmp_path):
+    task = Task(input="stale task input", conf=RalphConfig(execution_mode="fresh_context", workspace=str(tmp_path)))
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria())
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    iteration_input = IterationInput(task_input="current iteration payload", reuse_context=False)
+
+    context = await runner._build_iteration_context(iteration_input, task, iter_num=2)
+
+    assert context.task_input == "current iteration payload"
+    assert context.origin_user_input == "current iteration payload"
+    assert context.task_state.task_input.task_content == "current iteration payload"
+    assert context.task_state.task_input.origin_user_input == "current iteration payload"
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_execute_task_uses_current_iteration_payload_for_fresh_context(tmp_path, monkeypatch):
+    task = Task(input="stale task input", conf=RalphConfig(execution_mode="fresh_context", workspace=str(tmp_path)))
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria())
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    runner.memory_store = runner.loop_context.memory
+
+    class StubBuilder:
+        async def build(self, **kwargs):
+            return IterationInput(task_input="current iteration payload", reuse_context=False)
+
+    runner.input_builder = StubBuilder()
+    captured = {}
+
+    async def fake_exec_tasks(tasks):
+        current_task = tasks[0]
+        captured["task_input"] = current_task.input
+        captured["origin_user_input"] = current_task.context.origin_user_input
+        return {
+            current_task.id: TaskResponse(
+                id=current_task.id,
+                answer="done",
+                success=True,
+            )
+        }
+
+    monkeypatch.setattr("aworld.runners.ralph_runner.exec_tasks", fake_exec_tasks)
+
+    await runner._execute_task(task, iter_num=2)
+
+    assert captured["task_input"] == "current iteration payload"
+    assert captured["origin_user_input"] == "current iteration payload"
+    assert task.input == "current iteration payload"
+
+
+@pytest.mark.asyncio
 async def test_runner_ralph_run_preserves_public_api(monkeypatch):
     task = Task(input="Build API", conf=RalphConfig())
     response = TaskResponse(id=task.id, answer="done", success=True)

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -7,6 +7,7 @@ from aworld.core.context.amni import ApplicationContext
 from aworld.core.task import Task, TaskResponse
 from aworld.runners.ralph.config import RalphConfig, RalphVerifyConfig
 from aworld.runners.ralph.detect.types import StopType
+from aworld.runners.ralph.evaluator import IterationEvaluationResult, VerifyCommandResult, VerifyResult
 from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
 from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.policy import RalphLoopPolicy
@@ -250,6 +251,7 @@ async def test_ralph_runner_do_run_invokes_iteration_evaluator_after_execution(t
     response = TaskResponse(id=task.id, answer="done", success=True)
     runner._execute_task = AsyncMock(return_value=response)
     runner.evaluator = AsyncMock()
+    runner.evaluator.evaluate.return_value = IterationEvaluationResult(summary="done")
     runner.stop_detector.should_stop = AsyncMock(
         side_effect=[
             type("StopDecision", (), {"should_stop": False, "stop_type": None, "reason": None})(),
@@ -269,7 +271,7 @@ async def test_ralph_runner_do_run_invokes_iteration_evaluator_after_execution(t
 
 
 @pytest.mark.asyncio
-async def test_ralph_runner_do_run_skips_iteration_evaluator_when_run_on_each_iteration_is_disabled(tmp_path):
+async def test_ralph_runner_do_run_still_calls_evaluator_when_run_on_each_iteration_is_disabled(tmp_path):
     task = Task(
         input="Build API",
         conf=RalphConfig(
@@ -286,6 +288,7 @@ async def test_ralph_runner_do_run_skips_iteration_evaluator_when_run_on_each_it
     response = TaskResponse(id=task.id, answer="done", success=True)
     runner._execute_task = AsyncMock(return_value=response)
     runner.evaluator = AsyncMock()
+    runner.evaluator.evaluate.return_value = IterationEvaluationResult(summary="done")
     runner.stop_detector.should_stop = AsyncMock(
         side_effect=[
             type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
@@ -296,7 +299,12 @@ async def test_ralph_runner_do_run_skips_iteration_evaluator_when_run_on_each_it
     result = await runner.do_run()
 
     assert result is response
-    runner.evaluator.evaluate.assert_not_awaited()
+    runner.evaluator.evaluate.assert_awaited_once_with(
+        task=task,
+        iter_num=1,
+        execution_result=response,
+        phase="post_iteration",
+    )
 
 
 @pytest.mark.asyncio
@@ -322,6 +330,16 @@ async def test_ralph_runner_do_run_verifies_before_completion_when_configured(tm
     response = TaskResponse(id=task.id, answer="done", success=True)
     runner._execute_task = AsyncMock(return_value=response)
     runner.evaluator = AsyncMock()
+    runner.evaluator.evaluate.side_effect = [
+        IterationEvaluationResult(summary="done"),
+        IterationEvaluationResult(
+            summary="done",
+            verify_result=VerifyResult(
+                passed=True,
+                commands=[VerifyCommandResult(command="pytest -q", exit_code=0, output="ok", passed=True)],
+            ),
+        ),
+    ]
     runner.stop_detector.should_stop = AsyncMock(
         side_effect=[
             type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
@@ -332,12 +350,20 @@ async def test_ralph_runner_do_run_verifies_before_completion_when_configured(tm
     result = await runner.do_run()
 
     assert result is response
-    runner.evaluator.evaluate.assert_awaited_once_with(
-        task=task,
-        iter_num=1,
-        execution_result=response,
-        phase="before_completion",
-    )
+    assert runner.evaluator.evaluate.await_args_list == [
+        call(
+            task=task,
+            iter_num=1,
+            execution_result=response,
+            phase="post_iteration",
+        ),
+        call(
+            task=task,
+            iter_num=1,
+            execution_result=response,
+            phase="before_completion",
+        ),
+    ]
 
 
 @pytest.mark.asyncio
@@ -363,6 +389,7 @@ async def test_ralph_runner_do_run_does_not_verify_before_non_completion_stop(tm
     response = TaskResponse(id=task.id, answer="done", success=True)
     runner._execute_task = AsyncMock(return_value=response)
     runner.evaluator = AsyncMock()
+    runner.evaluator.evaluate.return_value = IterationEvaluationResult(summary="done")
     runner.stop_detector.should_stop = AsyncMock(
         side_effect=[
             type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
@@ -373,4 +400,79 @@ async def test_ralph_runner_do_run_does_not_verify_before_non_completion_stop(tm
     result = await runner.do_run()
 
     assert result is response
-    runner.evaluator.evaluate.assert_not_awaited()
+    runner.evaluator.evaluate.assert_awaited_once_with(
+        task=task,
+        iter_num=1,
+        execution_result=response,
+        phase="post_iteration",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_do_run_keeps_loop_alive_when_before_completion_verify_fails(tmp_path):
+    task = Task(
+        input="Build API",
+        conf=RalphConfig(
+            workspace=str(tmp_path),
+            verify=RalphVerifyConfig(
+                enabled=True,
+                commands=["pytest -q"],
+                run_on_each_iteration=False,
+                run_before_completion=True,
+            ),
+        ),
+    )
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria(max_iterations=3))
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(max_iterations=3),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    first_response = TaskResponse(id=task.id, answer="first", success=True)
+    second_response = TaskResponse(id=task.id, answer="second", success=True)
+    runner._execute_task = AsyncMock(side_effect=[first_response, second_response])
+    runner.evaluator = AsyncMock()
+    runner.evaluator.evaluate.side_effect = [
+        IterationEvaluationResult(summary="first"),
+        IterationEvaluationResult(
+            summary="first",
+            verify_result=VerifyResult(
+                passed=False,
+                commands=[VerifyCommandResult(command="pytest -q", exit_code=1, output="FAILED", passed=False)],
+            ),
+            reflection_feedback="Verification failed",
+        ),
+        IterationEvaluationResult(summary="second"),
+    ]
+    runner.stop_detector.should_stop = AsyncMock(
+        side_effect=[
+            type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": StopType.COMPLETION, "reason": "done"})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": StopType.MAX_ITERATIONS, "reason": "stop"})(),
+        ]
+    )
+
+    result = await runner.do_run()
+
+    assert result is second_response
+    assert runner._execute_task.await_count == 2
+    assert runner.evaluator.evaluate.await_args_list == [
+        call(
+            task=task,
+            iter_num=1,
+            execution_result=first_response,
+            phase="post_iteration",
+        ),
+        call(
+            task=task,
+            iter_num=1,
+            execution_result=first_response,
+            phase="before_completion",
+        ),
+        call(
+            task=task,
+            iter_num=2,
+            execution_result=second_response,
+            phase="post_iteration",
+        ),
+    ]

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -6,6 +6,7 @@ from aworld import runner as runner_module
 from aworld.core.context.amni import ApplicationContext
 from aworld.core.task import Task, TaskResponse
 from aworld.runners.ralph.config import RalphConfig, RalphVerifyConfig
+from aworld.runners.ralph.detect.types import StopType
 from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
 from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.policy import RalphLoopPolicy
@@ -263,4 +264,113 @@ async def test_ralph_runner_do_run_invokes_iteration_evaluator_after_execution(t
         task=task,
         iter_num=1,
         execution_result=response,
+        phase="post_iteration",
     )
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_do_run_skips_iteration_evaluator_when_run_on_each_iteration_is_disabled(tmp_path):
+    task = Task(
+        input="Build API",
+        conf=RalphConfig(
+            workspace=str(tmp_path),
+            verify=RalphVerifyConfig(enabled=True, commands=["pytest -q"], run_on_each_iteration=False),
+        ),
+    )
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria(max_iterations=2))
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(max_iterations=2),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    response = TaskResponse(id=task.id, answer="done", success=True)
+    runner._execute_task = AsyncMock(return_value=response)
+    runner.evaluator = AsyncMock()
+    runner.stop_detector.should_stop = AsyncMock(
+        side_effect=[
+            type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": StopType.MAX_ITERATIONS, "reason": "done"})(),
+        ]
+    )
+
+    result = await runner.do_run()
+
+    assert result is response
+    runner.evaluator.evaluate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_do_run_verifies_before_completion_when_configured(tmp_path):
+    task = Task(
+        input="Build API",
+        conf=RalphConfig(
+            workspace=str(tmp_path),
+            verify=RalphVerifyConfig(
+                enabled=True,
+                commands=["pytest -q"],
+                run_on_each_iteration=False,
+                run_before_completion=True,
+            ),
+        ),
+    )
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria(max_iterations=3))
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(max_iterations=3),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    response = TaskResponse(id=task.id, answer="done", success=True)
+    runner._execute_task = AsyncMock(return_value=response)
+    runner.evaluator = AsyncMock()
+    runner.stop_detector.should_stop = AsyncMock(
+        side_effect=[
+            type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": StopType.COMPLETION, "reason": "done"})(),
+        ]
+    )
+
+    result = await runner.do_run()
+
+    assert result is response
+    runner.evaluator.evaluate.assert_awaited_once_with(
+        task=task,
+        iter_num=1,
+        execution_result=response,
+        phase="before_completion",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_do_run_does_not_verify_before_non_completion_stop(tmp_path):
+    task = Task(
+        input="Build API",
+        conf=RalphConfig(
+            workspace=str(tmp_path),
+            verify=RalphVerifyConfig(
+                enabled=True,
+                commands=["pytest -q"],
+                run_on_each_iteration=False,
+                run_before_completion=True,
+            ),
+        ),
+    )
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria(max_iterations=2))
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(max_iterations=2),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    response = TaskResponse(id=task.id, answer="done", success=True)
+    runner._execute_task = AsyncMock(return_value=response)
+    runner.evaluator = AsyncMock()
+    runner.stop_detector.should_stop = AsyncMock(
+        side_effect=[
+            type("StopDecision", (), {"should_stop": False, "stop_type": StopType.NONE, "reason": None})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": StopType.MAX_ITERATIONS, "reason": "done"})(),
+        ]
+    )
+
+    result = await runner.do_run()
+
+    assert result is response
+    runner.evaluator.evaluate.assert_not_awaited()

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -1,5 +1,17 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aworld import runner as runner_module
+from aworld.core.context.amni import ApplicationContext
+from aworld.core.task import Task, TaskResponse
 from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
+from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.policy import RalphLoopPolicy
+from aworld.runners.ralph.state import LoopContext, LoopState
+from aworld.runners.ralph.types import CompletionCriteria
+from aworld.runners.ralph_runner import RalphRunner
 
 
 def test_ralph_config_defaults_to_reuse_context_execution_mode():
@@ -63,3 +75,98 @@ def test_ralph_config_parses_verify_from_raw_dict():
 
     assert config.verify.enabled is True
     assert config.verify.commands == ["pytest -q"]
+
+
+@pytest.mark.asyncio
+async def test_iteration_input_builder_fresh_context_includes_original_task_and_memory(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    builder = IterationInputBuilder(
+        policy=RalphLoopPolicy(execution_mode="fresh_context", verify_enabled=False),
+        memory_store=LoopMemoryStore(context),
+    )
+
+    payload = await builder.build(
+        task_id="task-1",
+        original_task="Build a REST API",
+        iteration=2,
+        previous_answer="Created app.py",
+        reflection_feedback="Add tests next",
+    )
+
+    assert payload.reuse_context is False
+    assert "Original task:" in payload.task_input
+    assert "Build a REST API" in payload.task_input
+    assert "Previous answer summary:" in payload.task_input
+    assert "Created app.py" in payload.task_input
+    assert "Add tests next" in payload.task_input
+
+
+@pytest.mark.asyncio
+async def test_iteration_input_builder_reuse_context_omits_original_task_header(tmp_path):
+    context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    builder = IterationInputBuilder(
+        policy=RalphLoopPolicy(execution_mode="reuse_context", verify_enabled=False),
+        memory_store=LoopMemoryStore(context),
+    )
+
+    payload = await builder.build(
+        task_id="task-1",
+        original_task="Build a REST API",
+        iteration=2,
+        previous_answer="Created app.py",
+        reflection_feedback="Add tests next",
+    )
+
+    assert payload.reuse_context is True
+    assert "Original task:" not in payload.task_input
+    assert "Previous answer summary:" in payload.task_input
+    assert "Created app.py" in payload.task_input
+    assert "Add tests next" in payload.task_input
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_build_iteration_context_uses_fresh_sub_context(tmp_path):
+    task = Task(input="Build API", conf=RalphConfig(execution_mode="fresh_context", workspace=str(tmp_path)))
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria())
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+
+    sub_context = ApplicationContext.create(task_id=task.id, task_content="fresh iteration")
+    runner.loop_context.build_sub_context = AsyncMock(return_value=sub_context)
+
+    iteration_input = IterationInput(task_input="fresh iteration", reuse_context=False)
+
+    context = await runner._build_iteration_context(iteration_input, task, iter_num=2)
+
+    runner.loop_context.build_sub_context.assert_awaited_once_with(
+        sub_task_content="fresh iteration",
+        sub_task_id=task.id,
+        task=task,
+    )
+    assert context.task_input == "fresh iteration"
+
+
+@pytest.mark.asyncio
+async def test_runner_ralph_run_preserves_public_api(monkeypatch):
+    task = Task(input="Build API", conf=RalphConfig())
+    response = TaskResponse(id=task.id, answer="done", success=True)
+
+    async def fake_run(self):
+        return response
+
+    monkeypatch.setattr(RalphRunner, "run", fake_run)
+
+    result = await runner_module.Runners.ralph_run(task, CompletionCriteria(max_iterations=1))
+
+    assert result is response

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -5,7 +5,7 @@ import pytest
 from aworld import runner as runner_module
 from aworld.core.context.amni import ApplicationContext
 from aworld.core.task import Task, TaskResponse
-from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.config import RalphConfig, RalphVerifyConfig
 from aworld.runners.ralph.input_builder import IterationInput, IterationInputBuilder
 from aworld.runners.ralph.memory import LoopMemoryStore
 from aworld.runners.ralph.policy import RalphLoopPolicy
@@ -229,3 +229,38 @@ async def test_runner_ralph_run_preserves_public_api(monkeypatch):
     result = await runner_module.Runners.ralph_run(task, CompletionCriteria(max_iterations=1))
 
     assert result is response
+
+
+@pytest.mark.asyncio
+async def test_ralph_runner_do_run_invokes_iteration_evaluator_after_execution(tmp_path):
+    task = Task(
+        input="Build API",
+        conf=RalphConfig(
+            workspace=str(tmp_path),
+            verify=RalphVerifyConfig(enabled=True, commands=["pytest -q"], run_on_each_iteration=True),
+        ),
+    )
+    runner = RalphRunner(task=task, completion_criteria=CompletionCriteria(max_iterations=2))
+    runner.loop_context = LoopContext(
+        completion_criteria=CompletionCriteria(max_iterations=2),
+        loop_state=LoopState(),
+        work_dir=str(tmp_path),
+    )
+    response = TaskResponse(id=task.id, answer="done", success=True)
+    runner._execute_task = AsyncMock(return_value=response)
+    runner.evaluator = AsyncMock()
+    runner.stop_detector.should_stop = AsyncMock(
+        side_effect=[
+            type("StopDecision", (), {"should_stop": False, "stop_type": None, "reason": None})(),
+            type("StopDecision", (), {"should_stop": True, "stop_type": "max_iterations", "reason": "done"})(),
+        ]
+    )
+
+    result = await runner.do_run()
+
+    assert result is response
+    runner.evaluator.evaluate.assert_awaited_once_with(
+        task=task,
+        iter_num=1,
+        execution_result=response,
+    )

--- a/tests/runners/test_ralph_runner_dual_mode.py
+++ b/tests/runners/test_ralph_runner_dual_mode.py
@@ -1,0 +1,65 @@
+from aworld.runners.ralph.config import RalphConfig
+from aworld.runners.ralph.policy import RalphLoopPolicy
+
+
+def test_ralph_config_defaults_to_reuse_context_execution_mode():
+    config = RalphConfig()
+
+    assert config.execution_mode == "reuse_context"
+    assert config.reuse_context is True
+
+
+def test_ralph_config_explicit_execution_mode_wins_and_normalizes_reuse_context():
+    config = RalphConfig(execution_mode="fresh_context")
+
+    assert config.execution_mode == "fresh_context"
+    assert config.reuse_context is False
+
+
+def test_ralph_loop_policy_maps_reuse_context_false_to_fresh_context():
+    config = RalphConfig(reuse_context=False)
+
+    policy = RalphLoopPolicy.from_config(config)
+
+    assert policy.execution_mode == "fresh_context"
+
+
+def test_ralph_config_round_trip_preserves_effective_execution_mode():
+    config = RalphConfig(reuse_context=False)
+
+    reloaded = RalphConfig.model_validate(config.model_dump())
+
+    assert reloaded.execution_mode == "fresh_context"
+    assert reloaded.reuse_context is False
+
+
+def test_ralph_config_conflicting_knobs_are_normalized_to_execution_mode():
+    config = RalphConfig(execution_mode="reuse_context", reuse_context=False)
+
+    assert config.execution_mode == "reuse_context"
+    assert config.reuse_context is True
+
+
+def test_ralph_config_assignment_updates_execution_mode_from_reuse_context():
+    config = RalphConfig()
+
+    config.reuse_context = False
+
+    assert config.execution_mode == "fresh_context"
+    assert config.reuse_context is False
+
+
+def test_ralph_config_assignment_updates_reuse_context_from_execution_mode():
+    config = RalphConfig()
+
+    config.execution_mode = "fresh_context"
+
+    assert config.execution_mode == "fresh_context"
+    assert config.reuse_context is False
+
+
+def test_ralph_config_parses_verify_from_raw_dict():
+    config = RalphConfig.model_validate({"verify": {"enabled": True, "commands": ["pytest -q"]}})
+
+    assert config.verify.enabled is True
+    assert config.verify.commands == ["pytest -q"]

--- a/tests/test_cli_user_input_hooks.py
+++ b/tests/test_cli_user_input_hooks.py
@@ -12,7 +12,22 @@ from aworld.core.context.session import Session
 from aworld.runners.hook.hook_factory import HookManager
 from aworld.runners.hook.v2 import permission
 from aworld_cli.console import AWorldCLI
+from aworld_cli.core.command_system import CommandContext, CommandRegistry
 from aworld_cli.plugin_capabilities.hooks import PluginHookResult
+from aworld_cli.plugin_capabilities.commands import register_plugin_commands
+from aworld_cli.runtime.base import BaseCliRuntime
+from aworld.plugins.discovery import discover_plugins
+
+
+def _get_builtin_ralph_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "ralph_session_loop"
+    )
 
 
 class TestCliUserInputHooks:
@@ -335,3 +350,210 @@ EOF
 
         assert should_exit is True
         assert follow_up_prompt is None
+
+    @pytest.mark.asyncio
+    async def test_apply_stop_hooks_runs_built_in_ralph_continuation_flow(self, tmp_path):
+        class DummyRuntime(BaseCliRuntime):
+            def __init__(self, plugin_dirs):
+                self.plugin_dirs = plugin_dirs
+                super().__init__(agent_name="Aworld")
+
+            async def _load_agents(self):
+                return []
+
+            async def _create_executor(self, agent):
+                return None
+
+            def _get_source_type(self):
+                return "TEST"
+
+            def _get_source_location(self):
+                return "test://ralph"
+
+        plugin = discover_plugins([_get_builtin_ralph_plugin_root()])[0]
+        runtime = DummyRuntime([_get_builtin_ralph_plugin_root()])
+
+        snapshot = CommandRegistry.snapshot()
+        try:
+            CommandRegistry.clear()
+            runtime._initialize_plugin_framework()
+            register_plugin_commands([plugin])
+
+            loop_command = CommandRegistry.get("ralph-loop")
+            assert loop_command is not None
+
+            workspace_path = str(tmp_path)
+            await loop_command.get_prompt(
+                CommandContext(
+                    cwd=workspace_path,
+                    user_args='"Build a REST API" --verify "pytest tests/api -q" --completion-promise "COMPLETE" --max-iterations 5',
+                    runtime=runtime,
+                    session_id="session-1",
+                )
+            )
+
+            cli = AWorldCLI()
+            session = Session()
+            session.session_id = "session-1"
+            context = Context(task_id="task-1", session=session)
+            context.workspace_path = workspace_path
+
+            executor_instance = MagicMock()
+            executor_instance.context = context
+            executor_instance._base_runtime = runtime
+            executor_instance.session_id = "session-1"
+
+            should_exit, follow_up_prompt = await cli._apply_stop_hooks(
+                executor_instance=executor_instance
+            )
+
+            assert should_exit is False
+            assert "Task:" in follow_up_prompt
+            assert "Verification requirements:" in follow_up_prompt
+
+            state = runtime.build_plugin_hook_state(
+                "ralph-session-loop",
+                "session",
+                executor_instance=executor_instance,
+            )
+            assert state["iteration"] == 2
+        finally:
+            CommandRegistry.restore(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_apply_stop_hooks_allows_exit_after_ralph_completion(self, tmp_path):
+        class DummyRuntime(BaseCliRuntime):
+            def __init__(self, plugin_dirs):
+                self.plugin_dirs = plugin_dirs
+                super().__init__(agent_name="Aworld")
+
+            async def _load_agents(self):
+                return []
+
+            async def _create_executor(self, agent):
+                return None
+
+            def _get_source_type(self):
+                return "TEST"
+
+            def _get_source_location(self):
+                return "test://ralph"
+
+        plugin = discover_plugins([_get_builtin_ralph_plugin_root()])[0]
+        runtime = DummyRuntime([_get_builtin_ralph_plugin_root()])
+
+        snapshot = CommandRegistry.snapshot()
+        try:
+            CommandRegistry.clear()
+            runtime._initialize_plugin_framework()
+            register_plugin_commands([plugin])
+
+            loop_command = CommandRegistry.get("ralph-loop")
+            assert loop_command is not None
+
+            workspace_path = str(tmp_path)
+            await loop_command.get_prompt(
+                CommandContext(
+                    cwd=workspace_path,
+                    user_args='"Build a REST API" --completion-promise "COMPLETE"',
+                    runtime=runtime,
+                    session_id="session-1",
+                )
+            )
+
+            cli = AWorldCLI()
+            session = Session()
+            session.session_id = "session-1"
+            context = Context(task_id="task-1", session=session)
+            context.workspace_path = workspace_path
+
+            executor_instance = MagicMock()
+            executor_instance.context = context
+            executor_instance._base_runtime = runtime
+            executor_instance.session_id = "session-1"
+
+            await runtime.run_plugin_hooks(
+                "task_completed",
+                event={"task_status": "completed", "final_answer": "<promise>COMPLETE</promise>"},
+                executor_instance=executor_instance,
+            )
+
+            should_exit, follow_up_prompt = await cli._apply_stop_hooks(
+                executor_instance=executor_instance
+            )
+
+            assert should_exit is True
+            assert follow_up_prompt is None
+        finally:
+            CommandRegistry.restore(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_apply_stop_hooks_allows_exit_after_cancel_ralph(self, tmp_path):
+        class DummyRuntime(BaseCliRuntime):
+            def __init__(self, plugin_dirs):
+                self.plugin_dirs = plugin_dirs
+                super().__init__(agent_name="Aworld")
+
+            async def _load_agents(self):
+                return []
+
+            async def _create_executor(self, agent):
+                return None
+
+            def _get_source_type(self):
+                return "TEST"
+
+            def _get_source_location(self):
+                return "test://ralph"
+
+        plugin = discover_plugins([_get_builtin_ralph_plugin_root()])[0]
+        runtime = DummyRuntime([_get_builtin_ralph_plugin_root()])
+
+        snapshot = CommandRegistry.snapshot()
+        try:
+            CommandRegistry.clear()
+            runtime._initialize_plugin_framework()
+            register_plugin_commands([plugin])
+
+            workspace_path = str(tmp_path)
+            loop_command = CommandRegistry.get("ralph-loop")
+            cancel_command = CommandRegistry.get("cancel-ralph")
+            assert loop_command is not None
+            assert cancel_command is not None
+
+            await loop_command.get_prompt(
+                CommandContext(
+                    cwd=workspace_path,
+                    user_args='"Build a REST API" --max-iterations 5',
+                    runtime=runtime,
+                    session_id="session-1",
+                )
+            )
+            await cancel_command.execute(
+                CommandContext(
+                    cwd=workspace_path,
+                    user_args="",
+                    runtime=runtime,
+                    session_id="session-1",
+                )
+            )
+
+            cli = AWorldCLI()
+            session = Session()
+            session.session_id = "session-1"
+            context = Context(task_id="task-1", session=session)
+            context.workspace_path = workspace_path
+
+            executor_instance = MagicMock()
+            executor_instance.context = context
+            executor_instance._base_runtime = runtime
+            executor_instance.session_id = "session-1"
+
+            should_exit, follow_up_prompt = await cli._apply_stop_hooks(
+                executor_instance=executor_instance
+            )
+
+            assert should_exit is True
+            assert follow_up_prompt is None
+        finally:
+            CommandRegistry.restore(snapshot)


### PR DESCRIPTION
- **feat(cli): add ralph session loop plugin**
- **docs: clarify ralph plugin and runner boundaries**
- **docs: add ralph runner dual-mode design spec**
- **test(cli): harden ralph session loop edge cases**
- **docs: add ralph runner dual-mode implementation plan**
- **feat: add explicit ralph execution mode config**
- **refactor: extract ralph loop memory store**
- **fix: restore ralph loop memory compatibility**
- **refactor: add dual-mode ralph iteration input builder**
- **fix: seed fresh ralph contexts from iteration input**
- **feat: add ralph verification pipeline**
- **fix: gate ralph verification scheduling**
- **fix: persist ralph iteration evaluation state**
- **docs: add ralph runner usage guide**
- **docs: record ralph runner implementation status**
- **docs: remove gateway naming note from main readme**
- **docs: add ralph runner example spec and plan**
- **feat: add ralph runner quick-start example**
