### PR TITLE
Fix WeChat inbound media loss on download failure

### DIFF
--- a/aworld_gateway/channels/wechat/connector.py
+++ b/aworld_gateway/channels/wechat/connector.py
@@ -755,11 +755,16 @@ class WechatConnector:
         )
         attachments = inbound_media["attachments"]
         attachment_prompt = build_attachment_prompt(attachments)
-        if attachment_prompt:
+        attachment_failure_prompt = self._build_attachment_failure_prompt(
+            inbound_media["attachment_failures"]
+        )
+        prompt_parts = [part for part in (attachment_prompt, attachment_failure_prompt) if part]
+        combined_attachment_prompt = "\n".join(prompt_parts).strip()
+        if combined_attachment_prompt:
             if text and not CommandBridge.is_slash_command(text):
-                text = f"{text}\n\n{attachment_prompt}".strip()
+                text = f"{text}\n\n{combined_attachment_prompt}".strip()
             elif not text:
-                text = attachment_prompt
+                text = combined_attachment_prompt
         if not text:
             logger.info(
                 "WeChat inbound message skipped "
@@ -785,6 +790,8 @@ class WechatConnector:
             metadata["attachments"] = attachments
             metadata["wechat_media"] = inbound_media["wechat_media"]
             metadata["multimodal_parts"] = inbound_media["multimodal_parts"]
+        if inbound_media["attachment_failures"]:
+            metadata["attachment_failures"] = inbound_media["attachment_failures"]
         session_binding_conversation_id = self._session_binding_conversation_ids.get(
             self._session_binding_key(
                 conversation_type=conversation_type,
@@ -860,10 +867,16 @@ class WechatConnector:
         item_list: list[dict[str, Any]],
     ) -> dict[str, list[dict[str, Any]]]:
         if self._poll_session is None:
-            return {"attachments": [], "wechat_media": [], "multimodal_parts": []}
+            return {
+                "attachments": [],
+                "wechat_media": [],
+                "multimodal_parts": [],
+                "attachment_failures": [],
+            }
         attachments: list[dict[str, str]] = []
         wechat_media: list[dict[str, Any]] = []
         multimodal_parts: list[dict[str, Any]] = []
+        attachment_failures: list[dict[str, Any]] = []
         for index, item in enumerate(item_list):
             candidate = self._inbound_media_candidate(item)
             if candidate is None:
@@ -881,6 +894,15 @@ class WechatConnector:
                 logger.exception(
                     "WeChat inbound media download failed "
                     f"message_id={message_id} index={index}"
+                )
+                attachment_failures.append(
+                    {
+                        "type": candidate["type"],
+                        "file_name": candidate["file_name"],
+                        "mime_type": candidate["mime_type"],
+                        "item_index": index,
+                        "reason": "download failed",
+                    }
                 )
                 continue
             path = await asyncio.to_thread(
@@ -920,7 +942,21 @@ class WechatConnector:
             "attachments": attachments,
             "wechat_media": wechat_media,
             "multimodal_parts": multimodal_parts,
+            "attachment_failures": attachment_failures,
         }
+
+    @staticmethod
+    def _build_attachment_failure_prompt(
+        attachment_failures: list[dict[str, Any]],
+    ) -> str:
+        if not attachment_failures:
+            return ""
+        lines = ["Attachment issues:"]
+        for failure in attachment_failures:
+            kind = str(failure.get("type") or "file").strip() or "file"
+            reason = str(failure.get("reason") or "download failed").strip() or "download failed"
+            lines.append(f"- {kind}: unavailable ({reason})")
+        return "\n".join(lines)
 
     def _write_inbound_attachment(
         self,
@@ -1257,7 +1293,7 @@ class WechatConnector:
     def _build_session(self) -> object:
         if aiohttp is None:
             return _NoopSession()
-        return aiohttp.ClientSession(trust_env=True)
+        return aiohttp.ClientSession(trust_env=False)
 
 
 class _NoopSession:

--- a/tests/gateway/test_wechat_connector.py
+++ b/tests/gateway/test_wechat_connector.py
@@ -87,6 +87,36 @@ class _BlockingWechatRouter:
         )
 
 
+def test_connector_build_session_disables_env_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat import connector as wechat_connector
+
+    seen: dict[str, object] = {}
+
+    class _FakeClientSession:
+        def __init__(self, *, trust_env: bool) -> None:
+            seen["trust_env"] = trust_env
+
+    monkeypatch.setattr(
+        wechat_connector,
+        "aiohttp",
+        SimpleNamespace(ClientSession=_FakeClientSession),
+    )
+
+    connector = wechat_connector.WechatConnector(
+        config=WechatChannelConfig(default_agent_id="aworld"),
+        router=None,
+        storage_root=tmp_path,
+    )
+
+    session = connector._build_session()
+
+    assert isinstance(session, _FakeClientSession)
+    assert seen["trust_env"] is False
+
+
 @pytest.mark.asyncio
 async def test_connector_process_message_caches_context_token_and_routes_text(
     monkeypatch: pytest.MonkeyPatch,
@@ -778,8 +808,100 @@ async def test_connector_logs_inbound_media_download_failure_and_continues(
     await connector.stop()
 
     assert "WeChat inbound media download failed message_id=m-1 index=1" in caplog.text
-    assert router.calls[0][0].text == "ping"
-    assert sent == [("user-1", "echo:ping", {})]
+    assert (
+        router.calls[0][0].text
+        == "ping\n\nAttachment issues:\n- image: unavailable (download failed)"
+    )
+    assert router.calls[0][0].metadata["attachment_failures"] == [
+        {
+            "type": "image",
+            "file_name": "image.jpg",
+            "mime_type": "image/jpeg",
+            "item_index": 1,
+            "reason": "download failed",
+        }
+    ]
+    assert sent == [
+        (
+            "user-1",
+            "echo:ping\n\nAttachment issues:\n- image: unavailable (download failed)",
+            {},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_connector_process_message_routes_media_download_failure_without_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from aworld_gateway.channels.wechat.connector import WechatConnector
+
+    router = _FakeRouter()
+    sent: list[tuple[str, str, dict | None]] = []
+
+    async def fake_download_media(
+        *,
+        session,
+        cdn_base_url: str,
+        encrypted_query_param: str | None,
+        aes_key_b64: str | None,
+        full_url: str | None,
+        timeout_seconds: float,
+    ) -> bytes:
+        raise RuntimeError("download failed")
+
+    async def fake_send_text(*, chat_id: str, text: str, metadata: dict | None = None):
+        sent.append((chat_id, text, metadata))
+        return {"chat_id": chat_id, "text": text}
+
+    cfg = WechatChannelConfig(default_agent_id="aworld")
+    monkeypatch.setenv("AWORLD_WECHAT_ACCOUNT_ID", "wx-account")
+    monkeypatch.setenv("AWORLD_WECHAT_TOKEN", "wx-token")
+
+    connector = WechatConnector(
+        config=cfg,
+        router=router,
+        storage_root=tmp_path,
+        download_media_func=fake_download_media,
+    )
+    connector.send_text = fake_send_text  # type: ignore[method-assign]
+    await connector.start()
+    await connector._process_message(
+        {
+            "message_id": "m-image-fail",
+            "from_user_id": "user-1",
+            "item_list": [
+                {
+                    "type": 2,
+                    "image_item": {
+                        "media": {"full_url": "mock-image-resource"}
+                    },
+                }
+            ],
+        }
+    )
+    await connector.stop()
+
+    assert len(router.calls) == 1
+    inbound, _channel_default_agent_id, _on_output = router.calls[0]
+    assert inbound.text == "Attachment issues:\n- image: unavailable (download failed)"
+    assert inbound.metadata["attachment_failures"] == [
+        {
+            "type": "image",
+            "file_name": "image.jpg",
+            "mime_type": "image/jpeg",
+            "item_index": 0,
+            "reason": "download failed",
+        }
+    ]
+    assert sent == [
+        (
+            "user-1",
+            "echo:Attachment issues:\n- image: unavailable (download failed)",
+            {},
+        )
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve inbound WeChat media messages when attachment download fails instead of dropping pure media messages as `empty_text`
- include `attachment_failures` metadata and fallback prompt text so downstream tasks still receive failure context
- disable env proxy inheritance for the WeChat aiohttp session and add regression coverage for the media-download-failure path

## Test Plan
- pytest -q tests/gateway/test_wechat_connector.py
