### PR TITLE
fix: improve ACP session logging and gateway final replies

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -689,13 +689,98 @@ class AcpStdioServer:
         )
 
     async def _write_session_update(self, params: dict[str, Any]) -> None:
-        if self._session_update_method == "session/update":
+        method = self._session_update_method
+        if method == "session/update":
             params = self._to_current_session_update(params)
-        await self._write_message(self._notification(self._session_update_method, params))
+        self._log_session_update_summary(method, params)
+        await self._write_message(self._notification(method, params))
 
     @staticmethod
     def _should_emit_current_session_update(params: dict[str, Any]) -> bool:
         return True
+
+    @staticmethod
+    def _log_session_update_summary(method: str, params: dict[str, Any]) -> None:
+        update = params.get("update")
+        if not isinstance(update, dict):
+            return
+
+        summary = [f"ACP session update method={method}"]
+
+        session_id = params.get("sessionId")
+        if isinstance(session_id, str) and session_id.strip():
+            summary.append(f"session_id={session_id.strip()}")
+
+        update_type = update.get("sessionUpdate")
+        if isinstance(update_type, str) and update_type.strip():
+            summary.append(f"type={update_type.strip()}")
+
+        tool_call_id = update.get("toolCallId")
+        if isinstance(tool_call_id, str) and tool_call_id.strip():
+            summary.append(f"tool_call_id={tool_call_id.strip()}")
+
+        kind = update.get("kind")
+        if isinstance(kind, str) and kind.strip():
+            summary.append(f"kind={kind.strip()}")
+
+        title = AcpStdioServer._session_update_summary_title(update)
+        if title:
+            summary.append(f"title={title}")
+
+        status = update.get("status")
+        if isinstance(status, str) and status.strip():
+            summary.append(f"status={status.strip()}")
+
+        preview = AcpStdioServer._session_update_preview(update)
+        if preview:
+            summary.append(f"preview={preview}")
+
+        logger.info(" ".join(summary))
+
+    @staticmethod
+    def _session_update_summary_title(update: dict[str, Any]) -> str | None:
+        content = update.get("content")
+        if isinstance(content, dict):
+            tool_call = content.get("toolCall")
+            if isinstance(tool_call, dict):
+                nested_title = tool_call.get("title")
+                if isinstance(nested_title, str) and nested_title.strip():
+                    return nested_title.strip()
+
+            command_title = AcpStdioServer._command_title(content.get("command"))
+            if command_title:
+                return command_title
+
+        title = update.get("title")
+        if isinstance(title, str) and title.strip():
+            return title.strip()
+        return None
+
+    @staticmethod
+    def _session_update_preview(update: dict[str, Any]) -> str | None:
+        content = update.get("content")
+        if isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return AcpStdioServer._preview_text(text)
+            stdout = content.get("stdout")
+            if isinstance(stdout, str):
+                return AcpStdioServer._preview_text(stdout)
+            stderr = content.get("stderr")
+            if isinstance(stderr, str):
+                return AcpStdioServer._preview_text(stderr)
+        if isinstance(content, str):
+            return AcpStdioServer._preview_text(content)
+        return None
+
+    @staticmethod
+    def _preview_text(value: str, *, limit: int = 80) -> str | None:
+        normalized = " ".join(value.split())
+        if not normalized:
+            return None
+        if len(normalized) <= limit:
+            return normalized
+        return f"{normalized[: limit - 3]}..."
 
     @staticmethod
     def _to_current_session_update(params: dict[str, Any]) -> dict[str, Any]:

--- a/aworld_gateway/router.py
+++ b/aworld_gateway/router.py
@@ -116,12 +116,10 @@ class LocalCliAgentBackend:
     ) -> str:
         chunks: list[str] = []
         saw_chunk_output = False
+        task = await executor._build_task(text, session_id=session_id)
+        outputs = Runners.streamed_run_task(task=task)
 
-        async for output in self._stream_outputs(
-            executor=executor,
-            text=text,
-            session_id=session_id,
-        ):
+        async for output in outputs.stream_events():
             callback_result = on_output(output)
             if isawaitable(callback_result):
                 await callback_result
@@ -136,6 +134,9 @@ class LocalCliAgentBackend:
                 saw_chunk_output = True
             chunks.append(chunk)
 
