### PR TITLE
fix: avoid empty assistant content in tool-call replays

### DIFF
--- a/aworld/memory/models.py
+++ b/aworld/memory/models.py
@@ -478,10 +478,16 @@ class MemoryAIMessage(MemoryMessage):
         def to_text_part(text: str) -> dict:
             return {"type": "text", "text": text}
 
+        def drop_empty_text_parts(parts: list[dict]) -> list[dict]:
+            return [
+                part for part in parts
+                if not (part.get("type") == "text" and part.get("text") == "")
+            ]
+
         if content is None:
             return []
         if isinstance(content, str):
-            return [to_text_part(content)]
+            return [] if content == "" else [to_text_part(content)]
         if isinstance(content, list):
             parts = []
             for item in content:
@@ -489,12 +495,12 @@ class MemoryAIMessage(MemoryMessage):
                     parts.append(item)
                 else:
                     parts.append(to_text_part(str(item)))
-            return parts
+            return drop_empty_text_parts(parts)
         if isinstance(content, dict):
             if content.get("type") == "text" and isinstance(content.get("text"), str):
-                return [content]
-            return [to_text_part(str(content))]
-        return [to_text_part(str(content))]
+                return [] if content.get("text") == "" else [content]
+            return drop_empty_text_parts([to_text_part(str(content))])
+        return drop_empty_text_parts([to_text_part(str(content))])
 
     @staticmethod
     def _normalize_reasoning_details(reasoning_details: Any) -> Optional[list[dict]]:

--- a/aworld/models/openai_message_sanitizer.py
+++ b/aworld/models/openai_message_sanitizer.py
@@ -45,13 +45,21 @@ def _normalize_content_part(item: Any) -> dict[str, str]:
 
 
 def _normalize_assistant_content(value: Any, *, has_tool_calls: bool) -> Any:
+    def drop_empty_text_parts(parts: list[dict[str, str]]) -> list[dict[str, str]]:
+        return [
+            part for part in parts
+            if not (part.get("type") == "text" and part.get("text") == "")
+        ]
+
     if not has_tool_calls:
         return value
     if value is None:
         return []
     if isinstance(value, list):
-        return [_normalize_content_part(item) for item in value]
-    return [_normalize_content_part(value)]
+        return drop_empty_text_parts([_normalize_content_part(item) for item in value])
+    if value == "":
+        return []
+    return drop_empty_text_parts([_normalize_content_part(value)])
 
 
 def _normalize_tool_content(value: Any) -> list[dict[str, str]]:

--- a/tests/memory/test_ai_message_serialization.py
+++ b/tests/memory/test_ai_message_serialization.py
@@ -35,6 +35,34 @@ def test_memory_ai_message_with_tool_calls_serializes_string_content_as_text_par
     assert openai_message["tool_calls"][0]["function"]["name"] == "bash"
 
 
+def test_memory_ai_message_with_tool_calls_omits_empty_string_content_parts():
+    message = MemoryAIMessage(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="toolu_test_empty_content",
+                type="function",
+                function={
+                    "name": "bash",
+                    "arguments": "{\"command\":\"echo hi\"}",
+                },
+            )
+        ],
+        metadata=MessageMetadata(
+            agent_id="agent-1",
+            agent_name="Aworld",
+            session_id="session-1",
+            task_id="task-1",
+            user_id="user-1",
+        ),
+    )
+
+    openai_message = message.to_openai_message()
+
+    assert openai_message["content"] == []
+    assert openai_message["tool_calls"][0]["function"]["name"] == "bash"
+
+
 def test_memory_ai_message_without_tool_calls_keeps_plain_string_content():
     message = MemoryAIMessage(
         content="Normal assistant reply.",

--- a/tests/models/test_openai_provider_preprocess.py
+++ b/tests/models/test_openai_provider_preprocess.py
@@ -72,6 +72,27 @@ def test_openai_provider_preprocess_drops_string_none_tool_calls():
     assert processed[0]["content"] == "Plain assistant reply."
 
 
+def test_openai_provider_preprocess_omits_empty_text_parts_for_tool_call_messages():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{\"command\":\"echo hi\"}"},
+                }
+            ],
+        },
+    ]
+
+    processed = sanitize_openai_messages(messages)
+
+    assert processed[0]["content"] == []
+    assert processed[0]["tool_calls"][0]["function"]["name"] == "bash"
+
+
 def test_openai_provider_preprocess_sanitizes_malformed_tool_call_arguments():
     messages = [
         {


### PR DESCRIPTION
## Summary
- omit empty assistant text parts when replaying assistant messages with tool calls
- sanitize OpenAI-format messages so tool-call turns no longer serialize to `[{"type":"text","text":""}]`
- add regression tests for memory serialization and provider preprocess behavior

## Test Plan
- `pytest -q tests/memory/test_ai_message_serialization.py tests/models/test_openai_provider_preprocess.py tests/core/agent/test_tool_result_followup_format.py tests/memory/test_tool_message_serialization.py`
