### PR TITLE
Improve /goal session handling and slash-prefixed input fallback

### DIFF
--- a/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/stop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/stop.py
@@ -72,7 +72,13 @@ class GoalCommand(PluginBoundCommand):
         if action == "pause":
             if not is_goal_active(current):
                 return "No active goal to pause."
-            updated = handle.update({"active": False, "status": "paused"})
+            updated = handle.update(
+                {
+                    "active": False,
+                    "status": "paused",
+                    "last_task_status": "paused",
+                }
+            )
             return build_goal_context_prompt(updated)
 
         if action == "clear":

--- a/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/stop.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/stop.py
@@ -23,6 +23,9 @@ class GoalCommand(PluginBoundCommand):
             return "tool"
         return "prompt"
 
+    def should_start_new_session(self, context: CommandContext) -> bool:
+        return resolve_goal_control_action(context.user_args) is None
+
     async def pre_execute(self, context: CommandContext):
         if resolve_goal_control_action(context.user_args):
             return None

--- a/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/task_completed.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/task_completed.py
@@ -113,7 +113,8 @@ def build_goal_context_prompt(state: dict) -> str:
         )
     else:
         lines.append("Completion promise: none")
-        lines.append("Keep iterating until the operator pauses, clears, or the goal budget is exhausted.")
+        if status in {"active", "budget_limited"}:
+            lines.append("Keep iterating until the operator pauses, clears, or the goal budget is exhausted.")
 
     if state.get("last_task_status"):
         lines.append(f"Last task status: {state['last_task_status']}")

--- a/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/task_completed.py
+++ b/aworld-cli/src/aworld_cli/builtin_plugins/goal_session/hooks/task_completed.py
@@ -90,6 +90,9 @@ def build_goal_context_prompt(state: dict) -> str:
     max_turns = _coerce_positive_int(state.get("max_turns"), DEFAULT_MAX_TURNS)
     commands = [str(item).strip() for item in (state.get("verification_commands") or []) if str(item).strip()]
     completion_promise = (state.get("completion_promise") or "").strip() or None
+    last_task_status = str(state.get("last_task_status") or "").strip()
+    if status == "complete" and last_task_status.lower() == "idle":
+        last_task_status = "completed"
 
     lines = [
         "<goal_contract>",
@@ -116,8 +119,8 @@ def build_goal_context_prompt(state: dict) -> str:
         if status in {"active", "budget_limited"}:
             lines.append("Keep iterating until the operator pauses, clears, or the goal budget is exhausted.")
 
-    if state.get("last_task_status"):
-        lines.append(f"Last task status: {state['last_task_status']}")
+    if last_task_status:
+        lines.append(f"Last task status: {last_task_status}")
     excerpt = state.get("last_final_answer_excerpt") or state.get("last_error_excerpt") or state.get(
         "last_partial_answer_excerpt"
     )

--- a/aworld-cli/src/aworld_cli/console.py
+++ b/aworld-cli/src/aworld_cli/console.py
@@ -2389,13 +2389,6 @@ class AWorldCLI:
         ):
             return True
 
-        if normalized.startswith("/"):
-            self._append_active_steering_history(
-                "system_notice",
-                "Only /interrupt is available while a task is active.",
-            )
-            return True
-
         if steering is None or not session_id:
             return False
 
@@ -3536,10 +3529,7 @@ class AWorldCLI:
                                         f"[dim]Use /skills enable {disabled_skill_name} to enable it[/dim]"
                                     )
                                     continue
-                                # Command not found in registry
-                                self.console.print(f"[yellow]Unknown command: /{cmd_name}[/yellow]")
-                                self.console.print("[dim]Type /help to see available commands[/dim]")
-                                continue
+                                # Unmatched slash-prefixed input falls back to a normal user query.
                             if command:
                                 # Create command context
                                 cmd_context = CommandContext(

--- a/aworld-cli/src/aworld_cli/console.py
+++ b/aworld-cli/src/aworld_cli/console.py
@@ -2380,6 +2380,15 @@ class AWorldCLI:
                 )
             return True
 
+        if normalized.startswith("/") and await self._handle_active_task_goal_command(
+            normalized,
+            runtime=runtime,
+            session_id=session_id,
+            executor_task=executor_task,
+            workspace_path=workspace_path,
+        ):
+            return True
+
         if normalized.startswith("/"):
             self._append_active_steering_history(
                 "system_notice",
@@ -2403,6 +2412,68 @@ class AWorldCLI:
             "queued_steering",
             normalized,
         )
