### PR TITLE
fix: route ACP reminder completions to active session

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/cron_bridge.py
+++ b/aworld-cli/src/aworld_cli/acp/cron_bridge.py
@@ -54,7 +54,7 @@ class AcpCronBridge:
         if not job_id:
             return
 
-        session_id = self._job_bindings.get(job_id)
+        session_id = self._resolve_session_id(job_id, notification_data)
         if not session_id or session_id not in self._session_ids:
             if notification_data.get("next_run_at") is None:
                 self._job_bindings.pop(job_id, None)
@@ -93,6 +93,42 @@ class AcpCronBridge:
         finally:
             if notification_data.get("next_run_at") is None:
                 self._job_bindings.pop(job_id, None)
+
+    def _resolve_session_id(self, job_id: str, notification_data: dict[str, Any]) -> str | None:
+        explicit_session_id = self._job_bindings.get(job_id)
+        if explicit_session_id:
+            return explicit_session_id
+
+        # Some reminder paths can produce scheduler notifications even when the
+        # ACP bridge did not observe the cron tool result that created the job.
+        # When there is exactly one live ACP session, route reminder-like terminal
+        # notifications back to that session so Happy can render the completion
+        # message instead of only receiving a push notification.
+        if len(self._session_ids) != 1:
+            return None
+        if not self._should_fallback_to_sole_session(notification_data):
+            return None
+        return next(iter(self._session_ids))
+
+    @classmethod
+    def _should_fallback_to_sole_session(cls, notification_data: dict[str, Any]) -> bool:
+        if notification_data.get("user_visible") is False:
+            return False
+        if notification_data.get("next_run_at") is not None:
+            return False
+        return cls._looks_like_reminder_notification(notification_data)
+
+    @staticmethod
+    def _looks_like_reminder_notification(notification_data: dict[str, Any]) -> bool:
+        parts = [
+            notification_data.get("job_name"),
+            notification_data.get("summary"),
+            notification_data.get("detail"),
+        ]
+        text = "\n".join(str(part) for part in parts if part is not None).strip().lower()
+        if not text:
+            return False
+        return "提醒" in text or "remind" in text or "reminder" in text
 
     @staticmethod
     def _is_cron_tool(tool_name: str | None) -> bool:

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -320,6 +320,72 @@ async def test_bound_cron_notification_is_pushed_only_to_own_session(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_unbound_terminal_reminder_notification_falls_back_to_sole_session() -> None:
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            yield MessageOutput(
+                source=ModelResponse(id="resp-1", model="demo", content="ready"),
+            )
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-unbound",
+            "job_name": "运动提醒",
+            "status": "ok",
+            "summary": 'Cron task "运动提醒" completed',
+            "detail": "提醒我运动",
+            "created_at": "2026-05-01T14:20:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert len(notifications) == 1
+    assert notifications[0]["params"]["sessionId"] == session["sessionId"]
+    assert notifications[0]["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+    assert notifications[0]["params"]["update"]["content"]["text"] == 'Cron task "运动提醒" completed\n提醒我运动'
+
+
+@pytest.mark.asyncio
+async def test_unbound_terminal_reminder_notification_does_not_guess_between_sessions() -> None:
+    server = AcpStdioServer(output_bridge=object())
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    server._handle_new_session({"cwd": ".", "mcpServers": []})
+    server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    await server._cron_bridge.publish_notification(  # type: ignore[attr-defined]
+        {
+            "job_id": "job-unbound",
+            "job_name": "运动提醒",
+            "status": "ok",
+            "summary": 'Cron task "运动提醒" completed',
+            "detail": "提醒我运动",
+            "created_at": "2026-05-01T14:20:00+00:00",
+            "next_run_at": None,
+            "user_visible": True,
+        }
+    )
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+    assert notifications == []
+
+
+@pytest.mark.asyncio
 async def test_silent_terminal_cron_notification_clears_binding_without_visible_push(monkeypatch) -> None:
     class FakeScheduler:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- route unbound terminal reminder notifications back to the sole active ACP session
- keep explicit cron job to session bindings as the primary routing path
- add ACP runtime wiring coverage for fallback and multi-session no-guess behavior

## Tests
- pytest tests/acp/test_server_runtime_wiring.py tests/acp/test_server_stdio.py tests/acp/test_event_mapper.py -q