### PR TITLE
fix: stop text fallback for ACP tool updates

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -694,54 +694,10 @@ class AcpStdioServer:
             params = self._to_current_session_update(params)
         self._log_session_update_summary(method, params)
         await self._write_message(self._notification(method, params))
-        fallback_params = self._current_tool_text_fallback(params) if method == "session/update" else None
-        if fallback_params is not None:
-            self._log_session_update_summary(method, fallback_params)
-            await self._write_message(self._notification(method, fallback_params))
 
     @staticmethod
     def _should_emit_current_session_update(params: dict[str, Any]) -> bool:
         return True
-
-    @staticmethod
-    def _current_tool_text_fallback(params: dict[str, Any]) -> dict[str, Any] | None:
-        update = params.get("update")
-        if not isinstance(update, dict):
-            return None
-
-        update_type = update.get("sessionUpdate")
-        if update_type not in {"tool_call", "tool_call_update"}:
-            return None
-        if update.get("kind") == "step":
-            return None
-
-        title = AcpStdioServer._session_update_summary_title(update)
-        if not title:
-            title = update.get("title")
-        if not isinstance(title, str) or not title.strip():
-            title = None
-        if not title:
-            kind = update.get("kind")
-            title = str(kind).strip() if isinstance(kind, str) and kind.strip() else "tool"
-
-        if update_type == "tool_call":
-            text = f"\n\nTool call: {title.strip()}\n"
-        else:
-            status = update.get("status")
-            status_text = str(status).strip() if isinstance(status, str) and status.strip() else "completed"
-            preview = AcpStdioServer._session_update_preview(update)
-            if preview:
-                text = f"\n\nTool result ({status_text}): {title.strip()} -> {preview}\n"
-            else:
-                text = f"\n\nTool result ({status_text}): {title.strip()}\n"
-
-        return {
-            "sessionId": params.get("sessionId"),
-            "update": {
-                "sessionUpdate": "agent_message_chunk",
-                "content": {"type": "text", "text": text},
-            },
-        }
 
     @staticmethod
     def _log_session_update_summary(method: str, params: dict[str, Any]) -> None:

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -921,11 +921,9 @@ async def test_current_acp_protocol_emits_shell_tool_notifications() -> None:
     assert response["result"]["status"] == "completed"
     assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
         "tool_call",
-        "agent_message_chunk",
         "agent_thought_chunk",
         "agent_message_chunk",
         "tool_call_update",
-        "agent_message_chunk",
     ]
     assert notifications[0]["params"]["update"]["toolCallId"] == "call-1"
     assert notifications[0]["params"]["update"]["kind"] == "execute"
@@ -933,14 +931,10 @@ async def test_current_acp_protocol_emits_shell_tool_notifications() -> None:
         "command": "pwd",
         "toolCall": {"title": "pwd"},
     }
-    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "\n\nTool call: pwd\n"}
-    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "searching sources"}
-    assert notifications[3]["params"]["update"]["content"] == {"type": "text", "text": "final"}
-    assert notifications[4]["params"]["update"]["status"] == "completed"
-    assert notifications[5]["params"]["update"]["content"] == {
-        "type": "text",
-        "text": "\n\nTool result (completed): shell\n",
-    }
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "searching sources"}
+    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+    assert notifications[3]["params"]["update"]["status"] == "completed"
+    assert notifications[3]["params"]["update"]["content"] == {"cwd": "/tmp"}
 
 
 @pytest.mark.asyncio
@@ -993,11 +987,9 @@ async def test_current_acp_protocol_emits_other_tool_notifications() -> None:
     assert response["result"]["status"] == "completed"
     assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
         "tool_call",
-        "agent_message_chunk",
         "agent_thought_chunk",
         "agent_message_chunk",
         "tool_call_update",
-        "agent_message_chunk",
     ]
     assert notifications[0]["params"]["update"]["toolCallId"] == "call-1"
     assert notifications[0]["params"]["update"]["kind"] == "Agent"
@@ -1010,19 +1002,11 @@ async def test_current_acp_protocol_emits_other_tool_notifications() -> None:
             {"type": "text", "text": "web_searcher"},
         ]
     }
-    assert notifications[1]["params"]["update"]["content"] == {
-        "type": "text",
-        "text": "\n\nTool call: async_spawn_subagent__spawn\n",
-    }
-    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "我先尝试搜索一下最新信息"}
-    assert notifications[3]["params"]["update"]["content"] == {"type": "text", "text": "final"}
-    assert notifications[4]["params"]["update"]["status"] == "completed"
-    assert notifications[4]["params"]["update"]["kind"] == "Agent"
-    assert notifications[4]["params"]["update"]["content"] == {"error": "subagent unavailable"}
-    assert notifications[5]["params"]["update"]["content"] == {
-        "type": "text",
-        "text": "\n\nTool result (completed): async_spawn_subagent__spawn\n",
-    }
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "我先尝试搜索一下最新信息"}
+    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+    assert notifications[3]["params"]["update"]["status"] == "completed"
+    assert notifications[3]["params"]["update"]["kind"] == "Agent"
+    assert notifications[3]["params"]["update"]["content"] == {"error": "subagent unavailable"}
 
 
 @pytest.mark.asyncio
@@ -1072,11 +1056,9 @@ async def test_current_acp_protocol_emits_execute_tool_notifications() -> None:
     assert response["result"]["status"] == "completed"
     assert [item["params"]["update"]["sessionUpdate"] for item in notifications] == [
         "tool_call",
-        "agent_message_chunk",
         "agent_thought_chunk",
         "agent_message_chunk",
         "tool_call_update",
-        "agent_message_chunk",
     ]
     assert notifications[0]["params"]["update"]["toolCallId"] == "call-1"
     assert notifications[0]["params"]["update"]["kind"] == "execute"
@@ -1084,19 +1066,11 @@ async def test_current_acp_protocol_emits_execute_tool_notifications() -> None:
         "command": "curl https://x.com",
         "toolCall": {"title": "curl https://x.com"},
     }
-    assert notifications[1]["params"]["update"]["content"] == {
-        "type": "text",
-        "text": "\n\nTool call: curl https://x.com\n",
-    }
-    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "我先检查一下页面"}
-    assert notifications[3]["params"]["update"]["content"] == {"type": "text", "text": "final"}
-    assert notifications[4]["params"]["update"]["status"] == "completed"
-    assert notifications[5]["params"]["update"]["content"] == {
-        "type": "text",
-        "text": "\n\nTool result (completed): execute -> ok\n",
-    }
-    assert notifications[4]["params"]["update"]["kind"] == "execute"
-    assert notifications[4]["params"]["update"]["content"] == {"stdout": "ok"}
+    assert notifications[1]["params"]["update"]["content"] == {"type": "text", "text": "我先检查一下页面"}
+    assert notifications[2]["params"]["update"]["content"] == {"type": "text", "text": "final"}
+    assert notifications[3]["params"]["update"]["status"] == "completed"
+    assert notifications[3]["params"]["update"]["kind"] == "execute"
+    assert notifications[3]["params"]["update"]["content"] == {"stdout": "ok"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop sending extra agent_message_chunk text fallbacks for ACP tool_call and tool_call_update events
- keep structured ACP tool updates so Happy can render tool calls with its native tool UI instead of plain `Tool call:` text
- update ACP wiring regression tests to lock the current protocol behavior

## Testing
- pytest tests/acp/test_server_runtime_wiring.py -q
- pytest tests/acp/test_runtime_adapter.py tests/acp/test_server_runtime_wiring.py tests/acp/test_server_stdio.py -q