+        return True
+
+    async def _handle_active_task_goal_command(
+        self,
+        user_input: str,
+        *,
+        runtime: Any,
+        session_id: str | None,
+        executor_task: asyncio.Task,
+        workspace_path: str | None = None,
+    ) -> bool:
+        normalized = (user_input or "").strip()
+        if not normalized.startswith("/"):
+            return False
+
+        parts = normalized[1:].split(maxsplit=1)
+        cmd_name = (parts[0] if parts else "").strip().lower()
+        if cmd_name != "goal":
+            return False
+
+        command = CommandRegistry.get(cmd_name)
+        if command is None:
+            return False
+
+        cmd_args = parts[1] if len(parts) > 1 else ""
+        context = CommandContext(
+            cwd=workspace_path or os.getcwd(),
+            user_args=cmd_args,
+            sandbox=None,
+            agent_config=None,
+            runtime=runtime,
+            session_id=session_id,
+        )
+        if command.resolve_command_type(context) != "tool":
+            return False
+
+        try:
+            error = await command.pre_execute(context)
+            if error:
+                self._append_active_steering_history("system_notice", f"Error: {error}")
+                return True
+
+            result = await command.execute(context)
+        except Exception as exc:
+            self._append_active_steering_history(
+                "error",
+                f"Error executing /goal: {exc}",
+            )
+            return True
+
+        if result:
+            self._append_active_steering_history("system_notice", str(result))
+
+        action = cmd_args.strip().lower()
+        if action in {"pause", "clear"}:
+            if runtime is not None and hasattr(runtime, "request_session_interrupt"):
+                try:
+                    runtime.request_session_interrupt(session_id)
+                except Exception:
+                    pass
+            if not executor_task.done():
+                executor_task.cancel()
         return True
 
     async def _prompt_active_task_input(
@@ -3516,11 +3587,22 @@ class AWorldCLI:
 
                                                 # Execute the prompt
                                                 try:
-                                                    response = await self._run_executor_prompt(
-                                                        prompt,
-                                                        executor,
-                                                        executor_instance=executor_instance,
-                                                    )
+                                                    if is_terminal:
+                                                        response = await self._run_executor_with_active_steering(
+                                                            prompt=prompt,
+                                                            executor=executor,
+                                                            completer=completer,
+                                                            runtime=runtime,
+                                                            agent_name=agent_name,
+                                                            executor_instance=executor_instance,
+                                                            is_terminal=True,
+                                                        )
+                                                    else:
+                                                        response = await self._run_executor_prompt(
+                                                            prompt,
+                                                            executor,
+                                                            executor_instance=executor_instance,
+                                                        )
                                                     # Response is returned for potential future use
                                                 except Exception as exec_error:
                                                     import traceback

--- a/aworld-cli/src/aworld_cli/console.py
+++ b/aworld-cli/src/aworld_cli/console.py
@@ -3552,13 +3552,29 @@ class AWorldCLI:
                                 )
 
                                 try:
-                                    # Pre-execute validation
+                                    command_type = command.resolve_command_type(cmd_context)
+                                    # Pre-execute validation on the current session first so
+                                    # invalid prompt commands do not rotate the session.
                                     error = await command.pre_execute(cmd_context)
                                     if error:
                                         self.console.print(f"[red]Error: {error}[/red]")
                                         continue
 
-                                    command_type = command.resolve_command_type(cmd_context)
+                                    if command_type == "prompt" and command.should_start_new_session(cmd_context):
+                                        if executor_instance is None or not hasattr(executor_instance, "new_session"):
+                                            self.console.print(
+                                                f"[red]Error: /{cmd_name} requires session management support.[/red]"
+                                            )
+                                            continue
+                                        new_session_id = executor_instance.new_session()
+                                        cmd_context = CommandContext(
+                                            cwd=os.getcwd(),
+                                            user_args=cmd_args,
+                                            sandbox=None,
+                                            agent_config=None,
+                                            runtime=runtime,
+                                            session_id=new_session_id,
+                                        )
 
                                     # Route by command type
                                     if command_type == "tool":

--- a/aworld-cli/src/aworld_cli/core/command_system.py
+++ b/aworld-cli/src/aworld_cli/core/command_system.py
@@ -101,6 +101,13 @@ class Command(ABC):
         """Return the effective command type for this invocation."""
         return self.command_type
 
+    def should_start_new_session(self, context: CommandContext) -> bool:
+        """
+        Return True when the command should rotate to a fresh executor session
+        before prompt generation and execution.
+        """
+        return False
+
     @property
     def allowed_tools(self) -> List[str]:
         """

--- a/aworld-cli/src/aworld_cli/executors/continuous.py
+++ b/aworld-cli/src/aworld_cli/executors/continuous.py
@@ -2,6 +2,7 @@
 Continuous execution executor for running agents in a loop.
 """
 import asyncio
+import sys
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any, Union, List
 from rich.console import Console
@@ -38,6 +39,20 @@ class ContinuousExecutor:
         self.total_cost: float = 0.0
         self.start_time: Optional[datetime] = None
         self.response_history: List[str] = []  # Track recent responses for repetition detection
+
+    def _active_steering_runtime(self, *, non_interactive: bool) -> Any | None:
+        if non_interactive or not sys.stdin.isatty():
+            return None
+
+        runtime = getattr(self.agent_executor, "_base_runtime", None)
+        cli = getattr(runtime, "cli", None) if runtime is not None else None
+        if cli is None:
+            return None
+        if not callable(getattr(cli, "_build_session_completer", None)):
+            return None
+        if not callable(getattr(cli, "_run_executor_with_active_steering", None)):
+            return None
+        return runtime
         
     def _parse_duration(self, duration_str: str) -> timedelta:
         """
@@ -107,6 +122,7 @@ class ContinuousExecutor:
         iteration: int,
         prompt: Union[str, tuple[str, List[str]]],
         completion_signal: Optional[str] = None,
+        agent_name: Optional[str] = None,
         **chat_kwargs,
     ) -> Dict[str, Any]:
         """
