### PR TITLE
feat: enable natural auto steering and harden follow-up flow

### DIFF
--- a/aworld-cli/src/aworld_cli/acp/executor.py
+++ b/aworld-cli/src/aworld_cli/acp/executor.py
@@ -34,13 +34,21 @@ class AcpLocalExecutor(LocalAgentExecutor):
         if env_config is not None:
             env_config.working_dir_base_path = str(self._workspace_base_dir())
 
-    async def _build_task(self, task_content: str, session_id: str = None, task_id: str = None, image_urls=None):
+    async def _build_task(
+        self,
+        task_content: str,
+        session_id: str = None,
+        task_id: str = None,
+        image_urls=None,
+        origin_user_input=None,
+    ):
         self._ensure_context_working_dir_config()
         return await super()._build_task(
             task_content,
             session_id=session_id,
             task_id=task_id,
             image_urls=image_urls,
+            origin_user_input=origin_user_input,
         )
 
     async def _create_workspace(self, session_id: str):

--- a/aworld-cli/src/aworld_cli/acp/server.py
+++ b/aworld-cli/src/aworld_cli/acp/server.py
@@ -594,14 +594,7 @@ class AcpStdioServer:
             and self._turns.has_active_turn(session_id)
             and hasattr(self._output_bridge, "queue_steering")
         ):
