### PR TITLE
feat: add steering support across gateway channels and ACP

### DIFF
--- a/aworld_gateway/channels/wechat/connector.py
+++ b/aworld_gateway/channels/wechat/connector.py
@@ -41,6 +41,7 @@ from aworld_gateway.channels.wechat.media import (
 from aworld_gateway.config import WechatChannelConfig
 from aworld_gateway.cron_push import CronPushBindingStore, CronPushBridge
 from aworld_gateway.logging import get_gateway_logger
+from aworld_gateway.router import SESSION_BINDING_CONVERSATION_ID_METADATA_KEY
 from aworld_gateway.types import InboundEnvelope
 from aworld_cli.core.command_bridge import CommandBridge
 
@@ -65,6 +66,8 @@ EP_GET_UPLOAD_URL = "ilink/bot/getuploadurl"
 DEDUP_MAX_SIZE = 1000
 LOG_TEXT_TRUNCATE_LIMIT = 300
 POLL_RETRY_DELAY_SECONDS = 2.0
+NEW_SESSION_COMMANDS = {"/new", "/summary", "新会话", "压缩上下文"}
+NEW_SESSION_CONFIRMATION_TEXT = "✨ 已开启新会话，之前的上下文已清空。"
 
 SendMessageFunc = Callable[..., Awaitable[dict[str, object]]]
 GetUpdatesFunc = Callable[..., Awaitable[dict[str, object]]]
@@ -363,6 +366,7 @@ class WechatConnector:
         self._poll_task: asyncio.Task[None] | None = None
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._conversation_tails: dict[str, asyncio.Future[None]] = {}
+        self._session_binding_conversation_ids: dict[str, str] = {}
         self._account_id = ""
         self._token = ""
         self._base_url = DEFAULT_BASE_URL
@@ -729,6 +733,20 @@ class WechatConnector:
 
         item_list = message.get("item_list") or []
         text = self._extract_text(item_list)
+        if text.lower() in {command.lower() for command in NEW_SESSION_COMMANDS}:
+            self._rotate_session_binding_conversation_id(
+                conversation_type=conversation_type,
+                conversation_id=conversation_id,
+            )
+            self._clear_context_tokens_for_reset(
+                conversation_id=conversation_id,
+                sender_id=sender_id,
+            )
+            await self.send_text(
+                chat_id=conversation_id,
+                text=NEW_SESSION_CONFIRMATION_TEXT,
+            )
+            return
 
         inbound_media = await self._collect_inbound_attachments(
             message_id=message_id or f"wx-{uuid.uuid4().hex}",
@@ -766,6 +784,16 @@ class WechatConnector:
             metadata["attachments"] = attachments
             metadata["wechat_media"] = inbound_media["wechat_media"]
             metadata["multimodal_parts"] = inbound_media["multimodal_parts"]
+        session_binding_conversation_id = self._session_binding_conversation_ids.get(
+            self._session_binding_key(
+                conversation_type=conversation_type,
+                conversation_id=conversation_id,
+            )
+        )
+        if session_binding_conversation_id:
+            metadata[SESSION_BINDING_CONVERSATION_ID_METADATA_KEY] = (
+                session_binding_conversation_id
+            )
 
         async def on_output(output) -> None:
             self._cron_push_bridge.bind_output(
@@ -975,6 +1003,41 @@ class WechatConnector:
             if text:
                 texts.append(text)
         return "\n".join(texts)
+
+    @staticmethod
+    def _session_binding_key(*, conversation_type: str, conversation_id: str) -> str:
+        return f"{conversation_type}:{conversation_id}"
+
+    def _rotate_session_binding_conversation_id(
+        self,
+        *,
+        conversation_type: str,
+        conversation_id: str,
+    ) -> str:
+        session_binding_conversation_id = (
+            f"{conversation_id}:session:{uuid.uuid4().hex}"
+        )
+        self._session_binding_conversation_ids[
+            self._session_binding_key(
+                conversation_type=conversation_type,
+                conversation_id=conversation_id,
+            )
+        ] = session_binding_conversation_id
+        logger.info(
+            "WeChat session reset requested "
+            f"conversation={conversation_id} session_binding={session_binding_conversation_id}"
+        )
+        return session_binding_conversation_id
+
+    def _clear_context_tokens_for_reset(
+        self,
+        *,
+        conversation_id: str,
+        sender_id: str,
+    ) -> None:
+        self._token_store.delete(self._account_id, sender_id)
+        if conversation_id != sender_id:
+            self._token_store.delete(self._account_id, conversation_id)
 
     @staticmethod
     def _optional_env(name: str | None) -> str:

--- a/aworld_gateway/channels/wechat/context_token_store.py
+++ b/aworld_gateway/channels/wechat/context_token_store.py
@@ -37,6 +37,11 @@ class ContextTokenStore:
         self._cache[self._key(account_id, peer_id)] = token
         self._persist(account_id)
 
+    def delete(self, account_id: str, peer_id: str) -> None:
+        removed = self._cache.pop(self._key(account_id, peer_id), None)
+        if removed is not None:
+            self._persist(account_id)
+
     def _persist(self, account_id: str) -> None:
         self._root.mkdir(parents=True, exist_ok=True)
         prefix = f"{account_id}:"

--- a/aworld_gateway/router.py
+++ b/aworld_gateway/router.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover
 
 
 logger = get_gateway_logger("router")
+SESSION_BINDING_CONVERSATION_ID_METADATA_KEY = "session_binding_conversation_id"
 
 
 class AgentBackend(Protocol):
@@ -439,12 +440,16 @@ class GatewayRouter:
             channel_default_agent_id=channel_default_agent_id,
             matched_route_agent_id=matched_route_agent_id,
         )
+        session_binding_conversation_id = inbound.conversation_id
+        metadata_override = inbound.metadata.get(SESSION_BINDING_CONVERSATION_ID_METADATA_KEY)
+        if isinstance(metadata_override, str) and metadata_override.strip():
+            session_binding_conversation_id = metadata_override.strip()
         session_id = self._session_binding.build(
             agent_id=resolved_agent_id,
             channel=inbound.channel,
             account_id=inbound.account_id,
             conversation_type=inbound.conversation_type,
-            conversation_id=inbound.conversation_id,
+            conversation_id=session_binding_conversation_id,
         )
         logger.info(
             "Gateway router resolved "
@@ -508,13 +513,15 @@ class GatewayRouter:
             )
             raise
 
+        outbound_metadata = dict(inbound.metadata)
+        outbound_metadata.pop(SESSION_BINDING_CONVERSATION_ID_METADATA_KEY, None)
         outbound = OutboundEnvelope(
             channel=inbound.channel,
             account_id=inbound.account_id,
             conversation_id=inbound.conversation_id,
             reply_to_message_id=inbound.message_id,
             text=response_text,
-            metadata=dict(inbound.metadata),
+            metadata=outbound_metadata,
         )
         logger.info(
             "Gateway router outbound "

--- a/tests/gateway/test_router.py
+++ b/tests/gateway/test_router.py
@@ -117,6 +117,44 @@ def test_handle_inbound_resolves_agent_builds_session_and_routes_execution():
     assert outbound.text == "backend reply"
 
 
+def test_handle_inbound_uses_session_binding_conversation_override_from_metadata():
+    backend = FakeAgentBackend()
+    router = GatewayRouter(
+        session_binding=SessionBinding(),
+        agent_resolver=AgentResolver(default_agent_id="aworld"),
+        agent_backend=backend,
+    )
+    inbound = InboundEnvelope(
+        channel="wechat",
+        account_id="acct-override",
+        conversation_id="conv-visible",
+        conversation_type="dm",
+        sender_id="sender-override",
+        sender_name="Sender",
+        message_id="msg-override",
+        text="hello after reset",
+        metadata={"session_binding_conversation_id": "conv-reset-2"},
+    )
+
+    outbound = asyncio.run(
+        router.handle_inbound(
+            inbound,
+            channel_default_agent_id="channel-agent",
+        )
+    )
+
+    assert backend.calls == [
+        {
+            "agent_id": "channel-agent",
+            "session_id": "gw:channel-agent:wechat:acct-override:dm:conv-reset-2",
+            "text": "hello after reset",
+        }
+    ]
+    assert outbound.conversation_id == "conv-visible"
+    assert outbound.reply_to_message_id == "msg-override"
+    assert outbound.metadata == {}
+
+
 def test_handle_inbound_prefers_explicit_agent_id_over_other_sources():
     backend = FakeAgentBackend()
     router = GatewayRouter(

--- a/tests/gateway/test_wechat_connector.py
+++ b/tests/gateway/test_wechat_connector.py
@@ -181,6 +181,78 @@ async def test_connector_process_message_routes_slash_command_through_router(
 
 
 @pytest.mark.asyncio
+async def test_connector_process_message_reset_command_rotates_session_and_sends_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(
+        config=cfg,
+        router=router,
+        storage_root=tmp_path,
+    )
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+    connector._token_store.set("wx-account", "user-1", "ctx-old")
+
+    await connector._process_message(
+        {
+            "message_id": "m-new-1",
+            "from_user_id": "user-1",
+            "context_token": "ctx-new",
+            "item_list": [{"type": 1, "text_item": {"text": "/new"}}],
+        }
+    )
+    first_session_binding = connector._session_binding_conversation_ids["dm:user-1"]
+
+    await connector._process_message(
+        {
+            "message_id": "m-new-2",
+            "from_user_id": "user-1",
+            "context_token": "ctx-newer",
+            "item_list": [{"type": 1, "text_item": {"text": "/new"}}],
+        }
+    )
+    second_session_binding = connector._session_binding_conversation_ids["dm:user-1"]
+
+    await connector._process_message(
+        {
+            "message_id": "m-after-new",
+            "from_user_id": "user-1",
+            "item_list": [{"type": 1, "text_item": {"text": "hello again"}}],
+        }
+    )
+
+    inbound, channel_default_agent_id, on_output = router.calls[0]
+    assert sent == [
+        ("user-1", "✨ 已开启新会话，之前的上下文已清空。", None),
+        ("user-1", "✨ 已开启新会话，之前的上下文已清空。", None),
+        ("user-1", "echo:hello again", {}),
+    ]
+    assert first_session_binding != second_session_binding
+    assert connector._token_store.get("wx-account", "user-1") is None
+    assert len(router.calls) == 1
+    assert inbound.text == "hello again"
+    assert inbound.metadata["session_binding_conversation_id"] == second_session_binding
+    assert channel_default_agent_id == "aworld"
+    assert callable(on_output)
+    await connector.stop()
+
+
+@pytest.mark.asyncio
 async def test_connector_serializes_same_conversation_messages_in_poll_batch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add steering support across gateway channels and ACP, including checkpoint pause and interrupt handling
- harden channel execution flow with serialized per-session processing and empty tool-call replay fixes
- support WeChat `/new` session reset by rotating session binding and clearing stored context tokens

## Test Plan
- [x] `pytest -q tests/gateway/test_router.py tests/gateway/test_wechat_connector.py`
- [ ] Manual verification for gateway/channel steering flows