@@ -135,7 +151,32 @@ class ContinuousExecutor:
                 if self.agent_executor.console is not global_console:
                     self.console.print(f"[yellow]⚠️ Warning: Failed to set agent_executor.console[/yellow]")
             
-            response = await self.agent_executor.chat(prompt, **chat_kwargs)
+            non_interactive = bool(chat_kwargs.pop("non_interactive", False))
+            runtime = self._active_steering_runtime(non_interactive=non_interactive)
+            if runtime is not None:
+                cli = runtime.cli
+                completer = cli._build_session_completer(
+                    agent_names=[agent_name] if agent_name else [],
+                    agent_name=agent_name,
+                    executor_instance=self.agent_executor,
+                    runtime=runtime,
+                    event_loop=asyncio.get_running_loop(),
+                )
+
+                async def _run_prompt(text: str):
+                    return await self.agent_executor.chat(text, **chat_kwargs)
+
+                response = await cli._run_executor_with_active_steering(
+                    prompt=prompt,
+                    executor=_run_prompt,
+                    completer=completer,
+                    runtime=runtime,
+                    agent_name=agent_name or "Aworld",
+                    executor_instance=self.agent_executor,
+                    is_terminal=True,
+                )
+            else:
+                response = await self.agent_executor.chat(prompt, **chat_kwargs)
 
             # Check for completion signal (only check if response is string)
             is_complete = False
@@ -363,7 +404,13 @@ class ContinuousExecutor:
                     break
                 
                 # Run iteration
-                result = await self.run_iteration(iteration, prompt, completion_signal, **kwargs)
+                result = await self.run_iteration(
+                    iteration,
+                    prompt,
+                    completion_signal,
+                    agent_name=agent_name,
+                    **kwargs,
+                )
                 results.append(result)
 
                 self.total_cost += result["cost"]