-            ack_text = self._output_bridge.queue_steering(record=record, text=prompt_text)
-            await self._write_session_update_for_session(
-                session_id,
-                {
-                    "sessionUpdate": "agent_message_chunk",
-                    "content": {"text": ack_text},
-                },
-            )
+            self._output_bridge.queue_steering(record=record, text=prompt_text)
             return self._response(request_id, {"status": "queued"})
 
         async def _run_streaming_prompt(
@@ -708,16 +701,9 @@ class AcpStdioServer:
                     task = await self._turns.start_turn(session_id, _run_turn())
             except AcpBusyError:
                 if hasattr(self._output_bridge, "queue_steering"):
-                    ack_text = self._output_bridge.queue_steering(
+                    self._output_bridge.queue_steering(
                         record=record,
                         text=executed_prompt_text,
-                    )
-                    await self._write_session_update_for_session(
-                        session_id,
-                        {
-                            "sessionUpdate": "agent_message_chunk",
-                            "content": {"text": ack_text},
-                        },
                     )
                     return self._response(request_id, {"status": "queued"})
                 return self._error(

--- a/aworld-cli/src/aworld_cli/acp/validation.py
+++ b/aworld-cli/src/aworld_cli/acp/validation.py
@@ -7,9 +7,6 @@ from typing import Any, Protocol
 
 from .errors import AWORLD_ACP_SESSION_BUSY
 from .stdio_harness import AcpStdioHarness
-from ..steering import STEERING_CAPTURED_ACK
-
-
 REQUIRED_PHASE1_CASE_IDS = (
     "initialize_handshake",
     "new_session_usable",
@@ -465,24 +462,36 @@ async def run_phase1_validation_cases(
             }
         )
         seen_by_id = await harness.read_responses({7, 8, 9})
-        busy_session_update = await harness.read_notification("sessionUpdate")
-
-        cases.append(
-            {
-                "id": "prompt_busy_queued",
-                "ok": (
-                    seen_by_id[8].get("result", {}).get("status") == "queued"
-                    and busy_session_update.get("params", {}).get("update", {}).get("sessionUpdate")
-                    == "agent_message_chunk"
-                    and busy_session_update.get("params", {}).get("update", {}).get("content", {}).get("text")
-                    == STEERING_CAPTURED_ACK
-                ),
-                "detail": {
-                    "response": seen_by_id[8],
-                    "update": busy_session_update,
-                },
-            }
-        )
+        try:
+            busy_session_update = await harness.read_notification(
+                "sessionUpdate",
+                timeout_seconds=0.1,
+            )
+        except RuntimeError as exc:
+            cases.append(
+                {
+                    "id": "prompt_busy_queued",
+                    "ok": (
+                        seen_by_id[8].get("result", {}).get("status") == "queued"
+                        and "timed out waiting for a JSON line" in str(exc)
+                    ),
+                    "detail": {
+                        "response": seen_by_id[8],
+                        "update": None,
+                    },
+                }
+            )
+        else:
+            cases.append(
+                {
+                    "id": "prompt_busy_queued",
+                    "ok": False,
+                    "detail": {
+                        "response": seen_by_id[8],
+                        "unexpected_update": busy_session_update,
+                    },
+                }
+            )
         cases.append(
             {
                 "id": "cancel_active_terminal",

--- a/aworld-cli/src/aworld_cli/executors/local.py
+++ b/aworld-cli/src/aworld_cli/executors/local.py
@@ -691,6 +691,7 @@ class LocalAgentExecutor(BaseAgentExecutor):
         task_id: str = None,
         image_urls: Optional[List[str]] = None,
         requested_skill_names: Optional[List[str]] = None,
+        origin_user_input: Any = None,
     ) -> Task:
         """
         Build task from task content.
@@ -718,7 +719,7 @@ class LocalAgentExecutor(BaseAgentExecutor):
             task_id = f"task_{datetime.now().strftime('%Y%m%d%H%M%S')}"
         
         # 🔥 Hook: PRE_INPUT_PARSE
-        original_task_content = task_content
+        original_task_content = task_content if origin_user_input is None else origin_user_input
         hook_kwargs = {
             'user_message': task_content,
             'task_content': task_content,

--- a/aworld-cli/src/aworld_cli/steering/coordinator.py
+++ b/aworld-cli/src/aworld_cli/steering/coordinator.py
@@ -25,6 +25,7 @@ class SteeringSessionState:
     steerable: bool = False
     interrupt_requested: bool = False
     next_sequence: int = 1
+    applied_inputs: list[SteeringInput] = field(default_factory=list)
     pending_inputs: list[SteeringInput] = field(default_factory=list)
 
 
@@ -36,6 +37,8 @@ class SteeringCoordinator:
     def begin_task(self, session_id: str, task_id: str, *, steerable: bool = True) -> None:
         with self._lock:
             state = self._sessions.setdefault(session_id, SteeringSessionState())
+            if state.active_task_id is None:
+                state.applied_inputs.clear()
             state.active_task_id = task_id
             state.steerable = steerable
             state.interrupt_requested = False
@@ -74,6 +77,7 @@ class SteeringCoordinator:
             state.steerable = False
             state.interrupt_requested = False
             if clear_pending:
+                state.applied_inputs.clear()
                 state.pending_inputs.clear()
 
     def snapshot(self, session_id: str) -> dict[str, object]:
@@ -106,6 +110,9 @@ class SteeringCoordinator:
 
             drained = list(state.pending_inputs)
             state.pending_inputs.clear()
+            if drained:
+                state.applied_inputs.extend(drained)
+            applied = list(state.applied_inputs)
             interrupt_requested = state.interrupt_requested
             state.interrupt_requested = False
 
@@ -123,10 +130,10 @@ class SteeringCoordinator:
             if drained:
                 lines.append("")
 
-        for index, item in enumerate(drained, start=1):
+        for index, item in enumerate(applied, start=1):
             lines.append(f"{index}. {item.text}")
 
-        return "\n".join(lines).strip(), drained, interrupt_requested
+        return "\n".join(lines).strip(), applied, interrupt_requested
 
     def consume_terminal_fallback_prompt(self, session_id: str) -> str | None:
         prompt, _drained, _interrupt_requested = self.consume_terminal_fallback(session_id)

--- a/aworld/runners/callback/tool.py
+++ b/aworld/runners/callback/tool.py
@@ -13,6 +13,8 @@ class ToolCallbackHandler(DefaultHandler):
         self.runner = runner
 
     async def handle(self, message):
+        if False:
+            yield None
         if message.category != Constants.TOOL_CALLBACK:
             return
         logger.info(f"-------ToolCallbackHandler start handle message----: {message}")
@@ -70,15 +72,6 @@ class ToolCallbackHandler(DefaultHandler):
             # todo
             logger.warning(f"ToolCallbackHandler Failed to parse payload: {e}")
             state_mng.run_failed(message.id, "callback failed", [])
-        finally:
-            yield Message(
-                category=Constants.OUTPUT,
-                payload=None,
-                sender=self.name(),
-                session_id=message.session_id,
-                headers={"context": self.context}
-            )
 
         return
-
 

--- a/aworld/runners/callback/tool.py
+++ b/aworld/runners/callback/tool.py
@@ -13,8 +13,6 @@ class ToolCallbackHandler(DefaultHandler):
         self.runner = runner
 
     async def handle(self, message):
-        if False:
-            yield None
         if message.category != Constants.TOOL_CALLBACK:
             return
         logger.info(f"-------ToolCallbackHandler start handle message----: {message}")
@@ -32,7 +30,7 @@ class ToolCallbackHandler(DefaultHandler):
             if isinstance(payload, CallbackItem):
                 observation = payload.data[0] if isinstance(payload.data, Tuple) else payload.data
             elif isinstance(payload, Tuple) and isinstance(payload[0], Observation):
-                observation=payload[0]
+                observation = payload[0]
             if not isinstance(observation, Observation):
                 state_mng.run_failed(message.id, "callback failed", [])
                 return
@@ -42,7 +40,6 @@ class ToolCallbackHandler(DefaultHandler):
 
             results = []
             for res in observation.action_result:
-                success = False
                 result = HandleResult(
                     result=Message(payload=None,
                                    category=Constants.TOOL_CALLBACK,
@@ -74,4 +71,3 @@ class ToolCallbackHandler(DefaultHandler):
             state_mng.run_failed(message.id, "callback failed", [])
 
         return
-

--- a/aworld/runners/event_runner.py
+++ b/aworld/runners/event_runner.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 inclusionAI.
 import asyncio
 import copy
+import inspect
 import json
 import time
 import traceback
@@ -592,7 +593,14 @@ class TaskEventRunner(TaskRunner):
                 if await self.should_stop_task(result):
                     await self.stop()
                     return
-                async for event in handler.handle(result):
+                handler_result = handler.handle(result)
+                if inspect.isasyncgen(handler_result):
+                    async for event in handler_result:
+                        yield event
+                    continue
+
+                event = await handler_result
+                if event:
                     yield event
 
     async def _update_trajectory(self, message: Message):

--- a/aworld/runners/event_runner.py
+++ b/aworld/runners/event_runner.py
@@ -394,6 +394,12 @@ class TaskEventRunner(TaskRunner):
                 handler_instance = HandlerFactory(handler, runner=self)
                 self.handlers.append(handler_instance)
 
+        # Tool callbacks are resolved through the inner handler pipeline rather than
+        # event-bus topic subscriptions, so wire the callback handler explicitly.
+        from aworld.runners.callback.tool import ToolCallbackHandler
+        if not any(isinstance(handler, ToolCallbackHandler) for handler in self.handlers):
+            self.handlers.append(ToolCallbackHandler(self))
+
         self.task_flag = "sub" if self.task.is_sub_task else "main"
         self.inited = True
         logger.debug(f"{self.task_flag} task: {self.task.id} pre run finish, will start to run...")

--- a/aworld/runners/handler/task.py
+++ b/aworld/runners/handler/task.py
@@ -45,6 +45,22 @@ class TaskHandler(DefaultHandler):
 
 @HandlerFactory.register(name=f'__{Constants.TASK}__')
 class DefaultTaskHandler(TaskHandler):
+    @staticmethod
+    def _build_user_safe_error_answer(raw_msg: str | None) -> str:
+        if not raw_msg:
+            return "Task fail, cause: internal runtime error."
+
+        message = str(raw_msg)
+        lowered = message.lower()
+
+        if "tool_calls mismatch" in lowered:
+            return "Task fail, cause: internal tool-call reconciliation error."
+
+        if "traceback" in lowered or "messages:" in lowered or len(message) > 1000:
+            return "Task fail, cause: internal runtime error."
+
+        return f"Task fail, cause: {message}"
+
     def is_valid_message(self, message: Message):
         if message.category != Constants.TASK:
             return False
@@ -82,7 +98,7 @@ class DefaultTaskHandler(TaskHandler):
 
             logger.warning(f"{task_flag} task {self.runner.task.id} stop, cause: {task_item.msg}")
             self.runner._task_response = TaskResponse(msg=task_item.msg,
-                                                      answer=f'Task fail, cause: {task_item.msg}',
+                                                      answer=self._build_user_safe_error_answer(task_item.msg),
                                                       context=message.context,
                                                       success=False,
                                                       id=self.runner.task.id,

--- a/aworld/runners/handler/tool.py
+++ b/aworld/runners/handler/tool.py
@@ -138,6 +138,10 @@ class DefaultToolHandler(ToolHandler):
                 sender=self.name(),
                 session_id=message.session_id,
                 topic=TopicType.SUBSCRIBE_TOOL,
+                # Dynamic registration must run before the first real tool invocation,
+                # otherwise the tool message can be consumed first and recurse back
+                # into DefaultToolHandler before the receiver is subscribed.
+                priority=message.priority - 1,
                 headers=headers
             )
 
@@ -154,6 +158,7 @@ class DefaultToolHandler(ToolHandler):
                 sender=actions[0].agent_name if actions else '',
                 session_id=message.session_id,
                 receiver=tool_name,
+                priority=message.priority,
                 headers=message.headers
             )
 

--- a/aworld_gateway/channels/dingding/bridge.py
+++ b/aworld_gateway/channels/dingding/bridge.py
@@ -47,6 +47,7 @@ class AworldDingdingBridge:
         session_id: str,
         text: Any,
         steering_text: str | None = None,
+        origin_user_input: Any = None,
         on_text_chunk: Callable[[str], Any] | None = None,
         on_output: Callable[[Any], Any] | None = None,
         allowed_tools: list[str] | None = None,
@@ -89,6 +90,7 @@ class AworldDingdingBridge:
                 result_text = await self._run_with_session_steering(
                     executor=executor,
                     text=text,
+                    origin_user_input=origin_user_input,
                     session_id=session_id,
                     on_text_chunk=on_text_chunk,
                     on_output=on_output,
@@ -144,17 +146,20 @@ class AworldDingdingBridge:
         *,
         executor: Any,
         text: Any,
+        origin_user_input: Any = None,
         session_id: str,
         on_text_chunk: Callable[[str], Any] | None = None,
         on_output: Callable[[Any], Any] | None = None,
     ) -> str:
         current_text = text
+        current_origin_user_input = origin_user_input
         result_text = ""
         runtime = getattr(executor, "_base_runtime", None)
         while True:
             result_text = await self._run_single_round(
                 executor=executor,
                 text=current_text,
+                origin_user_input=current_origin_user_input,
                 session_id=session_id,
                 on_text_chunk=on_text_chunk,
                 on_output=on_output,
@@ -175,19 +180,25 @@ class AworldDingdingBridge:
                 checkpoint="dingtalk_follow_up",
             )
             current_text = follow_up_prompt
+            current_origin_user_input = None
 
     async def _run_single_round(
         self,
         *,
         executor: Any,
         text: Any,
+        origin_user_input: Any = None,
         session_id: str,
         on_text_chunk: Callable[[str], Any] | None = None,
         on_output: Callable[[Any], Any] | None = None,
     ) -> str:
         chunks: list[str] = []
         saw_chunk_output = False
-        task = await executor._build_task(text, session_id=session_id)
+        task = await executor._build_task(
+            text,
+            session_id=session_id,
+            origin_user_input=origin_user_input,
+        )
         task_id = self._task_id(task, fallback=f"dingtalk-{session_id}")
         executor.context = getattr(task, "context", None)
         runtime = getattr(executor, "_base_runtime", None)

--- a/aworld_gateway/channels/dingding/bridge.py
+++ b/aworld_gateway/channels/dingding/bridge.py
@@ -46,6 +46,7 @@ class AworldDingdingBridge:
         agent_id: str,
         session_id: str,
         text: Any,
+        steering_text: str | None = None,
         on_text_chunk: Callable[[str], Any] | None = None,
         on_output: Callable[[Any], Any] | None = None,
         allowed_tools: list[str] | None = None,
@@ -62,7 +63,7 @@ class AworldDingdingBridge:
                     text=self._queue_session_steering(
                         runtime=runtime,
                         session_id=session_id,
-                        text=text,
+                        text=steering_text if steering_text is not None else text,
                     )
                 )
             if active_task is None:

--- a/aworld_gateway/channels/dingding/connector.py
+++ b/aworld_gateway/channels/dingding/connector.py
@@ -480,6 +480,8 @@ class DingTalkConnector:
             raw_steering_text = request_text.strip()
             if raw_steering_text and "steering_text" in signature(self._bridge.run).parameters:
                 bridge_run_kwargs["steering_text"] = raw_steering_text
+            if raw_steering_text and "origin_user_input" in signature(self._bridge.run).parameters:
+                bridge_run_kwargs["origin_user_input"] = raw_steering_text
             if allowed_tools is not None:
                 bridge_run_kwargs["allowed_tools"] = allowed_tools
             result = await self._bridge.run(

--- a/aworld_gateway/channels/dingding/connector.py
+++ b/aworld_gateway/channels/dingding/connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
-from inspect import isawaitable
+from inspect import isawaitable, signature
 import json
 import logging
 import mimetypes
@@ -477,6 +477,9 @@ class DingTalkConnector:
                 "on_text_chunk": on_text_chunk,
                 "on_output": on_output,
             }
+            raw_steering_text = request_text.strip()
+            if raw_steering_text and "steering_text" in signature(self._bridge.run).parameters:
+                bridge_run_kwargs["steering_text"] = raw_steering_text
             if allowed_tools is not None:
                 bridge_run_kwargs["allowed_tools"] = allowed_tools
             result = await self._bridge.run(

--- a/aworld_gateway/channels/wechat/connector.py
+++ b/aworld_gateway/channels/wechat/connector.py
@@ -43,6 +43,7 @@ from aworld_gateway.cron_push import CronPushBindingStore, CronPushBridge
 from aworld_gateway.logging import get_gateway_logger
 from aworld_gateway.router import SESSION_BINDING_CONVERSATION_ID_METADATA_KEY
 from aworld_gateway.types import InboundEnvelope
+from aworld_cli.steering import STEERING_CAPTURED_ACK
 from aworld_cli.core.command_bridge import CommandBridge
 
 try:
@@ -823,6 +824,15 @@ class WechatConnector:
             channel_default_agent_id=self.config.default_agent_id,
             on_output=on_output,
         )
+        if self._should_suppress_auto_steer_reply(
+            conversation_type=conversation_type,
+            text=outbound.text,
+        ):
+            logger.info(
+                "WeChat steering reply suppressed "
+                f"chat_id={conversation_id} reply_to={outbound.reply_to_message_id or message_id}"
+            )
+            return
         logger.info(
             "WeChat outbound reply "
             f"chat_id={outbound.conversation_id} reply_to={outbound.reply_to_message_id or message_id} "
@@ -1208,15 +1218,26 @@ class WechatConnector:
     def _poll_retry_delay_seconds() -> float:
         return POLL_RETRY_DELAY_SECONDS
 
-    @staticmethod
-    def _conversation_key_for_message(message: dict[str, Any]) -> str | None:
+    def _conversation_key_for_message(self, message: dict[str, Any]) -> str | None:
         room_id = str(message.get("roomid") or "").strip()
         if room_id:
             return f"group:{room_id}"
         sender_id = str(message.get("from_user_id") or "").strip()
-        if sender_id:
+        if sender_id and not self.config.auto_steer_while_running:
             return f"dm:{sender_id}"
         return None
+
+    def _should_suppress_auto_steer_reply(
+        self,
+        *,
+        conversation_type: str,
+        text: str,
+    ) -> bool:
+        return (
+            conversation_type == "dm"
+            and self.config.auto_steer_while_running
+            and text == STEERING_CAPTURED_ACK
+        )
 
     @staticmethod
     def _truncate_log_text(value: object, *, limit: int = LOG_TEXT_TRUNCATE_LIMIT) -> str:

--- a/aworld_gateway/config/models.py
+++ b/aworld_gateway/config/models.py
@@ -44,6 +44,7 @@ class WechatChannelConfig(BaseChannelConfig):
     allow_from: list[str] = Field(default_factory=list)
     group_allow_from: list[str] = Field(default_factory=list)
     split_multiline_messages: bool = False
+    auto_steer_while_running: bool = True
 
 
 class WecomChannelConfig(BaseChannelConfig):

--- a/docs/superpowers/specs/2026-05-15-natural-auto-steering-wechat-acp-design.md
+++ b/docs/superpowers/specs/2026-05-15-natural-auto-steering-wechat-acp-design.md
@@ -1,0 +1,412 @@
+# Natural Auto-Steering for WeChat and ACP
+
+## Date
+2026-05-15
+
+## Goal
+
+Make same-session follow-up input feel natural in chat-like surfaces by treating new single-session input as steering while a task is still running, without requiring explicit user commands or a separate manual steering control.
+
+The first implementation phase applies this policy to:
+- WeChat direct-message sessions
+- ACP sessions
+
+The longer-term target is a common inbound steering policy that other channels can adopt.
+
+## Scope
+
+Included:
+- natural auto-steering semantics for WeChat DM
+- natural auto-steering semantics for ACP session prompts
+- silent capture behavior for running-task follow-up input
+- reuse of the existing session steering queue, interrupt, checkpoint, and follow-up execution path
+- configuration for WeChat auto-steer behavior
+- tests covering running-turn, completed-turn, reset-command, and queued-follow-up behavior
+
+Excluded:
+- group-chat auto-steering
+- new user-visible “steer now” buttons or commands
+- frontend or Happy-side protocol changes
+- a new separate steering RPC/input type for ACP
+- WeCom and other channel implementations in this phase
+- redesign of the steering coordinator or executor internals beyond small integration changes
+
+## Problem
+
+Current behavior is technically safe but product-suboptimal for chat-driven use.
+
+For WeChat:
+- messages from the same DM session are serialized at the connector layer
+- follow-up messages sent while a task is still running do not reach the router/backend immediately
+- they therefore cannot enter the steering queue
+- users experience them as separate turns only after the previous task ends
+
+For ACP:
+- paused turns already support follow-up steering through the next `prompt`
+- but a new prompt arriving while a turn is still actively running does not naturally behave like steering
+- this makes ACP and chat-based usage feel inconsistent
+
+The resulting UX does not match how users naturally interact in chat:
+- they send one request
+- they notice something to clarify
+- they send one or more short follow-up messages
+- they expect those follow-ups to modify the in-flight task, not wait to become unrelated later turns
+
+## Product Decision
+
+### 1. Natural follow-up input becomes steering while a turn is active
+
+When a session already has an active running task:
+- new same-session follow-up input is interpreted as steering by default
+- the follow-up text is queued into the existing steering coordinator
+- execution continues until the next steering checkpoint or terminal fallback follow-up path consumes the queued steering
+
+This behavior should feel automatic and natural.
+
+The user should not need to:
+- type a special steering command
+- explicitly request “interrupt”
+- choose between “new turn” and “steer current turn”
+
+### 2. Natural auto-steering is silent
+
+When input is captured into the steering queue:
+- the system must not emit a user-visible steering acknowledgment
+- the system must not send extra “received your update” text
+- the only visible effect is that subsequent task output reflects the follow-up input
+
+This keeps the experience simple and chat-native.
+
+### 3. Auto-steering only applies while the task is still running
+
+Natural auto-steering only has meaning when the session still has an active running turn.
+
+If the task has already ended:
+- the next input must start a normal new turn
+- it must not be interpreted as steering against a completed task
+
+This preserves an intuitive boundary:
+- before completion: follow-up input modifies the current task
+- after completion: follow-up input becomes the next request
+
+### 4. Single-chat direct messages are the default target
+
+To reduce semantic ambiguity and avoid group-chat misfires:
+- WeChat DM sessions enable natural auto-steering by default
+- group chats do not auto-steer in this phase
+
+This default is intentional:
+- DM sessions have a clear single operator
+- follow-up intent is much easier to infer
+- group chat has much higher risk of accidental steering capture
+
+### 5. Reset/new-session commands still take precedence
+
+Explicit new-session intent must override auto-steering.
+
+For example:
+- `/new`
+- `/summary`
+- `新会话`
+- `压缩上下文`
+
+If such an input arrives:
+- it must perform the existing new-session/reset behavior
+- it must not be queued as steering
+
+### 6. ACP and WeChat should share the same mental model
+
+The user mental model should be:
+- if the current task is still running, my next same-session input updates that task
+- if it has stopped, my next same-session input starts a fresh turn
+
+ACP and WeChat should therefore behave the same at this semantic level, even if their transport/protocol surfaces differ.
+
+## Runtime Semantics
+
+### Shared session policy
+
+Each supported inbound surface should apply this policy:
+
+#### Auto-steer eligible
+
+Follow-up input is auto-steer eligible only when all of the following are true:
+- the session has an active running turn
+- the session type is allowed by policy
+- the input is ordinary text input
+- the input is not an explicit reset/new-session command
+
+#### Auto-steer ineligible
+
+Input must not auto-steer when any of the following are true:
+- there is no active turn
+- the active turn has already finished
+- the session type is disallowed by policy
+- the input is a reset/new-session command
+
+### WeChat semantics
+
+#### WeChat DM
+
+For WeChat direct messages:
+- while the session has an active running turn, the next input should reach the existing router/backend immediately
+- if the backend sees the session is already active, it should queue the input as steering through the existing session steering path
+- the connector should swallow the steering acknowledgment instead of replying to the user
+
+Once the running task ends:
+- the next DM message becomes a normal new turn again
+
+#### WeChat group
+
+For WeChat group chats in this phase:
+- keep current behavior
+- do not auto-steer
+- maintain serialized/non-auto-steer semantics
+
+### ACP semantics
+
+#### Running turn
+
+For ACP while a turn is actively running:
+- the next same-session `prompt` should be treated as steering instead of “busy”
+- the input should be enqueued into the existing steering coordinator
+- the server should complete the prompt call successfully without emitting an extra user-visible steering acknowledgment
+- the running turn should continue until the next checkpoint or follow-up consumption path applies the steering
+
+Silent here means:
+- WeChat does not send a chat reply such as `STEERING_CAPTURED_ACK`
+- ACP does not introduce a separate steering-status payload that the caller must render to end users
+
+#### Paused turn
+
+Paused-turn behavior remains unchanged:
+- the next same-session `prompt` resumes through the existing paused follow-up steering path
+- paused state handling must continue to work exactly as it does today
+
+#### Completed turn
+
+If the ACP turn has already finished:
+- the next prompt starts a normal new turn
+- it must not be attached to old steering state
+
+## User Experience
+
+The desired user experience is:
+
+1. User sends a request.
+2. The task starts running.
+3. Before the task ends, the user sends one or more short follow-up messages.
+4. Those messages are silently captured as steering.
+5. The task reaches a checkpoint or follow-up continuation point.
+6. The queued follow-up messages are applied as additional operator steering.
+7. The user sees later output reflect the updated direction.
+
+The user should not need to reason about:
+- “interrupt” versus “new turn”
+- steering queue commands
+- protocol-specific steering controls
+
+## Configuration
+
+### WeChat
+
+Add a WeChat channel config flag:
+- `auto_steer_while_running: bool = True`
+
+Semantics:
+- `True`: WeChat DM follow-up input may auto-steer while a turn is active
+- `False`: preserve current serialized-next-turn behavior even in DM
+
+Important constraint:
+- group-chat auto-steer remains off even if this flag is `True`
+
+### ACP
+
+ACP should enable the same behavior by default in this phase.
+
+An explicit ACP config/env toggle is optional, but not required for phase one.
+The implementation may hard-default to enabled if that keeps the ACP surface simpler.
+
+## Implementation Strategy
+
+### 1. Reuse existing steering machinery
+
+Do not build a second steering queue implementation at the channel or ACP entry layer.
+
+Reuse the existing:
+- `SteeringCoordinator`
+- session interrupt request path
+- queued steering checkpoint pause path
+- terminal fallback follow-up path
+- steering observability logging
+
+This keeps semantics unified and avoids duplicate logic.
+
+### 2. Add a lightweight inbound auto-steer policy layer
+
+Introduce a small integration-layer policy that decides whether new inbound input should:
+- start a fresh turn
+- enter the active session’s steering queue
+
+This policy layer should not own steering state.
+It should only decide whether to route the inbound text toward existing steering handling.
+
+### 3. WeChat integration point
+
+Primary implementation area:
+- `aworld_gateway/channels/wechat/connector.py`
+
+Current blocker:
+- connector-level per-conversation serialization prevents running-turn follow-up messages from reaching the router in time
+
+Required change:
+- allow WeChat DM follow-up input to pass through to the router/backend while a same-session task is still running
+- preserve existing serialized behavior for group chats and for DM when auto-steer is disabled
+
+The router/backend already knows how to queue same-session concurrent input as steering.
+
+The connector must additionally:
+- recognize the returned steering-ack result
+- suppress it so the user sees no extra message
+
+### 4. Router/backend integration point
+
+Primary implementation area:
+- `aworld_gateway/router.py`
+
+Expected behavior:
+- keep existing same-session active-run detection
+- keep existing `_queue_session_steering()` logic
+- keep existing checkpoint and follow-up steering application logic
+
+Only minimal changes should be needed, if any.
+The main requirement is that upstream callers can use the existing result to implement silent capture behavior.
+
+### 5. ACP integration point
+
+Primary implementation areas:
+- `aworld-cli/src/aworld_cli/acp/server.py`
+- `aworld-cli/src/aworld_cli/acp/turn_controller.py`
+
+Current blocker:
+- a running session does not naturally treat the next prompt as steering
+
+Required behavior:
+- paused sessions keep their current paused-resume path
+- actively running sessions should no longer reject the next prompt as merely “busy”
+- instead, the new prompt text should be queued into the active session steering state
+- the ACP server should return success without surfacing a visible steering acknowledgment
+
+This should align ACP with WeChat DM semantics without changing the paused-turn contract.
+
+### 6. Session reset remains explicit
+
+WeChat new-session/reset commands must continue to:
+- rotate the effective session binding
+- clear stored context tokens as needed
+- bypass auto-steering
+
+ACP should likewise treat an explicit fresh-turn mechanism, if introduced later, as stronger than auto-steer.
+
+## Observability
+
+Natural auto-steering must remain debuggable.
+
+The implementation should preserve or emit enough signal to answer:
+- was this follow-up input auto-steered or treated as a new turn?
+- when was the steering queued?
+- when was it applied?
+- at which checkpoint was it consumed?
+
+The user-facing path is silent, but the operator/developer path must not be.
+
+Expected observable signals:
+- queued steering event
+- applied steering event
+- active session/task identifiers
+- distinction between fresh-turn and steering-follow-up processing
+
+## Risks
+
+### 1. Silent capture can hide system state
+
+Because the product decision is silent mode:
+- users do not receive confirmation that follow-up input was captured
+- if steering is never applied due to upstream failure, the experience may feel like the follow-up was ignored
+
+This is an accepted trade-off for simplicity, but logs must make diagnosis easy.
+
+### 2. Over-eager auto-steering can misclassify true new turns
+
+The strongest protection in this phase is:
+- only enable by default in single-user DM-like contexts
+- only while a turn is genuinely still active
+- keep explicit reset commands higher priority
+
+### 3. WeChat connector behavior changes are sensitive
+
+Removing or weakening connector serialization for DM must not reintroduce the earlier regression where ordinary consecutive messages were unintentionally reclassified in cases that should remain separate turns.
+
+The new behavior is intentional only while the prior turn is still active.
+Once the turn ends, later messages must behave as normal fresh turns.
+
+## Test Matrix
+
+### WeChat
+
+- DM + running turn + second ordinary text:
+  - no visible acknowledgment is sent
+  - input is queued as steering
+  - steering is later applied at checkpoint/follow-up
+
+- DM + running turn + multiple follow-up texts:
+  - all follow-ups enter the steering queue in order
+  - later applied steering preserves that order
+
+- DM + completed turn + next text:
+  - new normal turn starts
+  - no steering capture occurs
+
+- DM + running turn + `/new`:
+  - reset behavior takes precedence
+  - no steering capture occurs
+
+- group + running turn + next text:
+  - no auto-steering
+  - current group semantics remain intact
+
+### ACP
+
+- running turn + second prompt:
+  - no busy rejection
+  - input is queued as steering
+  - no visible steering acknowledgment is emitted
+
+- paused turn + next prompt:
+  - existing paused resume behavior remains unchanged
+
+- completed turn + next prompt:
+  - starts a fresh turn
+
+- running turn + multiple follow-up prompts:
+  - queue order is preserved
+  - later checkpoint/follow-up applies them in order
+
+### Regression coverage
+
+- same-session steering queue path in gateway router still functions
+- steering checkpoint pause behavior still functions
+- interrupt-only steering behavior remains intact
+- existing WeChat `/new` behavior remains correct
+- existing ACP paused steering behavior remains correct
+
+## Acceptance Criteria
+
+This design is successful when all of the following are true:
+
+- In WeChat DM, while a task is still running, follow-up messages naturally modify the current task instead of waiting as unrelated later turns.
+- In ACP, while a task is still running, the next same-session prompt naturally acts as steering instead of a separate or rejected prompt.
+- Once the active task ends, the next input starts a fresh turn in both surfaces.
+- Group-chat behavior is unchanged in this phase.
+- No user-visible “steering captured” acknowledgment is emitted.
+- The implementation reuses the existing steering queue/checkpoint machinery rather than introducing a duplicate steering stack.

--- a/tests/acp/test_executor.py
+++ b/tests/acp/test_executor.py
@@ -50,7 +50,14 @@ async def test_acp_local_executor_build_task_sets_context_working_dir_base_path(
 ) -> None:
     seen: dict[str, str] = {}
 
-    async def fake_parent_build_task(self, task_content: str, session_id=None, task_id=None, image_urls=None):
+    async def fake_parent_build_task(
+        self,
+        task_content: str,
+        session_id=None,
+        task_id=None,
+        image_urls=None,
+        origin_user_input=None,
+    ):
         seen["task_content"] = task_content
         seen["working_dir_base_path"] = self.context_config.env_config.working_dir_base_path
         return {"task_content": task_content, "session_id": session_id}

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -19,7 +19,7 @@ from aworld_cli.acp.server import AcpExecutorOutputBridge, AcpStdioServer
 from aworld_cli.acp.human_intercept import AcpRequiresHumanError
 from aworld_cli.acp.errors import AWORLD_ACP_APPROVAL_UNSUPPORTED, AWORLD_ACP_REQUIRES_HUMAN
 from aworld_cli.acp.session_store import AcpSessionRecord
-from aworld_cli.steering import SessionSteeringRuntime
+from aworld_cli.steering import STEERING_CAPTURED_ACK, SessionSteeringRuntime, SteeringCoordinator
 
 
 @pytest.mark.asyncio
@@ -153,6 +153,103 @@ async def test_running_prompt_queues_steering_without_visible_ack_update() -> No
         for item in notifications
         if item["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
     )
+
+
+@pytest.mark.asyncio
+async def test_running_prompt_reapplies_previous_steering_when_newer_follow_up_arrives() -> None:
+    class ReSteerBridge:
+        def __init__(self) -> None:
+            self._steering = SteeringCoordinator()
+            self.calls: list[str] = []
+            self.first_started = asyncio.Event()
+            self.second_started = asyncio.Event()
+            self.release_first = asyncio.Event()
+            self.release_second = asyncio.Event()
+
+        def queue_steering(self, *, record, text: str) -> str:
+            self._steering.begin_task(record.aworld_session_id, f"acp-{record.aworld_session_id}")
+            self._steering.enqueue_text(record.aworld_session_id, text)
+            self._steering.request_interrupt(record.aworld_session_id)
+            return STEERING_CAPTURED_ACK
+
+        async def stream_outputs(self, *, record, prompt_text):
+            current_prompt = prompt_text
+            while True:
+                self.calls.append(current_prompt)
+                self._steering.begin_task(record.aworld_session_id, f"task-{len(self.calls)}")
+                if current_prompt == "slow":
+                    self.first_started.set()
+                    await self.release_first.wait()
+                elif "1. follow-up" in current_prompt and "2. newer" not in current_prompt:
+                    self.second_started.set()
+                    await self.release_second.wait()
+
+                yield MessageOutput(
+                    source=ModelResponse(
+                        id=f"resp-{len(self.calls)}",
+                        model="demo",
+                        content=f"done:{len(self.calls)}",
+                    ),
+                )
+
+                follow_up_prompt, _applied_items, _interrupt_requested = self._steering.consume_terminal_fallback(
+                    record.aworld_session_id
+                )
+                if not follow_up_prompt:
+                    self._steering.end_task(record.aworld_session_id, clear_pending=True)
+                    return
+                current_prompt = follow_up_prompt
+
+    bridge = ReSteerBridge()
+    server = AcpStdioServer(output_bridge=bridge)
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    first_task = asyncio.create_task(
+        server._handle_prompt(
+            31,
+            {
+                "sessionId": session["sessionId"],
+                "prompt": {"content": [{"type": "text", "text": "slow"}]},
+            },
+        )
+    )
+    await asyncio.wait_for(bridge.first_started.wait(), timeout=1.0)
+
+    second = await server._handle_prompt(
+        32,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "follow-up"}]},
+        },
+    )
+
+    bridge.release_first.set()
+    await asyncio.wait_for(bridge.second_started.wait(), timeout=1.0)
+
+    third = await server._handle_prompt(
+        33,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "newer"}]},
+        },
+    )
+
+    bridge.release_second.set()
+    first = await first_task
+
+    assert first["result"]["status"] == "completed"
+    assert second["result"]["status"] == "queued"
+    assert third["result"]["status"] == "queued"
+    assert bridge.calls[1].startswith("Continue the current task with this additional operator steering:")
+    assert "1. follow-up" in bridge.calls[1]
+    assert "1. follow-up" in bridge.calls[2]
+    assert "2. newer" in bridge.calls[2]
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_server_runtime_wiring.py
+++ b/tests/acp/test_server_runtime_wiring.py
@@ -90,6 +90,72 @@ async def test_prompt_streams_executor_outputs_through_adapter_and_mapper() -> N
 
 
 @pytest.mark.asyncio
+async def test_running_prompt_queues_steering_without_visible_ack_update() -> None:
+    class SlowQueueBridge:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.queued: list[str] = []
+
+        def queue_steering(self, *, record, text: str) -> str:
+            del record
+            self.queued.append(text)
+            return "Steering captured. Applying at next checkpoint."
+
+        async def stream_outputs(self, *, record, prompt_text):
+            del record, prompt_text
+            self.started.set()
+            await self.release.wait()
+            yield MessageOutput(
+                source=ModelResponse(id="resp-1", model="demo", content="done"),
+            )
+
+    bridge = SlowQueueBridge()
+    server = AcpStdioServer(output_bridge=bridge)
+    writes: list[dict] = []
+
+    async def capture(message: dict) -> None:
+        writes.append(message)
+
+    server._write_message = capture  # type: ignore[method-assign]
+    session = server._handle_new_session({"cwd": ".", "mcpServers": []})
+
+    first_task = asyncio.create_task(
+        server._handle_prompt(
+            21,
+            {
+                "sessionId": session["sessionId"],
+                "prompt": {"content": [{"type": "text", "text": "slow"}]},
+            },
+        )
+    )
+    await asyncio.wait_for(bridge.started.wait(), timeout=1.0)
+
+    second = await server._handle_prompt(
+        22,
+        {
+            "sessionId": session["sessionId"],
+            "prompt": {"content": [{"type": "text", "text": "follow-up"}]},
+        },
+    )
+
+    bridge.release.set()
+    first = await first_task
+
+    notifications = [message for message in writes if message.get("method") == "sessionUpdate"]
+
+    assert first["result"]["status"] == "completed"
+    assert second["result"]["status"] == "queued"
+    assert bridge.queued == ["follow-up"]
+    assert all(
+        item["params"]["update"].get("content", {}).get("text")
+        != "Steering captured. Applying at next checkpoint."
+        for item in notifications
+        if item["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+    )
+
+
+@pytest.mark.asyncio
 async def test_current_acp_protocol_emits_step_lifecycle_updates() -> None:
     class FakeOutputBridge:
         async def stream_outputs(self, *, record, prompt_text):

--- a/tests/acp/test_server_stdio.py
+++ b/tests/acp/test_server_stdio.py
@@ -991,7 +991,7 @@ async def test_acp_server_can_cancel_active_prompt_with_self_test_bridge() -> No
 
 
 @pytest.mark.asyncio
-async def test_acp_server_queues_busy_prompt_with_self_test_bridge() -> None:
+async def test_acp_server_silently_queues_busy_prompt_with_self_test_bridge() -> None:
     proc = await _spawn_async_acp_server({"AWORLD_ACP_SELF_TEST_BRIDGE": "1"})
     try:
         assert proc.stdin is not None
@@ -1054,8 +1054,8 @@ async def test_acp_server_queues_busy_prompt_with_self_test_bridge() -> None:
         assert seen_by_id[4]["result"]["status"] == "queued"
         assert seen_by_id[5]["result"]["status"] == "cancelled"
         assert seen_by_id[3]["result"]["status"] == "cancelled"
-        assert any(
-            item["params"]["update"]["content"]["text"] == "Steering captured. Applying at next checkpoint."
+        assert all(
+            item["params"]["update"]["content"]["text"] != "Steering captured. Applying at next checkpoint."
             for item in session_updates
             if item.get("params", {}).get("update", {}).get("sessionUpdate") == "agent_message_chunk"
         )

--- a/tests/core/agent/test_dynamic_tool_registration_e2e.py
+++ b/tests/core/agent/test_dynamic_tool_registration_e2e.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+"""
+End-to-end regression for dynamic tool registration followed by a second LLM turn.
+
+This guards the path that previously failed with:
+- first tool message consumed before dynamic subscription completed
+- duplicate tool execution / duplicate tool-memory writes
+- second LLM round crashing with `tool_calls mismatch`
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from aworld.agents.llm_agent import Agent
+from aworld.config import ConfigDict
+from aworld.config.conf import AgentConfig
+from aworld.core.common import Observation
+from aworld.core.tool.base import AsyncTool
+import aworld.memory.main as memory_main
+from aworld.models.model_response import Function, ModelResponse, ToolCall
+from aworld.runner import Runners
+
+
+class DynamicEchoTool(AsyncTool):
+    def __init__(self, conf=None, **kwargs):
+        self.execution_count = 0
+        super().__init__(conf=conf or ConfigDict({}), **kwargs)
+
+    async def do_step(self, action, **kwargs):
+        self.execution_count += 1
+        return Observation(content="dynamic tool executed"), 1.0, False, False, {}
+
+    async def close(self):
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
+async def test_dynamic_tool_registration_survives_second_llm_turn_without_tool_call_mismatch():
+    llm_call_count = 0
+    dynamic_tool = DynamicEchoTool(name="dynamic_echo_tool")
+
+    original_memory_instance = memory_main.MEMORY_HOLDER.get("instance")
+    memory_main.MEMORY_HOLDER.clear()
+    memory_main.MemoryFactory.init(custom_memory_store=memory_main.InMemoryMemoryStore())
+
+    async def fake_acall_llm_model(_llm, messages, model, temperature, tools, stream, context, **kwargs):
+        nonlocal llm_call_count
+        llm_call_count += 1
+
+        if llm_call_count == 1:
+            return ModelResponse(
+                id="resp-dynamic-1",
+                model="fake-model",
+                tool_calls=[
+                    ToolCall(
+                        id="call-dynamic-1",
+                        function=Function(
+                            name="dynamic_echo_tool__echo",
+                            arguments="{}",
+                        ),
+                    )
+                ],
+            )
+
+        if llm_call_count == 2:
+            return ModelResponse(
+                id="resp-dynamic-2",
+                model="fake-model",
+                content="dynamic tool flow completed",
+            )
+
+        raise AssertionError(f"Unexpected extra LLM call: {llm_call_count}")
+
+    agent = Agent(
+        name="Aworld",
+        conf=AgentConfig(
+            llm_provider="openai",
+            llm_model_name="fake-model",
+            llm_api_key="fake-key",
+        ),
+        tool_names=["dynamic_echo_tool"],
+        wait_tool_result=True,
+        feedback_tool_result=True,
+        llm_max_attempts=1,
+        llm_retry_delay=0.01,
+    )
+    agent._llm = object()
+
+    try:
+        with patch("aworld.agents.llm_agent.acall_llm_model", fake_acall_llm_model):
+            with patch("aworld.runners.handler.tool.ToolFactory", return_value=dynamic_tool):
+                response = await Runners.run(
+                    input="run the dynamic echo tool",
+                    agent=agent,
+                )
+
+        assert response.success is True
+        assert response.answer == "dynamic tool flow completed"
+        assert llm_call_count == 2
+        assert dynamic_tool.execution_count == 1
+    finally:
+        memory_main.MEMORY_HOLDER.clear()
+        if original_memory_instance is not None:
+            memory_main.MEMORY_HOLDER["instance"] = original_memory_instance

--- a/tests/core/test_cli_steering_coordinator.py
+++ b/tests/core/test_cli_steering_coordinator.py
@@ -81,6 +81,40 @@ def test_consume_terminal_fallback_returns_prompt_and_drained_inputs():
     assert coordinator.snapshot("sess-1")["pending_count"] == 0
 
 
+def test_consume_terminal_fallback_reuses_previously_applied_steering_until_task_ends():
+    coordinator = SteeringCoordinator()
+    coordinator.begin_task(session_id="sess-1", task_id="task-1")
+    coordinator.enqueue_text("sess-1", "Focus on AMD first.")
+
+    prompt, applied, interrupt_requested = coordinator.consume_terminal_fallback("sess-1")
+
+    assert interrupt_requested is False
+    assert "1. Focus on AMD first." in prompt
+    assert [item.text for item in applied] == ["Focus on AMD first."]
+
+    coordinator.enqueue_text("sess-1", "Also include ETFs.")
+    coordinator.request_interrupt("sess-1")
+
+    prompt, applied, interrupt_requested = coordinator.consume_terminal_fallback("sess-1")
+
+    assert interrupt_requested is True
+    assert "1. Focus on AMD first." in prompt
+    assert "2. Also include ETFs." in prompt
+    assert [item.text for item in applied] == [
+        "Focus on AMD first.",
+        "Also include ETFs.",
+    ]
+
+    coordinator.end_task("sess-1", clear_pending=True)
+    coordinator.begin_task(session_id="sess-1", task_id="task-2")
+    coordinator.enqueue_text("sess-1", "Fresh task only.")
+
+    prompt = coordinator.consume_terminal_fallback_prompt("sess-1")
+
+    assert "Fresh task only." in prompt
+    assert "Focus on AMD first." not in prompt
+
+
 def test_interrupt_only_consumption_returns_prompt_and_clears_flag():
     coordinator = SteeringCoordinator()
     coordinator.begin_task(session_id="sess-1", task_id="task-1")

--- a/tests/gateway/test_dingding_bridge.py
+++ b/tests/gateway/test_dingding_bridge.py
@@ -38,8 +38,20 @@ class FakeExecutor:
         self.pause_checks: list[dict[str, object]] = []
         type(self).instances.append(self)
 
-    async def _build_task(self, text: object, *, session_id: str):
-        self.build_calls.append((text, session_id))
+    async def _build_task(
+        self,
+        text: object,
+        *,
+        session_id: str,
+        origin_user_input: object | None = None,
+    ):
+        self.build_calls.append(
+            {
+                "text": text,
+                "session_id": session_id,
+                "origin_user_input": origin_user_input,
+            }
+        )
         build_index = len(self.build_calls)
         return SimpleNamespace(
             id=f"task-{build_index}",
@@ -111,7 +123,13 @@ def test_bridge_streams_chunks_and_returns_aggregated_text(monkeypatch) -> None:
 
     assert result == DingdingBridgeResult(text="hello world")
     assert seen_chunks == ["hello", " ", "world"]
-    assert FakeExecutor.instances[0].build_calls == [("hi", "dingding_conv")]
+    assert FakeExecutor.instances[0].build_calls == [
+        {
+            "text": "hi",
+            "session_id": "dingding_conv",
+            "origin_user_input": None,
+        }
+    ]
     assert FakeExecutor.instances[0].cleanup_called is True
 
 
@@ -382,10 +400,46 @@ def test_bridge_queues_same_session_input_as_steering(monkeypatch) -> None:
     assert steering_ack == DingdingBridgeResult(text=bridge_module.STEERING_CAPTURED_ACK)
     assert first_result == DingdingBridgeResult(text="handled beta")
     assert len(FakeExecutor.instances) == 1
-    assert FakeExecutor.instances[0].build_calls[0] == ("alpha", "dingding_conv")
+    assert FakeExecutor.instances[0].build_calls[0] == {
+        "text": "alpha",
+        "session_id": "dingding_conv",
+        "origin_user_input": None,
+    }
     assert "Continue the current task with this additional operator steering:" in follow_up_prompts[0]
     assert "beta" in follow_up_prompts[0]
     assert FakeExecutor.instances[0].cleanup_called is True
+
+
+def test_bridge_forwards_raw_origin_user_input_to_executor(monkeypatch) -> None:
+    class FakeOutput:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    async def events_factory(task):
+        assert task.text == "整理结果\n会话附加信息:\n - conversationId: conv-1"
+        yield FakeOutput("ok")
+
+    FakeExecutor.instances = []
+    _install_streamed_run_task(monkeypatch, events_factory)
+    bridge = AworldDingdingBridge(registry_cls=FakeRegistry, executor_cls=FakeExecutor)
+
+    result = asyncio.run(
+        bridge.run(
+            agent_id="aworld",
+            session_id="dingding_conv",
+            text="整理结果\n会话附加信息:\n - conversationId: conv-1",
+            origin_user_input="整理结果",
+        )
+    )
+
+    assert result == DingdingBridgeResult(text="ok")
+    assert FakeExecutor.instances[0].build_calls == [
+        {
+            "text": "整理结果\n会话附加信息:\n - conversationId: conv-1",
+            "session_id": "dingding_conv",
+            "origin_user_input": "整理结果",
+        }
+    ]
 
 
 def test_bridge_falls_back_to_temp_context_when_agent_requires_it(monkeypatch) -> None:

--- a/tests/gateway/test_dingding_connector.py
+++ b/tests/gateway/test_dingding_connector.py
@@ -53,6 +53,7 @@ class _FakeBridge:
         agent_id: str,
         session_id: str,
         text,
+        origin_user_input=None,
         on_text_chunk=None,
         on_output=None,
         allowed_tools=None,
@@ -62,6 +63,7 @@ class _FakeBridge:
                 "agent_id": agent_id,
                 "session_id": session_id,
                 "text": text,
+                "origin_user_input": origin_user_input,
             }
         )
         if allowed_tools is not None:
@@ -1551,6 +1553,7 @@ def test_connector_appends_user_context_before_bridge_call() -> None:
     assert bridge.calls
     assert bridge.calls[0]["agent_id"] == "agent-1"
     assert bridge.calls[0]["session_id"] == connector._session_ids["conv-1"]
+    assert bridge.calls[0]["origin_user_input"] == "帮我总结一下"
     assert bridge.calls[0]["text"] == (
         "帮我总结一下\n"
         "会话附加信息:\n"

--- a/tests/gateway/test_dingding_connector.py
+++ b/tests/gateway/test_dingding_connector.py
@@ -12,6 +12,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from aworld_gateway.channels.dingding import bridge as dingding_bridge_module
+from aworld_gateway.channels.dingding.bridge import AworldDingdingBridge
 from aworld_gateway.channels.dingding.connector import (
     PROCESSING_ACK_TEXT,
     DingTalkConnector,
@@ -202,6 +204,71 @@ class _FakeHttpClient:
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class _SteeringRegistry:
+    @staticmethod
+    def get_agent(agent_id: str):
+        class _FakeAgent:
+            context_config = None
+            hooks = None
+
+            async def get_swarm(self, _context):
+                return "fake-swarm"
+
+        return _FakeAgent()
+
+
+class _SteeringExecutor:
+    instances: list["_SteeringExecutor"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.cleanup_called = False
+        self.build_calls: list[tuple[object, str]] = []
+        self.pause_checks: list[dict[str, object]] = []
+        type(self).instances.append(self)
+
+    async def _build_task(self, text: object, *, session_id: str):
+        self.build_calls.append((text, session_id))
+        build_index = len(self.build_calls)
+        return SimpleNamespace(
+            id=f"task-{build_index}",
+            context=SimpleNamespace(
+                task_id=f"task-{build_index}",
+                workspace_path="/tmp/dingding-test-workspace",
+            ),
+            text=text,
+            session_id=session_id,
+        )
+
+    async def _should_pause_for_queued_steering_checkpoint(self, **kwargs) -> bool:
+        self.pause_checks.append(kwargs)
+        runtime = getattr(self, "_base_runtime", None)
+        if runtime is None:
+            return False
+        snapshot = runtime.steering_snapshot(self.kwargs["session_id"])
+        return bool(snapshot["interrupt_requested"]) and int(snapshot["pending_count"]) > 0
+
+    async def cleanup_resources(self) -> None:
+        self.cleanup_called = True
+
+
+class _SteeringStreamingOutputs:
+    def __init__(self, events_factory) -> None:
+        self._events_factory = events_factory
+
+    async def stream_events(self):
+        async for event in self._events_factory():
+            yield event
+
+
+def _install_dingding_bridge_streamed_run_task(monkeypatch, events_factory) -> None:
+    monkeypatch.setattr(
+        dingding_bridge_module.Runners,
+        "streamed_run_task",
+        lambda *, task: _SteeringStreamingOutputs(lambda: events_factory(task)),
+    )
 
 
 def test_connector_start_registers_stream_callback_handler(monkeypatch) -> None:
@@ -749,6 +816,100 @@ def test_connector_reuses_session_for_overlapping_callbacks() -> None:
     assert bridge.calls[0]["session_id"] == bridge.calls[1]["session_id"]
     assert connector._session_ids["conv-1"] == bridge.calls[0]["session_id"]
     assert sent == ["echo:beta", "echo:alpha"]
+
+
+def test_connector_with_real_bridge_applies_same_conversation_follow_up_as_steering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_chunk_seen = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class _FakeChunkOutput:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+        def output_type(self) -> str:
+            return "chunk"
+
+    class _FakeMessageOutput:
+        def __init__(self, response: str) -> None:
+            self.response = response
+
+        def output_type(self) -> str:
+            return "message"
+
+    async def events_factory(task):
+        text = _FakeBridge._display_input_text(task.text)
+        if text == "alpha":
+            yield _FakeChunkOutput("draft")
+            first_chunk_seen.set()
+            await release_first.wait()
+            yield _FakeMessageOutput("draft")
+            return
+
+        assert "Continue the current task with this additional operator steering:" in text
+        assert "beta" in text
+        yield _FakeMessageOutput("handled beta")
+
+    _install_dingding_bridge_streamed_run_task(monkeypatch, events_factory)
+    _SteeringExecutor.instances = []
+
+    connector = DingTalkConnector(
+        config=DingdingChannelConfig(default_agent_id="agent-1"),
+        bridge=AworldDingdingBridge(
+            registry_cls=_SteeringRegistry,
+            executor_cls=_SteeringExecutor,
+        ),
+        stream_module=object(),
+        command_bridge=_FakeCommandBridge(handled=False),
+    )
+    sent: list[str] = []
+
+    async def fake_send_text(*, session_webhook: str, text: str) -> None:
+        assert session_webhook == "https://callback"
+        sent.append(text)
+
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+
+    async def run_scenario() -> None:
+        first_task = asyncio.create_task(
+            connector.handle_callback(
+                {
+                    "sessionWebhook": "https://callback",
+                    "conversationId": "conv-1",
+                    "senderId": "user-1",
+                    "text": {"content": "alpha"},
+                }
+            )
+        )
+        await first_chunk_seen.wait()
+
+        second_task = asyncio.create_task(
+            connector.handle_callback(
+                {
+                    "sessionWebhook": "https://callback",
+                    "conversationId": "conv-1",
+                    "senderId": "user-1",
+                    "text": {"content": "beta"},
+                }
+            )
+        )
+        await second_task
+        assert sent == ["Steering captured. Applying at next checkpoint."]
+
+        release_first.set()
+        await first_task
+
+    asyncio.run(run_scenario())
+
+    assert sent == [
+        "Steering captured. Applying at next checkpoint.",
+        "handled beta",
+    ]
+    assert len(_SteeringExecutor.instances) == 1
+    assert _SteeringExecutor.instances[0].kwargs["session_id"] == connector._session_ids["conv-1"]
+    assert _SteeringExecutor.instances[0].build_calls[0][1] == connector._session_ids["conv-1"]
+    assert _SteeringExecutor.instances[0].cleanup_called is True
 
 
 def test_connector_sends_processing_ack_for_complex_request() -> None:

--- a/tests/gateway/test_dingding_connector.py
+++ b/tests/gateway/test_dingding_connector.py
@@ -912,6 +912,96 @@ def test_connector_with_real_bridge_applies_same_conversation_follow_up_as_steer
     assert _SteeringExecutor.instances[0].cleanup_called is True
 
 
+def test_connector_with_real_bridge_queues_raw_follow_up_text_without_dingtalk_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_chunk_seen = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class _FakeChunkOutput:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+        def output_type(self) -> str:
+            return "chunk"
+
+    class _FakeMessageOutput:
+        def __init__(self, response: str) -> None:
+            self.response = response
+
+        def output_type(self) -> str:
+            return "message"
+
+    async def events_factory(task):
+        text = str(task.text)
+        if "今天google股价怎么样" in text:
+            yield _FakeChunkOutput("draft")
+            first_chunk_seen.set()
+            await release_first.wait()
+            yield _FakeMessageOutput("draft")
+            return
+
+        assert "Continue the current task with this additional operator steering:" in text
+        assert "要不还是看看amd的股价吧" in text
+        assert "会话附加信息" not in text
+        assert "执行要求" not in text
+        yield _FakeMessageOutput("handled steering")
+
+    _install_dingding_bridge_streamed_run_task(monkeypatch, events_factory)
+    _SteeringExecutor.instances = []
+
+    connector = DingTalkConnector(
+        config=DingdingChannelConfig(default_agent_id="agent-1"),
+        bridge=AworldDingdingBridge(
+            registry_cls=_SteeringRegistry,
+            executor_cls=_SteeringExecutor,
+        ),
+        stream_module=object(),
+        command_bridge=_FakeCommandBridge(handled=False),
+    )
+    sent: list[str] = []
+
+    async def fake_send_text(*, session_webhook: str, text: str) -> None:
+        assert session_webhook == "https://callback"
+        sent.append(text)
+
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+
+    async def run_scenario() -> None:
+        first_task = asyncio.create_task(
+            connector.handle_callback(
+                {
+                    "sessionWebhook": "https://callback",
+                    "conversationId": "conv-raw-steering",
+                    "senderId": "user-1",
+                    "text": {"content": "今天google股价怎么样"},
+                }
+            )
+        )
+        await first_chunk_seen.wait()
+
+        second_task = asyncio.create_task(
+            connector.handle_callback(
+                {
+                    "sessionWebhook": "https://callback",
+                    "conversationId": "conv-raw-steering",
+                    "senderId": "user-1",
+                    "text": {"content": "要不还是看看amd的股价吧"},
+                }
+            )
+        )
+        await second_task
+        release_first.set()
+        await first_task
+
+    asyncio.run(run_scenario())
+
+    assert sent == [
+        "Steering captured. Applying at next checkpoint.",
+        "handled steering",
+    ]
+
+
 def test_connector_sends_processing_ack_for_complex_request() -> None:
     bridge = _FakeBridge()
     connector = DingTalkConnector(

--- a/tests/gateway/test_router.py
+++ b/tests/gateway/test_router.py
@@ -507,6 +507,67 @@ def test_local_cli_backend_queues_same_session_input_as_steering():
     assert QueuedSteeringExecutor.instances[0].cleanup_called is True
 
 
+def test_local_cli_backend_reapplies_previous_steering_when_newer_follow_up_arrives():
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    release_first = asyncio.Event()
+    release_second = asyncio.Event()
+
+    class ReSteeringExecutor(_SuccessExecutor):
+        instances = []
+
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            self.chat_calls: list[str] = []
+
+        async def chat(self, text: str) -> str:
+            self.chat_calls.append(text)
+            if text == "alpha":
+                first_started.set()
+                await release_first.wait()
+            elif "1. beta" in text and "2. gamma" not in text:
+                second_started.set()
+                await release_second.wait()
+            return f"ok:{text}"
+
+    backend = LocalCliAgentBackend(
+        registry_cls=_SimpleRegistry,
+        executor_cls=ReSteeringExecutor,
+    )
+
+    async def run_scenario() -> tuple[str, str, str]:
+        first_task = asyncio.create_task(
+            backend.run(agent_id="aworld", session_id="s-steer", text="alpha")
+        )
+        await first_started.wait()
+        first_ack = await backend.run(
+            agent_id="aworld",
+            session_id="s-steer",
+            text="beta",
+        )
+        release_first.set()
+        await second_started.wait()
+        second_ack = await backend.run(
+            agent_id="aworld",
+            session_id="s-steer",
+            text="gamma",
+        )
+        release_second.set()
+        return await first_task, first_ack, second_ack
+
+    first_result, first_ack, second_ack = asyncio.run(run_scenario())
+
+    assert first_ack == router_module.STEERING_CAPTURED_ACK
+    assert second_ack == router_module.STEERING_CAPTURED_ACK
+    assert len(ReSteeringExecutor.instances) == 1
+    assert ReSteeringExecutor.instances[0].chat_calls[0] == "alpha"
+    assert "1. beta" in ReSteeringExecutor.instances[0].chat_calls[1]
+    assert "1. beta" in ReSteeringExecutor.instances[0].chat_calls[2]
+    assert "2. gamma" in ReSteeringExecutor.instances[0].chat_calls[2]
+    assert "gamma" in first_result
+    assert ReSteeringExecutor.instances[0].cleanup_called is True
+
+
 def test_local_cli_backend_on_output_streams_visible_text_and_cleans_up(monkeypatch):
     class FakeChunkOutput:
         def __init__(self, content: str) -> None:

--- a/tests/gateway/test_wechat_config.py
+++ b/tests/gateway/test_wechat_config.py
@@ -23,6 +23,7 @@ def test_wechat_config_defaults_are_text_phase_one_safe() -> None:
     assert cfg.allow_from == []
     assert cfg.group_allow_from == []
     assert cfg.split_multiline_messages is False
+    assert cfg.auto_steer_while_running is True
 
 
 def test_loader_persists_wechat_defaults(tmp_path: Path) -> None:
@@ -37,3 +38,4 @@ def test_loader_persists_wechat_defaults(tmp_path: Path) -> None:
         raw = yaml.safe_load(fh)
 
     assert raw["channels"]["wechat"]["enabled"] is False
+    assert raw["channels"]["wechat"]["auto_steer_while_running"] is True

--- a/tests/gateway/test_wechat_connector.py
+++ b/tests/gateway/test_wechat_connector.py
@@ -253,14 +253,14 @@ async def test_connector_process_message_reset_command_rotates_session_and_sends
 
 
 @pytest.mark.asyncio
-async def test_connector_serializes_same_conversation_messages_in_poll_batch(
+async def test_connector_does_not_serialize_dm_messages_when_auto_steer_enabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     from aworld_gateway.channels.wechat.connector import WechatConnector
 
     router = _BlockingWechatRouter()
-    cfg = WechatChannelConfig(default_agent_id="aworld")
+    cfg = WechatChannelConfig(default_agent_id="aworld", auto_steer_while_running=True)
     monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
     monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
     monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
@@ -297,6 +297,58 @@ async def test_connector_serializes_same_conversation_messages_in_poll_batch(
     )
 
     await asyncio.wait_for(router.first_started.wait(), timeout=1.0)
+    await asyncio.wait_for(router.second_started.wait(), timeout=1.0)
+
+    router.release_first.set()
+    await connector.stop()
+
+    assert router.started_texts == ["first", "second"]
+    assert len(sent) == 2
+    assert all(chat_id == "user-1" and metadata == {} for chat_id, _text, metadata in sent)
+    assert sorted(text for _chat_id, text, _metadata in sent) == ["echo:first", "echo:second"]
+
+
+@pytest.mark.asyncio
+async def test_connector_serializes_dm_messages_when_auto_steer_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _BlockingWechatRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld", auto_steer_while_running=False)
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(config=cfg, router=router, storage_root=tmp_path)
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+
+    connector._schedule_message(
+        {
+            "message_id": "m-1",
+            "from_user_id": "user-1",
+            "context_token": "ctx-1",
+            "item_list": [{"type": 1, "text_item": {"text": "first"}}],
+        }
+    )
+    connector._schedule_message(
+        {
+            "message_id": "m-2",
+            "from_user_id": "user-1",
+            "context_token": "ctx-2",
+            "item_list": [{"type": 1, "text_item": {"text": "second"}}],
+        }
+    )
+
+    await asyncio.wait_for(router.first_started.wait(), timeout=1.0)
     await asyncio.sleep(0.05)
     assert router.second_started.is_set() is False
 
@@ -304,11 +356,149 @@ async def test_connector_serializes_same_conversation_messages_in_poll_batch(
     await asyncio.wait_for(router.second_started.wait(), timeout=1.0)
     await connector.stop()
 
-    assert router.started_texts == ["first", "second"]
     assert sent == [
         ("user-1", "echo:first", {}),
         ("user-1", "echo:second", {}),
     ]
+
+
+@pytest.mark.asyncio
+async def test_connector_keeps_group_messages_serialized_when_auto_steer_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _BlockingWechatRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld", auto_steer_while_running=True)
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(config=cfg, router=router, storage_root=tmp_path)
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+
+    connector._schedule_message(
+        {
+            "message_id": "m-1",
+            "from_user_id": "user-1",
+            "roomid": "group-1",
+            "context_token": "ctx-1",
+            "item_list": [{"type": 1, "text_item": {"text": "first"}}],
+        }
+    )
+    connector._schedule_message(
+        {
+            "message_id": "m-2",
+            "from_user_id": "user-1",
+            "roomid": "group-1",
+            "context_token": "ctx-2",
+            "item_list": [{"type": 1, "text_item": {"text": "second"}}],
+        }
+    )
+
+    await asyncio.wait_for(router.first_started.wait(), timeout=1.0)
+    await asyncio.sleep(0.05)
+    assert router.second_started.is_set() is False
+
+    router.release_first.set()
+    await asyncio.wait_for(router.second_started.wait(), timeout=1.0)
+    await connector.stop()
+
+    assert sent == [
+        ("user-1", "echo:first", {}),
+        ("user-1", "echo:second", {}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_connector_suppresses_steering_ack_for_dm_auto_steer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_cli.steering import STEERING_CAPTURED_ACK
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter(response_text=STEERING_CAPTURED_ACK)
+    cfg = WechatChannelConfig(default_agent_id="aworld", auto_steer_while_running=True)
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(config=cfg, router=router, storage_root=tmp_path)
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-ack-1",
+            "from_user_id": "user-1",
+            "item_list": [{"type": 1, "text_item": {"text": "follow-up"}}],
+        }
+    )
+
+    assert len(router.calls) == 1
+    assert sent == []
+    await connector.stop()
+
+
+@pytest.mark.asyncio
+async def test_connector_process_message_reset_command_bypasses_auto_steer_while_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _BlockingWechatRouter()
+    cfg = WechatChannelConfig(default_agent_id="aworld", auto_steer_while_running=True)
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+    monkeypatch.setenv("AWORLD_WECHAT_BASE_URL", "https://ilink.example.test")
+
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    connector = WechatConnector(config=cfg, router=router, storage_root=tmp_path)
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+
+    connector._schedule_message(
+        {
+            "message_id": "m-running",
+            "from_user_id": "user-1",
+            "item_list": [{"type": 1, "text_item": {"text": "first"}}],
+        }
+    )
+    await asyncio.wait_for(router.first_started.wait(), timeout=1.0)
+
+    await connector._process_message(
+        {
+            "message_id": "m-reset",
+            "from_user_id": "user-1",
+            "item_list": [{"type": 1, "text_item": {"text": "/new"}}],
+        }
+    )
+
+    router.release_first.set()
+    await connector.stop()
+
+    assert len(router.started_texts) == 1
+    assert sent[0] == ("user-1", "✨ 已开启新会话，之前的上下文已清空。", None)
 
 
 @pytest.mark.asyncio

--- a/tests/hooks/test_cli_steering_before_llm_hook.py
+++ b/tests/hooks/test_cli_steering_before_llm_hook.py
@@ -165,6 +165,39 @@ async def test_local_executor_reattaches_steering_after_post_build_context_repla
     assert task.context._aworld_cli_steering is coordinator
 
 
+@pytest.mark.asyncio
+async def test_local_executor_preserves_explicit_origin_user_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    captured = {}
+
+    async def _fake_from_input(task_input, workspace=None, context_config=None):
+        captured["task_input"] = task_input
+        return _DummyContext(task_input)
+
+    async def _fake_create_workspace(_session_id):
+        return tmp_path / "workspace"
+
+    agent = Agent(name="developer", conf=AgentConfig(skill_configs={}))
+    executor = LocalAgentExecutor(Swarm(agent))
+    monkeypatch.setattr(
+        "aworld_cli.executors.local.ApplicationContext.from_input",
+        _fake_from_input,
+    )
+    monkeypatch.setattr(executor, "_create_workspace", _fake_create_workspace)
+
+    await executor._build_task(
+        "整理结果\n会话附加信息:\n - conversationId: conv-1",
+        session_id="session-1",
+        task_id="task-1",
+        origin_user_input="整理结果",
+    )
+
+    assert captured["task_input"].task_content == "整理结果\n会话附加信息:\n - conversationId: conv-1"
+    assert captured["task_input"].origin_user_input == "整理结果"
+
+
 def test_local_executor_streaming_output_can_be_suppressed_for_interactive_steering(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/runners/test_tool_reset_compat.py
+++ b/tests/runners/test_tool_reset_compat.py
@@ -1,18 +1,21 @@
 # coding: utf-8
 # Copyright (c) 2025 inclusionAI.
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from aworld.config import ConfigDict
-from aworld.core.common import ActionModel, Observation
+from aworld.core.common import ActionModel, Observation, TaskItem
 from aworld.core.context.base import Context
 from aworld.core.event.base import Constants, Message, TopicType
 from aworld.core.task import Task, TaskResponse
 from aworld.core.tool.base import AsyncTool
 from aworld.runners.handler.tool import DefaultToolHandler
+from aworld.runners.handler.task import DefaultTaskHandler
 from aworld.runners.task_runner import TaskRunner
+from aworld.runners.event_runner import TaskEventRunner
 
 
 class SyncResetAsyncTool(AsyncTool):
@@ -73,6 +76,87 @@ async def test_default_tool_handler_accepts_sync_reset_for_async_tool():
     assert tool.context is message.context
     assert any(msg.topic == TopicType.SUBSCRIBE_TOOL for msg in outputs)
     assert any(msg.category == Constants.TOOL and msg.receiver == "async_broken_tool" for msg in outputs)
+
+
+@pytest.mark.asyncio
+async def test_default_tool_handler_prioritizes_dynamic_subscription_before_tool_execution():
+    runner = MagicMock()
+    runner.tools = {}
+    runner.tools_conf = {}
+    runner.event_mng.get_handlers.return_value = {}
+
+    handler = DefaultToolHandler(runner)
+    tool = SyncResetAsyncTool(name="async_broken_tool")
+
+    message = Message(
+        category=Constants.TOOL,
+        payload=[
+            ActionModel(
+                tool_name="async_broken_tool",
+                tool_call_id="call-1",
+                agent_name="root-agent",
+            )
+        ],
+        session_id="session-1",
+        headers={"context": Context()},
+    )
+
+    with patch("aworld.runners.handler.tool.ToolFactory", return_value=tool):
+        outputs = [msg async for msg in handler._do_handle(message)]
+
+    subscribe_message = next(msg for msg in outputs if msg.topic == TopicType.SUBSCRIBE_TOOL)
+    tool_message = next(msg for msg in outputs if msg.category == Constants.TOOL and msg.receiver == "async_broken_tool")
+
+    assert subscribe_message.priority < tool_message.priority
+
+
+@pytest.mark.asyncio
+async def test_task_event_runner_wires_tool_callback_handler():
+    task = Task(
+        id="task-tool-callback",
+        name="task-tool-callback",
+        input="hello",
+        observation=Observation(content=[]),
+        context=Context(),
+        conf=ConfigDict(),
+    )
+
+    runner = TaskEventRunner(task, agent_oriented=False)
+    await runner.pre_run()
+
+    assert any(handler.__class__.__name__ == "ToolCallbackHandler" for handler in runner.handlers)
+
+
+@pytest.mark.asyncio
+async def test_default_task_handler_sanitizes_internal_tool_mismatch_errors():
+    runner = MagicMock()
+    runner.task = SimpleNamespace(max_retry_count=0, hooks=None, is_sub_task=False, id="task-1")
+    runner.context = Context()
+    runner.start_time = 0.0
+    runner.stop = AsyncMock()
+    runner.should_stop_task = AsyncMock(return_value=False)
+
+    handler = DefaultTaskHandler(runner)
+    context = Context()
+    context.set_task(SimpleNamespace(timeout=0))
+    message = Message(
+        category=Constants.TASK,
+        payload=TaskItem(
+            msg="AWorldRuntimeException: tool_calls mismatch! CONTEXT_TOOL__list_sessions:0 not found in [], messages: [{'role': 'system', 'content': 'secret'}]",
+            data=None,
+            stop=True,
+        ),
+        session_id="session-1",
+        topic=TopicType.ERROR,
+        headers={"context": context},
+    )
+
+    outputs = [msg async for msg in handler.handle(message)]
+
+    response = outputs[-1].payload
+    assert "tool_calls mismatch" not in response.answer
+    assert "messages:" not in response.answer
+    assert "internal" in response.answer.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/runners/test_tool_reset_compat.py
+++ b/tests/runners/test_tool_reset_compat.py
@@ -45,6 +45,15 @@ class DummyTaskRunner(TaskRunner):
             yield None
 
 
+class CoroutineOnlyInnerHandler:
+    def __init__(self):
+        self.messages = []
+
+    async def handle(self, message):
+        self.messages.append(message)
+        return None
+
+
 @pytest.mark.asyncio
 async def test_default_tool_handler_accepts_sync_reset_for_async_tool():
     runner = MagicMock()
@@ -125,6 +134,34 @@ async def test_task_event_runner_wires_tool_callback_handler():
     await runner.pre_run()
 
     assert any(handler.__class__.__name__ == "ToolCallbackHandler" for handler in runner.handlers)
+
+
+@pytest.mark.asyncio
+async def test_task_event_runner_inner_handlers_accept_coroutine_only_handlers():
+    task = Task(
+        id="task-inner-handler",
+        name="task-inner-handler",
+        input="hello",
+        observation=Observation(content=[]),
+        context=Context(),
+        conf=ConfigDict(),
+    )
+
+    runner = TaskEventRunner(task, agent_oriented=False)
+    await runner.pre_run()
+
+    handler = CoroutineOnlyInnerHandler()
+    message = Message(
+        category=Constants.OUTPUT,
+        payload=SimpleNamespace(output_type=lambda: "default"),
+        session_id="session-1",
+        headers={"context": runner.context},
+    )
+
+    outputs = [event async for event in runner._inner_handler_process([message], [handler])]
+
+    assert outputs == []
+    assert handler.messages == [message]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- enable silent natural auto steering for WeChat and ACP, and document the design for the new flow
- harden steering follow-up continuation plus coroutine/dynamic tool callback handling across gateway/runtime boundaries with regression coverage
- preserve raw DingTalk user input as the authoritative request so result validation is not polluted by appended channel metadata

## Test Plan
- [x] `pytest tests/acp/test_executor.py tests/hooks/test_cli_steering_before_llm_hook.py tests/core/context/amni/prompt/neurons/test_task_grounding_neuron.py tests/gateway/test_dingding_bridge.py -q`
- [x] `pytest tests/gateway/test_dingding_connector.py -q -k 'appends_user_context_before_bridge_call'`
