### PR TITLE
Fix cron recurring task deduplication

### DIFF
--- a/aworld/core/scheduler/scheduler.py
+++ b/aworld/core/scheduler/scheduler.py
@@ -778,11 +778,30 @@ class CronScheduler:
         if not current_job:
             return None
 
-        if updates.get("enabled") is True and not current_job.enabled:
-            now = datetime.now(pytz.UTC)
-            recalculated_next_run = self._calculate_next_run(current_job, now)
+        should_recalculate_next_run = (
+            "schedule" in updates
+            or (updates.get("enabled") is True and not current_job.enabled)
+        )
+        if should_recalculate_next_run:
+            candidate = CronJob(
+                id=current_job.id,
+                name=updates.get("name", current_job.name),
+                description=updates.get("description", current_job.description),
+                enabled=updates.get("enabled", current_job.enabled),
+                delete_after_run=updates.get("delete_after_run", current_job.delete_after_run),
+                schedule=updates.get("schedule", current_job.schedule),
+                payload=updates.get("payload", current_job.payload),
+                state=current_job.state,
+                created_at=current_job.created_at,
+                updated_at=current_job.updated_at,
+            )
             state_updates = dict(updates.get("state") or {})
-            state_updates["next_run_at"] = recalculated_next_run.isoformat() if recalculated_next_run else None
+            if candidate.enabled:
+                now = datetime.now(pytz.UTC)
+                recalculated_next_run = self._calculate_next_run(candidate, now)
+                state_updates["next_run_at"] = recalculated_next_run.isoformat() if recalculated_next_run else None
+            else:
+                state_updates.setdefault("next_run_at", None)
             updates["state"] = state_updates
 
         return await self.store.update_job(job_id, **updates)

--- a/aworld/core/scheduler/store.py
+++ b/aworld/core/scheduler/store.py
@@ -299,6 +299,22 @@ class FileBasedCronStore:
                             if key == "state":
                                 # Merge state updates
                                 job_dict["state"].update(value)
+                            elif key == "schedule":
+                                job_dict["schedule"] = {
+                                    "kind": value.kind,
+                                    "at": value.at,
+                                    "every_seconds": value.every_seconds,
+                                    "cron_expr": value.cron_expr,
+                                    "timezone": value.timezone,
+                                }
+                            elif key == "payload":
+                                job_dict["payload"] = {
+                                    "message": value.message,
+                                    "agent_name": value.agent_name,
+                                    "tool_names": value.tool_names,
+                                    "timeout_seconds": value.timeout_seconds,
+                                    "max_runs": value.max_runs,
+                                }
                             else:
                                 job_dict[key] = value
 

--- a/aworld/tools/cron_tool.py
+++ b/aworld/tools/cron_tool.py
@@ -332,6 +332,81 @@ async def cron_tool(
             "job_ids": removed_ids,
         }
 
+    def recurring_dedupe_key_local(job: 'CronJob') -> Optional[str]:
+        if job.schedule.kind not in ("cron", "every"):
+            return None
+
+        normalized_name = re.sub(r"[\s_\-]+", "", job.name or "").casefold()
+        if not normalized_name:
+            return None
+
+        return "|".join([
+            normalized_name,
+            normalize_agent_name_local(job.payload.agent_name),
+        ])
+
+    def parse_created_at_local(job: 'CronJob') -> datetime:
+        try:
+            return datetime.fromisoformat(job.created_at.replace("Z", "+00:00"))
+        except Exception:
+            return datetime.min
+
+    async def upsert_recurring_job_local(job: 'CronJob') -> tuple['CronJob', Dict[str, Any]]:
+        dedupe_key = recurring_dedupe_key_local(job)
+        list_jobs = getattr(scheduler, "list_jobs", None)
+        update_job = getattr(scheduler, "update_job", None)
+        if not dedupe_key or not callable(list_jobs) or not callable(update_job):
+            return await scheduler.add_job(job), {"updated_existing": False, "disabled_duplicate_job_ids": []}
+
+        jobs = await list_jobs(enabled_only=False)
+        candidates = [
+            existing
+            for existing in jobs
+            if recurring_dedupe_key_local(existing) == dedupe_key
+        ]
+        if not candidates:
+            return await scheduler.add_job(job), {"updated_existing": False, "disabled_duplicate_job_ids": []}
+
+        keeper = sorted(
+            candidates,
+            key=lambda existing: (bool(existing.enabled), parse_created_at_local(existing)),
+            reverse=True,
+        )[0]
+        updated = await update_job(
+            keeper.id,
+            name=job.name,
+            schedule=job.schedule,
+            payload=job.payload,
+            delete_after_run=job.delete_after_run,
+            enabled=True,
+            state={
+                "last_status": None,
+                "last_error": None,
+                "last_result_summary": None,
+                "running": False,
+                "consecutive_errors": 0,
+            },
+        )
+        if not updated:
+            return await scheduler.add_job(job), {"updated_existing": False, "disabled_duplicate_job_ids": []}
+
+        disabled_duplicate_job_ids = []
+        for duplicate in candidates:
+            if duplicate.id == keeper.id or not duplicate.enabled:
+                continue
+            disabled = await update_job(
+                duplicate.id,
+                enabled=False,
+                state={"next_run_at": None, "running": False},
+            )
+            if disabled:
+                disabled_duplicate_job_ids.append(duplicate.id)
+
+        return updated, {
+            "updated_existing": True,
+            "disabled_duplicate_job_ids": disabled_duplicate_job_ids,
+        }
+
     try:
         from aworld.core.scheduler import get_scheduler
         from aworld.core.scheduler.types import CronJob, CronSchedule, CronPayload