--- a/aworld-cli/src/aworld_cli/main.py
+++ b/aworld-cli/src/aworld_cli/main.py
@@ -962,6 +962,10 @@ async def _run_direct_mode(
     if not agent_executor:
         print(f"❌ Error: Failed to create executor for agent '{agent_name}'")
         return
+
+    # Match interactive mode so direct runs can access runtime-scoped features
+    # such as steering checkpoints and HUD state.
+    agent_executor._base_runtime = runtime
     
     # If session_id was provided, ensure it's properly restored (for session history management)
     if session_id and hasattr(agent_executor, 'restore_session'):
@@ -995,6 +999,7 @@ async def _run_direct_mode(
         prompt=multimodal_prompt,
         agent_name=agent_name,
         requested_skill_names=requested_skill_names,
+        non_interactive=non_interactive,
         max_runs=max_runs,
         max_cost=max_cost,
         max_duration=max_duration,

--- a/tests/core/test_skill_cli.py
+++ b/tests/core/test_skill_cli.py
@@ -810,6 +810,53 @@ async def test_run_chat_session_reports_disabled_skill_alias(
 
 
 @pytest.mark.asyncio
+async def test_run_chat_session_treats_absolute_path_text_as_plain_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = AWorldCLI()
+    output = StringIO()
+    cli.console = Console(file=output, force_terminal=False, color_system=None, width=160)
+    captured: dict[str, object] = {}
+    prompts = iter(
+        [
+            "/Users/manwu/Documents/health/2026-05-25/icloud，你看看这个里面有今天的健康数据吗？",
+            "/exit",
+        ]
+    )
+
+    async def fake_executor(prompt: str, requested_skill_names=None):
+        captured["prompt"] = prompt
+        captured["requested_skill_names"] = requested_skill_names
+        return "ok"
+
+    async def fake_apply_user_input_hooks(user_input: str, executor_instance=None):
+        return True, user_input
+
+    async def fake_stop_notification_poller():
+        return None
+
+    monkeypatch.setattr(cli, "_apply_user_input_hooks", fake_apply_user_input_hooks)
+    monkeypatch.setattr(cli, "_stop_notification_poller", fake_stop_notification_poller)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr("builtins.input", lambda: next(prompts))
+
+    result = await cli.run_chat_session(
+        "Aworld",
+        fake_executor,
+        available_agents=[AgentInfo(name="Aworld")],
+    )
+
+    rendered = output.getvalue()
+
+    assert result is False
+    assert (
+        captured["prompt"]
+        == "/Users/manwu/Documents/health/2026-05-25/icloud，你看看这个里面有今天的健康数据吗？"
+    )
+    assert "Unknown command:" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_run_chat_session_routes_prompt_commands_through_active_steering_in_terminal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/test_skill_cli.py
+++ b/tests/core/test_skill_cli.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "aworld-cli" / "src
 
 from aworld_cli import main as main_module
 from aworld_cli.console import AWorldCLI
+from aworld_cli.core.command_system import Command, CommandContext, CommandRegistry
 from aworld_cli.core.installed_skill_manager import InstalledSkillManager
 from aworld_cli.core.plugin_manager import PluginManager
 from aworld_cli.core.skill_state_manager import SkillStateManager
@@ -406,6 +407,53 @@ async def test_run_direct_mode_passes_requested_skill_names(
 
 
 @pytest.mark.asyncio
+async def test_run_direct_mode_binds_runtime_to_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyExecutor(SimpleNamespace):
+        pass
+
+    class DummyRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            self._scheduler = None
+
+        async def _load_agents(self):
+            return [SimpleNamespace(name="Aworld")]
+
+        def _bind_scheduler_default_agent(self, agent_name: str) -> None:
+            captured["bound_agent"] = agent_name
+
+        async def _create_executor(self, _agent):
+            executor = DummyExecutor(console=None)
+            captured["executor"] = executor
+            return executor
+
+    class DummyContinuousExecutor:
+        def __init__(self, agent_executor, console=None) -> None:
+            self.agent_executor = agent_executor
+            self.console = console
+
+        async def run_continuous(self, **kwargs) -> None:
+            captured["runtime_on_executor"] = getattr(self.agent_executor, "_base_runtime", None)
+
+    monkeypatch.setattr(main_module, "CliRuntime", DummyRuntime)
+    monkeypatch.setattr(main_module, "ContinuousExecutor", DummyContinuousExecutor)
+    monkeypatch.setattr(
+        "aworld.core.scheduler.get_scheduler",
+        lambda: SimpleNamespace(),
+    )
+
+    await main_module._run_direct_mode(
+        prompt="use browser",
+        agent_name="Aworld",
+    )
+
+    assert captured["runtime_on_executor"] is not None
+
+
+@pytest.mark.asyncio
 async def test_console_skills_use_sets_pending_override() -> None:
     cli = AWorldCLI()
     cli._pending_skill_overrides = []
@@ -745,3 +793,86 @@ async def test_run_chat_session_reports_disabled_skill_alias(
     assert executed["called"] is False
     assert "disabled" in rendered.lower()
     assert "/skills enable youtube_search" in rendered
+
+
+@pytest.mark.asyncio
+async def test_run_chat_session_routes_prompt_commands_through_active_steering_in_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = AWorldCLI()
+    output = StringIO()
+    cli.console = Console(file=output, force_terminal=False, color_system=None, width=160)
+    captured: dict[str, object] = {}
+    prompts = iter(["/steercheck now", "/exit"])
+
+    class DummyPromptCommand(Command):
+        @property
+        def name(self) -> str:
+            return "steercheck"
+
+        @property
+        def description(self) -> str:
+            return "exercise active steering path"
+
+        async def get_prompt(self, context: CommandContext) -> str:
+            captured["user_args"] = context.user_args
+            return "generated prompt"
+
+    class FakePromptSession:
+        def prompt(self, *_args, **_kwargs):
+            return next(prompts)
+
+    async def fake_executor(prompt: str, requested_skill_names=None):
+        captured["executor_prompt"] = prompt
+        captured["requested_skill_names"] = requested_skill_names
+        return "ok"
+
+    async def fake_apply_user_input_hooks(user_input: str, executor_instance=None):
+        return True, user_input
+
+    async def fake_ensure_notification_poller(_runtime):
+        return None
+
+    async def fake_stop_notification_poller():
+        return None
+
+    async def fake_run_executor_with_active_steering(**kwargs):
+        captured["steering_kwargs"] = kwargs
+        return "ok"
+
+    def fake_create_prompt_session(_completer, **_kwargs):
+        session = FakePromptSession()
+        cli._active_prompt_session = session
+        return session
+
+    monkeypatch.setattr(cli, "_apply_user_input_hooks", fake_apply_user_input_hooks)
+    monkeypatch.setattr(cli, "_ensure_notification_poller", fake_ensure_notification_poller)
+    monkeypatch.setattr(cli, "_stop_notification_poller", fake_stop_notification_poller)
+    monkeypatch.setattr(cli, "_build_session_completer", lambda **_kwargs: object())
+    monkeypatch.setattr(cli, "_create_prompt_session", fake_create_prompt_session)
+    monkeypatch.setattr(cli, "_run_executor_with_active_steering", fake_run_executor_with_active_steering)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    executor_instance = SimpleNamespace(
+        session_id="sess-1",
+        swarm=SimpleNamespace(tools=[]),
+        _base_runtime=SimpleNamespace(),
+    )
+    command = DummyPromptCommand()
+    CommandRegistry.register(command)
+    try:
+        result = await cli.run_chat_session(
+            "Aworld",
+            fake_executor,
+            available_agents=[AgentInfo(name="Aworld")],
+            executor_instance=executor_instance,
+        )
+    finally:
+        CommandRegistry.unregister(command.name)
+
+    assert result is False
+    assert captured["user_args"] == "now"
+    assert captured["steering_kwargs"]["prompt"] == "generated prompt"
+    assert captured["steering_kwargs"]["executor_instance"] is executor_instance
+    assert captured["steering_kwargs"]["is_terminal"] is True
+    assert "executor_prompt" not in captured

--- a/tests/core/test_skill_cli.py
+++ b/tests/core/test_skill_cli.py
@@ -21,7 +21,10 @@ from aworld_cli.core.skill_activation_resolver import (
 )
 from aworld_cli.core.top_level_command_system import TopLevelCommandRegistry
 from aworld_cli.models import AgentInfo
+from aworld_cli.plugin_capabilities.commands import register_plugin_commands
+from aworld_cli.plugin_capabilities.state import PluginStateStore
 from aworld_cli.top_level_commands import register_builtin_top_level_commands
+from aworld.plugins.discovery import discover_plugins
 
 
 def _write_skill(root: Path, skill_name: str) -> None:
@@ -30,6 +33,17 @@ def _write_skill(root: Path, skill_name: str) -> None:
     (skill_dir / "SKILL.md").write_text(
         "---\nname: demo\ndescription: demo\n---\n\n# Demo\n",
         encoding="utf-8",
+    )
+
+
+def _get_builtin_goal_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "goal_session"
     )
 
 
@@ -876,3 +890,130 @@ async def test_run_chat_session_routes_prompt_commands_through_active_steering_i
     assert captured["steering_kwargs"]["executor_instance"] is executor_instance
     assert captured["steering_kwargs"]["is_terminal"] is True
     assert "executor_prompt" not in captured
+
+
+@pytest.mark.asyncio
+async def test_run_chat_session_starts_goal_prompt_in_a_new_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cli = AWorldCLI()
+    output = StringIO()
+    cli.console = Console(file=output, force_terminal=False, color_system=None, width=160)
+    monkeypatch.chdir(tmp_path)
+    prompts = iter(
+        [
+            '/goal "Build a REST API" --verify "pytest tests/api -q" --completion-promise "COMPLETE"',
+            "/exit",
+        ]
+    )
+    captured: dict[str, object] = {}
+
+    class DummyRuntime:
+        def __init__(self, state_root: Path):
+            self._plugin_state_store = PluginStateStore(state_root)
+
+        def _resolve_plugin_state_path(
+            self,
+            plugin_id: str,
+            scope: str,
+            session_id: str | None,
+            workspace_path: str | None,
+        ):
+            if scope == "global":
+                return self._plugin_state_store.global_state(plugin_id)
+            if scope == "session" and session_id:
+                return self._plugin_state_store.session_state(plugin_id, session_id)
+            if workspace_path:
+                return self._plugin_state_store.workspace_state(plugin_id, workspace_path)
+            return None
+
+    class GoalExecutor:
+        def __init__(self, runtime):
+            self.session_id = "sess-1"
+            self._base_runtime = runtime
+            self.swarm = SimpleNamespace(tools=[])
+            self.created_sessions: list[str] = []
+
+        def new_session(self) -> str:
+            self.created_sessions.append(self.session_id)
+            self.session_id = "sess-2"
+            return self.session_id
+
+    class FakePromptSession:
+        def prompt(self, *_args, **_kwargs):
+            return next(prompts)
+
+    async def fake_executor(prompt: str, requested_skill_names=None):
+        captured["executor_prompt"] = prompt
+        captured["requested_skill_names"] = requested_skill_names
+        return "ok"
+
+    async def fake_apply_user_input_hooks(user_input: str, executor_instance=None):
+        return True, user_input
+
+    async def fake_ensure_notification_poller(_runtime):
+        return None
+
+    async def fake_stop_notification_poller():
+        return None
+
+    async def fake_run_executor_with_active_steering(**kwargs):
+        captured["steering_kwargs"] = kwargs
+        return "ok"
+
+    def fake_create_prompt_session(_completer, **_kwargs):
+        session = FakePromptSession()
+        cli._active_prompt_session = session
+        return session
+
+    monkeypatch.setattr(cli, "_apply_user_input_hooks", fake_apply_user_input_hooks)
+    monkeypatch.setattr(cli, "_ensure_notification_poller", fake_ensure_notification_poller)
+    monkeypatch.setattr(cli, "_stop_notification_poller", fake_stop_notification_poller)
+    monkeypatch.setattr(cli, "_build_session_completer", lambda **_kwargs: object())
+    monkeypatch.setattr(cli, "_create_prompt_session", fake_create_prompt_session)
+    monkeypatch.setattr(cli, "_run_executor_with_active_steering", fake_run_executor_with_active_steering)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    runtime = DummyRuntime(tmp_path / "state")
+    executor_instance = GoalExecutor(runtime)
+    plugin = discover_plugins([_get_builtin_goal_plugin_root()])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+
+        result = await cli.run_chat_session(
+            "Aworld",
+            fake_executor,
+            available_agents=[AgentInfo(name="Aworld")],
+            executor_instance=executor_instance,
+        )
+    finally:
+        CommandRegistry.restore(snapshot)
+
+    new_session_state_path = runtime._resolve_plugin_state_path(
+        plugin_id="goal-session",
+        scope="session",
+        session_id="sess-2",
+        workspace_path=str(tmp_path),
+    )
+    old_session_state_path = runtime._resolve_plugin_state_path(
+        plugin_id="goal-session",
+        scope="session",
+        session_id="sess-1",
+        workspace_path=str(tmp_path),
+    )
+
+    assert result is False
+    assert executor_instance.created_sessions == ["sess-1"]
+    assert executor_instance.session_id == "sess-2"
+    assert "steering_kwargs" in captured
+    assert "executor_prompt" not in captured
+    assert "Objective: Build a REST API" in str(captured["steering_kwargs"]["prompt"])
+    assert (
+        runtime._plugin_state_store.handle(new_session_state_path).read()["objective"]
+        == "Build a REST API"
+    )
+    assert runtime._plugin_state_store.handle(old_session_state_path).read() == {}

--- a/tests/executors/test_continuous.py
+++ b/tests/executors/test_continuous.py
@@ -1,0 +1,55 @@
+from io import StringIO
+import sys
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+from aworld_cli.executors.continuous import ContinuousExecutor
+
+
+@pytest.mark.asyncio
+async def test_run_iteration_uses_active_steering_in_terminal_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_chat(prompt: str, **kwargs):
+        captured["chat_prompt"] = prompt
+        captured["chat_kwargs"] = kwargs
+        return "chat-result"
+
+    async def fake_run_executor_with_active_steering(**kwargs):
+        captured["active_steering_kwargs"] = kwargs
+        executor = kwargs["executor"]
+        return await executor(kwargs["prompt"])
+
+    fake_cli = SimpleNamespace(
+        _build_session_completer=lambda **kwargs: "completer",
+        _run_executor_with_active_steering=fake_run_executor_with_active_steering,
+    )
+    fake_runtime = SimpleNamespace(cli=fake_cli)
+    fake_executor = SimpleNamespace(
+        chat=fake_chat,
+        session_id="sess-1",
+        _base_runtime=fake_runtime,
+    )
+    continuous = ContinuousExecutor(
+        fake_executor,
+        console=Console(file=StringIO(), force_terminal=False),
+    )
+
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    result = await continuous.run_iteration(
+        1,
+        "hello",
+        agent_name="Aworld",
+        requested_skill_names=["browser-use"],
+    )
+
+    assert result["success"] is True
+    assert captured["active_steering_kwargs"]["prompt"] == "hello"
+    assert captured["active_steering_kwargs"]["agent_name"] == "Aworld"
+    assert captured["active_steering_kwargs"]["executor_instance"] is fake_executor
+    assert captured["chat_kwargs"]["requested_skill_names"] == ["browser-use"]

--- a/tests/plugins/test_plugin_commands.py
+++ b/tests/plugins/test_plugin_commands.py
@@ -12,6 +12,7 @@ from aworld_cli.builtin_plugins.goal_session.common import (
 )
 from aworld_cli.builtin_plugins.goal_session.hooks.task_completed import (
     _extract_completion_promise as extract_completion_promise,
+    build_goal_context_prompt,
     summarize_text,
 )
 from aworld.plugins.discovery import discover_plugins
@@ -113,6 +114,28 @@ def test_summarize_text_handles_edge_cases():
     assert summarize_text("a" * 161) == "a" * 157 + "..."
     assert summarize_text("Hello 🎉 World", limit=10) == "Hello 🎉..."
     assert summarize_text(None) is None
+
+
+def test_build_goal_context_prompt_omits_iterating_copy_when_paused():
+    prompt = build_goal_context_prompt(
+        {
+            "active": False,
+            "status": "paused",
+            "objective": "Create file goal_pause.txt with exact content pause ok",
+            "turn_count": 1,
+            "max_turns": 3,
+            "verification_commands": [
+                "test -f goal_pause.txt && grep -qx 'pause ok' goal_pause.txt"
+            ],
+            "completion_promise": None,
+            "source": "goal",
+            "last_task_status": "paused",
+        }
+    )
+
+    assert "Status: paused" in prompt
+    assert "Completion promise: none" in prompt
+    assert "Keep iterating until the operator pauses, clears, or the goal budget is exhausted." not in prompt
 
 
 def test_register_plugin_command_from_manifest():
@@ -1875,6 +1898,93 @@ async def test_goal_command_status_pause_and_clear(tmp_path):
         assert "Last task status: paused" in pause_result
         assert handle.read() == {}
         assert clear_result == "Goal cleared."
+    finally:
+        CommandRegistry.restore(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_goal_command_control_actions_only_affect_current_session(tmp_path):
+    plugin_root = _get_builtin_goal_plugin_root()
+    plugin = discover_plugins([plugin_root])[0]
+
+    snapshot = CommandRegistry.snapshot()
+    try:
+        CommandRegistry.clear()
+        register_plugin_commands([plugin])
+        runtime = _build_dummy_runtime(tmp_path)
+        workspace_path = str(tmp_path / "workspace")
+        session_one_path = runtime._resolve_plugin_state_path(
+            plugin_id="goal-session",
+            scope="session",
+            session_id="session-1",
+            workspace_path=workspace_path,
+        )
+        session_two_path = runtime._resolve_plugin_state_path(
+            plugin_id="goal-session",
+            scope="session",
+            session_id="session-2",
+            workspace_path=workspace_path,
+        )
+        session_one = runtime._plugin_state_store.handle(session_one_path)
+        session_two = runtime._plugin_state_store.handle(session_two_path)
+        session_one.write(
+            {
+                "active": True,
+                "status": "active",
+                "objective": "Keep session one intact",
+                "turn_count": 1,
+                "max_turns": 3,
+                "verification_commands": [],
+                "completion_promise": None,
+                "source": "goal",
+            }
+        )
+        session_two.write(
+            {
+                "active": True,
+                "status": "active",
+                "objective": "Pause and clear session two only",
+                "turn_count": 1,
+                "max_turns": 3,
+                "verification_commands": [],
+                "completion_promise": None,
+                "source": "goal",
+            }
+        )
+
+        command = CommandRegistry.get("goal")
+        pause_result = await command.execute(
+            CommandContext(
+                cwd=workspace_path,
+                user_args="pause",
+                runtime=runtime,
+                session_id="session-2",
+            )
+        )
+        clear_result = await command.execute(
+            CommandContext(
+                cwd=workspace_path,
+                user_args="clear",
+                runtime=runtime,
+                session_id="session-2",
+            )
+        )
+        status_result = await command.execute(
+            CommandContext(
+                cwd=workspace_path,
+                user_args="status",
+                runtime=runtime,
+                session_id="session-1",
+            )
+        )
+
+        assert "Status: paused" in pause_result
+        assert clear_result == "Goal cleared."
+        assert "Objective: Keep session one intact" in status_result
+        assert "Status: active" in status_result
+        assert session_two.read() == {}
+        assert session_one.read()["objective"] == "Keep session one intact"
+        assert session_one.read()["status"] == "active"
     finally:
         CommandRegistry.restore(snapshot)
 

--- a/tests/plugins/test_plugin_commands.py
+++ b/tests/plugins/test_plugin_commands.py
@@ -138,6 +138,28 @@ def test_build_goal_context_prompt_omits_iterating_copy_when_paused():
     assert "Keep iterating until the operator pauses, clears, or the goal budget is exhausted." not in prompt
 
 
+def test_build_goal_context_prompt_labels_idle_as_completed_for_complete_goal():
+    prompt = build_goal_context_prompt(
+        {
+            "active": False,
+            "status": "complete",
+            "objective": "Create file goal_promise.txt with exact content promise ok",
+            "turn_count": 1,
+            "max_turns": 5,
+            "verification_commands": [
+                "test -f goal_promise.txt && grep -qx 'promise ok' goal_promise.txt"
+            ],
+            "completion_promise": "COMPLETE",
+            "source": "goal",
+            "last_task_status": "idle",
+        }
+    )
+
+    assert "Status: complete" in prompt
+    assert "Last task status: completed" in prompt
+    assert "Last task status: idle" not in prompt
+
+
 def test_register_plugin_command_from_manifest():
     plugin_root = Path("tests/fixtures/plugins/code_review_like").resolve()
     plugin = discover_plugins([plugin_root])[0]

--- a/tests/plugins/test_plugin_commands.py
+++ b/tests/plugins/test_plugin_commands.py
@@ -1872,6 +1872,7 @@ async def test_goal_command_status_pause_and_clear(tmp_path):
         assert "Objective: Stabilize the goal flow" in status_result
         assert "Status: active" in status_result
         assert "Status: paused" in pause_result
+        assert "Last task status: paused" in pause_result
         assert handle.read() == {}
         assert clear_result == "Goal cleared."
     finally:

--- a/tests/test_interactive_steering.py
+++ b/tests/test_interactive_steering.py
@@ -199,6 +199,36 @@ async def test_plain_text_steering_ack_is_committed_into_active_history():
 
 
 @pytest.mark.asyncio
+async def test_absolute_path_text_is_queued_while_task_is_active():
+    cli = AWorldCLI()
+    cli._active_steering_view = cli._create_active_steering_view()
+    runtime = FakeRuntime()
+    runtime._steering.begin_task("sess-1", "task-1")
+    task = asyncio.create_task(asyncio.sleep(60))
+    prompt = "/Users/manwu/Documents/health/2026-05-25/icloud，你看看这个里面有今天的健康数据吗？"
+
+    handled = await cli._handle_active_task_input(
+        prompt,
+        runtime=runtime,
+        session_id="sess-1",
+        executor_task=task,
+    )
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert handled is True
+    snapshot = runtime._steering.snapshot("sess-1")
+    assert snapshot["pending_count"] == 1
+    assert snapshot["last_steer_excerpt"] == prompt
+    assert cli._active_steering_view.history[-1] == {
+        "kind": "queued_steering",
+        "text": prompt,
+    }
+
+
+@pytest.mark.asyncio
 async def test_fallback_interrupt_command_cancels_active_task():
     cli = AWorldCLI()
     runtime = FakeRuntime()

--- a/tests/test_interactive_steering.py
+++ b/tests/test_interactive_steering.py
@@ -3,6 +3,7 @@ import json
 import os
 import time
 from io import StringIO
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -16,8 +17,12 @@ from aworld.config import AgentConfig
 from aworld.core.agent.swarm import Swarm
 from aworld.core.event.base import Message
 from aworld_cli.console import AWorldCLI, _ESC_INTERRUPT_SENTINEL
+from aworld_cli.core.command_system import CommandRegistry
 from aworld_cli.executors.local import LocalAgentExecutor
+from aworld_cli.plugin_capabilities.commands import register_plugin_commands
+from aworld_cli.plugin_capabilities.state import PluginStateStore
 from aworld_cli.steering.coordinator import SteeringCoordinator
+from aworld.plugins.discovery import discover_plugins
 
 
 class FakeRuntime:
@@ -30,6 +35,45 @@ class FakeRuntime:
             return False
         self.interrupt_requests.append(session_id)
         return self._steering.request_interrupt(session_id)
+
+
+def _get_builtin_goal_plugin_root() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "aworld-cli"
+        / "src"
+        / "aworld_cli"
+        / "builtin_plugins"
+        / "goal_session"
+    )
+
+
+class GoalCommandRuntime:
+    def __init__(self, state_root: Path):
+        self._steering = SteeringCoordinator()
+        self.interrupt_requests: list[str] = []
+        self._plugin_state_store = PluginStateStore(state_root)
+
+    def request_session_interrupt(self, session_id: str | None) -> bool:
+        if not session_id:
+            return False
+        self.interrupt_requests.append(session_id)
+        return self._steering.request_interrupt(session_id)
+
+    def _resolve_plugin_state_path(
+        self,
+        plugin_id: str,
+        scope: str,
+        session_id: str | None,
+        workspace_path: str | None,
+    ):
+        if scope == "global":
+            return self._plugin_state_store.global_state(plugin_id)
+        if scope == "session" and session_id:
+            return self._plugin_state_store.session_state(plugin_id, session_id)
+        if workspace_path:
+            return self._plugin_state_store.workspace_state(plugin_id, workspace_path)
+        return None
 
 
 def test_active_steering_status_line_uses_runtime_override_when_present():
@@ -206,6 +250,57 @@ async def test_escape_interrupts_and_keeps_pending_steering_for_immediate_follow
         "kind": "system_notice",
         "text": "Interrupting current run to submit queued steering immediately.",
     }
+
+
+@pytest.mark.asyncio
+async def test_goal_pause_command_is_allowed_while_task_is_active(tmp_path):
+    cli = AWorldCLI()
+    cli._active_steering_view = cli._create_active_steering_view()
+    runtime = GoalCommandRuntime(tmp_path / "state")
+    plugin = discover_plugins([_get_builtin_goal_plugin_root()])[0]
+    if CommandRegistry.get("goal") is None:
+        register_plugin_commands([plugin])
+    runtime._plugin_state_store.handle(
+        runtime._plugin_state_store.session_state("goal-session", "sess-1")
+    ).write(
+        {
+            "objective": "Create file goal_pause.txt with exact content pause ok",
+            "active": True,
+            "status": "active",
+            "verification_commands": [
+                "test -f goal_pause.txt && grep -qx 'pause ok' goal_pause.txt"
+            ],
+            "completion_promise": None,
+            "max_turns": 3,
+            "turns_used": 1,
+            "source": "goal",
+        }
+    )
+    runtime._steering.begin_task("sess-1", "task-1")
+    task = asyncio.create_task(asyncio.sleep(60))
+
+    try:
+        handled = await cli._handle_active_task_input(
+            "/goal pause",
+            runtime=runtime,
+            session_id="sess-1",
+            executor_task=task,
+            workspace_path=str(tmp_path),
+        )
+
+        assert handled is True
+        assert runtime.interrupt_requests == ["sess-1"]
+        assert task.cancelled() or task.cancelling()
+        paused = runtime._plugin_state_store.handle(
+            runtime._plugin_state_store.session_state("goal-session", "sess-1")
+        ).read()
+        assert paused["status"] == "paused"
+        assert paused["active"] is False
+        assert "Status: paused" in cli._active_steering_view.history[-1]["text"]
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- isolate new  runs into a fresh session while keeping [H[2J[3J scoped to the current session and supporting steering during goal-command runs
- treat slash-prefixed path-like input as normal user queries or steering text when no registered slash command matches, instead of surfacing 
- clarify completed goal wording by showing 
wtmp begins Wed Feb 11 19:00:13 CST 2026 for complete goals whose executor runtime has already settled to idle

## Test Plan
- [x] ============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/wuman/Documents/workspace/aworld-mas/aworld
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.24, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 33 items / 31 deselected / 2 selected

tests/core/test_skill_cli.py ..                                          [100%]

======================= 2 passed, 31 deselected in 2.32s =======================
- [x] ============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/wuman/Documents/workspace/aworld-mas/aworld
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.24, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 45 items / 42 deselected / 3 selected

tests/test_interactive_steering.py ...                                   [100%]

======================= 3 passed, 42 deselected in 1.71s =======================
- [x] ============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/wuman/Documents/workspace/aworld-mas/aworld
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.24, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 57 items / 53 deselected / 4 selected

tests/plugins/test_plugin_commands.py ....                               [100%]

======================= 4 passed, 53 deselected in 1.65s =======================
- [x] ============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/wuman/Documents/workspace/aworld-mas/aworld
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.24, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 23 items / 22 deselected / 1 selected

tests/plugins/test_plugin_hooks.py .                                     [100%]

======================= 1 passed, 22 deselected in 1.64s =======================