+        final_answer = self._extract_final_task_answer(outputs)
+        if final_answer:
+            return final_answer
         return "".join(chunks).strip()
 
     async def _stream_outputs(
@@ -199,6 +200,31 @@ class LocalCliAgentBackend:
                 return source_content
 
         return ""
+
+    @staticmethod
+    def _extract_final_task_answer(outputs: Any) -> str:
+        response_getter = getattr(outputs, "response", None)
+        if not callable(response_getter):
+            return ""
+        task_response = response_getter()
+        if task_response is None:
+            return ""
+        return LocalCliAgentBackend._coerce_final_answer(
+            getattr(task_response, "answer", None)
+        )
+
+    @staticmethod
+    def _coerce_final_answer(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+
+        content = getattr(value, "content", None)
+        if isinstance(content, str):
+            return content.strip()
+
+        return str(value).strip()
 
 
 class GatewayRouter:

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -14,6 +14,7 @@ from aworld.output.base import ChunkOutput, MessageOutput, StepOutput, ToolResul
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "aworld-cli" / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from aworld_cli.acp import server as acp_server_module
 from aworld_cli.acp.server import AcpExecutorOutputBridge, AcpStdioServer
 from aworld_cli.acp.human_intercept import AcpRequiresHumanError
 from aworld_cli.acp.errors import AWORLD_ACP_APPROVAL_UNSUPPORTED
@@ -1069,6 +1070,67 @@ async def test_current_acp_protocol_emits_execute_tool_notifications() -> None:
     assert notifications[3]["params"]["update"]["status"] == "completed"
     assert notifications[3]["params"]["update"]["kind"] == "execute"
     assert notifications[3]["params"]["update"]["content"] == {"stdout": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_current_acp_protocol_logs_session_update_summary(monkeypatch) -> None:
+    class FakeOutputBridge:
+        async def stream_outputs(self, *, record, prompt_text):
+            tool_call = ToolCall(
+                id="call-1",
+                function=Function(name="shell", arguments='{"command":"pwd"}'),
+            )
+            yield MessageOutput(
+                source=ModelResponse(
+                    id="resp-2",
+                    model="demo",
+                    content="final",
+                    reasoning_content="searching sources",
+                    tool_calls=[tool_call],
+                ),
+                metadata={"sender": "Aworld", "is_finished": True},
+            )
+            yield ToolResultOutput(
+                tool_name="shell",
+                data={"cwd": "/tmp"},
+                origin_tool_call=tool_call,
+            )
+
+    server = AcpStdioServer(output_bridge=FakeOutputBridge())
+    server._session_update_method = "session/update"
+    writes: list[dict] = []
+    logged_messages: list[str] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    monkeypatch.setattr(
+        acp_server_module.logger,
+        "info",
+        lambda message, color=None, highlight_key=None: logged_messages.append(str(message)),
+    )
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    response = await server._handle_prompt(
+        6,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "hello"}]},
+        },
+    )
+
+    notifications = [message for message in writes if message.get("method") == "session/update"]
+
+    assert response["result"]["status"] == "completed"
+    assert notifications
+    assert any(
+        "ACP session update method=session/update" in message
+        and "type=tool_call" in message
+        and "kind=execute" in message
+        and "title=pwd" in message
+        for message in logged_messages
+    )
 
 
 def test_current_acp_protocol_maps_internal_and_unknown_tools_to_happy_friendly_kinds() -> None:

--- a/tests/gateway/test_router.py
+++ b/tests/gateway/test_router.py
@@ -15,6 +15,7 @@ from aworld_gateway import router as router_module
 from aworld_gateway.router import GatewayRouter, LocalCliAgentBackend
 from aworld_gateway.session_binding import SessionBinding
 from aworld_gateway.types import InboundEnvelope
+from aworld.core.task import TaskResponse
 from aworld.output.base import ToolResultOutput
 
 
@@ -485,6 +486,85 @@ def test_local_cli_backend_on_output_streams_visible_text_and_cleans_up(monkeypa
     assert seen_output_types == ["chunk", "chunk", "tool_call_result", "message", "step"]
     assert len(_StreamingExecutor.instances) == 1
     assert _StreamingExecutor.instances[0].build_calls == [("hi", "stream-session")]
+    assert _StreamingExecutor.instances[0].cleanup_called is True
+
+
+def test_local_cli_backend_on_output_prefers_final_task_answer_over_accumulated_progress(
+    monkeypatch,
+):
+    class FakeChunkOutput:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+        def output_type(self) -> str:
+            return "chunk"
+
+    class FakeMessageOutput:
+        def __init__(self, response: str) -> None:
+            self.response = response
+
+        def output_type(self) -> str:
+            return "message"
+
+    class FakeStreamingOutputs:
+        def __init__(self) -> None:
+            self._task_response = TaskResponse(
+                success=True,
+                answer="最终抓取完成。",
+                msg="ok",
+            )
+
+        async def stream_events(self):
+            yield FakeChunkOutput("先打开 X。")
+            yield FakeMessageOutput("先打开 X。")
+            yield ToolResultOutput(tool_name="bash", action_name="bash", data="opened")
+            yield FakeChunkOutput("确认已登录。")
+            yield FakeMessageOutput("确认已登录。")
+            yield FakeChunkOutput("最终抓取完成。")
+            yield FakeMessageOutput("最终抓取完成。")
+
+        def response(self):
+            return self._task_response
+
+    seen_output_types = []
+
+    async def on_output(output) -> None:
+        output_type_getter = getattr(output, "output_type", None)
+        seen_output_types.append(
+            output_type_getter() if callable(output_type_getter) else type(output).__name__
+        )
+
+    _StreamingExecutor.instances = []
+    monkeypatch.setattr(
+        router_module.Runners,
+        "streamed_run_task",
+        lambda *, task: FakeStreamingOutputs(),
+    )
+    backend = LocalCliAgentBackend(
+        registry_cls=_SimpleRegistry,
+        executor_cls=_StreamingExecutor,
+    )
+
+    result = asyncio.run(
+        backend.run(
+            agent_id="aworld",
+            session_id="stream-session",
+            text="hi",
+            on_output=on_output,
+        )
+    )
+
+    assert result == "最终抓取完成。"
+    assert seen_output_types == [
+        "chunk",
+        "message",
+        "tool_call_result",
+        "chunk",
+        "message",
+        "chunk",
+        "message",
+    ]
+    assert len(_StreamingExecutor.instances) == 1
     assert _StreamingExecutor.instances[0].cleanup_called is True
 
 


### PR DESCRIPTION
## Summary
- add ACP session/update summary logging so Happy-side rendering issues can be diagnosed from logs
- preserve Happy-friendly ACP tool kind/title mapping visibility in logs
- prefer final TaskResponse.answer for gateway replies instead of concatenated intermediate progress text
- add regression coverage for both ACP logging and gateway final reply behavior

## Testing
- pytest tests/acp/test_server_runtime_wiring.py -q
- pytest tests/acp/test_runtime_adapter.py tests/acp/test_server_runtime_wiring.py tests/acp/test_server_stdio.py -q
- pytest tests/gateway/test_router.py tests/gateway/test_wechat_connector.py -q