@@ -415,7 +490,7 @@ async def cron_tool(
                 delete_after_run=delete_after_run or (schedule_type == "at"),
             )
 
-            result = await scheduler.add_job(job)
+            result, upsert_metadata = await upsert_recurring_job_local(job)
 
             advance_reminder = None
             try:
@@ -446,7 +521,7 @@ async def cron_tool(
                         ),
                         delete_after_run=advance_spec["delete_after_run"],
                     )
-                    advance_result = await scheduler.add_job(advance_job)
+                    advance_result, advance_upsert_metadata = await upsert_recurring_job_local(advance_job)
                     advance_reminder = {
                         "job_id": advance_result.id,
                         "name": advance_result.name,
@@ -454,6 +529,12 @@ async def cron_tool(
                         "display": _format_confirmed_time_display(advance_result.state.next_run_at),
                         "lead_minutes": DEFAULT_ADVANCE_REMINDER_MINUTES,
                     }
+                    if advance_upsert_metadata["updated_existing"]:
+                        advance_reminder["updated_existing"] = True
+                    if advance_upsert_metadata["disabled_duplicate_job_ids"]:
+                        advance_reminder["disabled_duplicate_job_ids"] = advance_upsert_metadata[
+                            "disabled_duplicate_job_ids"
+                        ]
             except Exception as advance_error:
                 logger.warning(
                     "cron_tool(add): failed to create advance reminder for "
@@ -463,10 +544,17 @@ async def cron_tool(
             response = {
                 "success": True,
                 "job_id": result.id,
-                "message": f"Created task '{name}' (ID: {result.id})",
+                "message": (
+                    f"Updated existing task '{name}' (ID: {result.id})"
+                    if upsert_metadata["updated_existing"]
+                    else f"Created task '{name}' (ID: {result.id})"
+                ),
                 "next_run": result.state.next_run_at,
                 "next_run_display": _format_confirmed_time_display(result.state.next_run_at),
+                "updated_existing": upsert_metadata["updated_existing"],
             }
+            if upsert_metadata["disabled_duplicate_job_ids"]:
+                response["disabled_duplicate_job_ids"] = upsert_metadata["disabled_duplicate_job_ids"]
             if advance_reminder:
                 response["advance_reminder"] = advance_reminder
             return response

--- a/tests/core/scheduler/test_scheduler.py
+++ b/tests/core/scheduler/test_scheduler.py
@@ -696,5 +696,32 @@ async def test_enable_job_recalculates_next_run(scheduler, temp_store):
     assert updated_job.state.next_run_at == future.isoformat()
 
 
+@pytest.mark.asyncio
+async def test_update_job_recalculates_next_run_when_schedule_changes(scheduler, temp_store):
+    """Updating a recurring job schedule should refresh stale next_run_at."""
+    job = CronJob(
+        name="daily-report",
+        schedule=CronSchedule(kind="cron", cron_expr="0 8 * * *"),
+        payload=CronPayload(message="old"),
+        state=CronJobState(next_run_at="2026-01-01T08:00:00+00:00", last_status="error"),
+    )
+
+    await temp_store.add_job(job)
+
+    updated_job = await scheduler.update_job(
+        job.id,
+        schedule=CronSchedule(kind="cron", cron_expr="0 1 * * *"),
+        payload=CronPayload(message="new"),
+        state={"last_status": None, "last_error": None},
+    )
+
+    assert updated_job is not None
+    assert updated_job.schedule.cron_expr == "0 1 * * *"
+    assert updated_job.payload.message == "new"
+    assert updated_job.state.last_status is None
+    assert updated_job.state.next_run_at is not None
+    assert updated_job.state.next_run_at != "2026-01-01T08:00:00+00:00"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tools/test_cron_tool.py
+++ b/tests/tools/test_cron_tool.py
@@ -413,6 +413,132 @@ async def test_cron_tool_normalizes_string_max_runs_and_aworld_agent_name(monkey
 
 
 @pytest.mark.asyncio
+async def test_cron_tool_add_updates_existing_same_name_recurring_job(monkeypatch):
+    """Repeated same-name recurring adds should update instead of appending another active job."""
+    import aworld.tools.cron_tool as cron_tool_module
+    from aworld.core.scheduler.types import CronJob, CronJobState, CronPayload, CronSchedule
+
+    existing_job = CronJob(
+        id="job-existing",
+        name="每日 X AI 资讯摘要",
+        schedule=CronSchedule(kind="cron", cron_expr="0 8 * * *"),
+        payload=CronPayload(message="old message"),
+        state=CronJobState(next_run_at="2026-06-02T08:00:00+00:00", last_status="error"),
+        created_at="2026-05-20T00:00:00+00:00",
+    )
+
+    class FakeScheduler:
+        def __init__(self):
+            self.add_called = False
+            self.updated = []
+
+        async def list_jobs(self, enabled_only=False):
+            assert enabled_only is False
+            return [existing_job]
+
+        async def add_job(self, job):
+            self.add_called = True
+            return job
+
+        async def update_job(self, job_id, **updates):
+            self.updated.append((job_id, updates))
+            existing_job.name = updates.get("name", existing_job.name)
+            existing_job.schedule = updates.get("schedule", existing_job.schedule)
+            existing_job.payload = updates.get("payload", existing_job.payload)
+            existing_job.enabled = updates.get("enabled", existing_job.enabled)
+            existing_job.state.next_run_at = "2026-06-03T01:00:00+00:00"
+            existing_job.state.last_status = updates["state"]["last_status"]
+            return existing_job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        name="每日 X AI 资讯摘要",
+        message="new message",
+        schedule_type="cron",
+        schedule_value="0 1 * * *",
+    )
+
+    assert result["success"] is True
+    assert result["updated_existing"] is True
+    assert result["job_id"] == "job-existing"
+    assert result["next_run"] == "2026-06-03T01:00:00+00:00"
+    assert fake_scheduler.add_called is False
+    assert len(fake_scheduler.updated) == 1
+    update_id, updates = fake_scheduler.updated[0]
+    assert update_id == "job-existing"
+    assert updates["schedule"].cron_expr == "0 1 * * *"
+    assert updates["payload"].message == "new message"
+    assert updates["state"]["last_status"] is None
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_disables_older_same_name_recurring_duplicates(monkeypatch):
+    """If duplicates already exist, adding one same-name recurring job leaves one active copy."""
+    import aworld.tools.cron_tool as cron_tool_module
+    from aworld.core.scheduler.types import CronJob, CronJobState, CronPayload, CronSchedule
+
+    older_job = CronJob(
+        id="job-older",
+        name="每日 X AI 资讯摘要",
+        enabled=True,
+        schedule=CronSchedule(kind="cron", cron_expr="0 8 * * *"),
+        payload=CronPayload(message="old"),
+        state=CronJobState(next_run_at="2026-06-02T08:00:00+00:00"),
+        created_at="2026-05-20T00:00:00+00:00",
+    )
+    newer_job = CronJob(
+        id="job-newer",
+        name="每日X AI资讯摘要",
+        enabled=True,
+        schedule=CronSchedule(kind="cron", cron_expr="0 9 * * *"),
+        payload=CronPayload(message="newer"),
+        state=CronJobState(next_run_at="2026-06-02T09:00:00+00:00"),
+        created_at="2026-05-21T00:00:00+00:00",
+    )
+
+    class FakeScheduler:
+        def __init__(self):
+            self.updated = []
+
+        async def list_jobs(self, enabled_only=False):
+            return [older_job, newer_job]
+
+        async def add_job(self, job):
+            raise AssertionError("same-name recurring add should not append")
+
+        async def update_job(self, job_id, **updates):
+            self.updated.append((job_id, updates))
+            job = newer_job if job_id == "job-newer" else older_job
+            if "enabled" in updates:
+                job.enabled = updates["enabled"]
+            if "schedule" in updates:
+                job.schedule = updates["schedule"]
+            if job_id == "job-newer":
+                job.state.next_run_at = "2026-06-03T01:00:00+00:00"
+            return job
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+
+    result = await cron_tool_module.cron_tool(
+        action="add",
+        name="每日 X AI 资讯摘要",
+        message="canonical task",
+        schedule_type="cron",
+        schedule_value="0 1 * * *",
+    )
+
+    assert result["success"] is True
+    assert result["updated_existing"] is True
+    assert result["job_id"] == "job-newer"
+    assert result["disabled_duplicate_job_ids"] == ["job-older"]
+    assert [item[0] for item in fake_scheduler.updated] == ["job-newer", "job-older"]
+
+
+@pytest.mark.asyncio
 async def test_cron_tool_add_binds_job_to_runtime_default_agent(monkeypatch):
     """Cron add should bind the persisted job to the CLI-selected root agent."""
     from aworld.core.scheduler.types import CronJobState
@@ -434,13 +560,14 @@ async def test_cron_tool_add_binds_job_to_runtime_default_agent(monkeypatch):
 
     fake_scheduler = FakeScheduler()
     monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+    future_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
 
     result = await cron_tool_module.cron_tool(
         action="add",
         name="爬取X最新10条内容",
         message="参考当前目录下twitter_scraper_skill.md skill爬取x上面的内容，存到当前目录。注意爬取最新的10条就行",
         schedule_type="at",
-        schedule_value="2026-05-26T18:32:00+08:00",
+        schedule_value=future_at,
         agent_name="default",
         tools=["bash", "CAST_SEARCH"],
         delete_after_run=True,
@@ -473,13 +600,14 @@ async def test_cron_tool_add_ignores_non_string_runtime_default_agent(monkeypatc
 
     fake_scheduler = FakeScheduler()
     monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+    future_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
 
     result = await cron_tool_module.cron_tool(
         action="add",
         name="喝水提醒",
         message="提醒我喝水",
         schedule_type="at",
-        schedule_value="2026-05-26T18:32:00+08:00",
+        schedule_value=future_at,
         delete_after_run=True,
     )
 
@@ -505,13 +633,14 @@ async def test_cron_tool_add_splits_comma_delimited_tools_for_non_aworld_agent(m
 
     fake_scheduler = FakeScheduler()
     monkeypatch.setattr("aworld.core.scheduler.get_scheduler", lambda: fake_scheduler)
+    future_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
 
     result = await cron_tool_module.cron_tool(
         action="add",
         name="special-agent-task",
         message="run with specific tools",
         schedule_type="at",
-        schedule_value="2026-05-26T18:32:00+08:00",
+        schedule_value=future_at,
         agent_name="SpecialAgent",
         tools="CAST_SEARCH,bash,SKILL",
         delete_after_run=True,
@@ -653,7 +782,7 @@ async def test_cron_tool_enable_all_skips_expired_one_time_history(monkeypatch):
     from aworld.core.scheduler.types import CronJob, CronJobState, CronPayload, CronSchedule
 
     updated_ids = []
-    future_at = "2026-04-30T10:00:00+00:00"
+    future_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
     past_at = "2026-04-10T10:00:00+00:00"
 
     class FakeScheduler:


### PR DESCRIPTION
## Summary
- Upsert same-name recurring cron/every tasks instead of appending duplicates
- Disable older active duplicates when a recurring task is re-added
- Recalculate next_run_at when a job schedule is updated and persist schedule/payload updates safely

## Tests
- pytest tests/tools/test_cron_tool.py tests/core/scheduler/test_scheduler.py