### PR TITLE
feat: add aworld-cli resume support

### DIFF
--- a/aworld-cli/src/aworld_cli/console.py
+++ b/aworld-cli/src/aworld_cli/console.py
@@ -30,6 +30,7 @@ from rich.text import Text
 from aworld.logs.util import logger
 from ._globals import console
 from .core.command_system import CommandRegistry, CommandContext
+from .core.session_restore import SessionRestoreError, restore_session_to_executor
 from .models import AgentInfo
 from .steering.observability import (
     log_applied_steering_event,
@@ -463,7 +464,7 @@ class AWorldCLI:
         builtin_cmds = [
             "/agents", "/skills", "/new", "/restore", "/latest",
             "/exit", "/switch", "/cost", "/cost -all", "/compact",
-            "/team",
+            "/team", "/sessions", "/sessions show",
             "/memory", "/memory view", "/memory reload", "/memory status",
         ]
         builtin_meta = {
@@ -472,6 +473,8 @@ class AWorldCLI:
             "/new": "Create a new session",
             "/restore": "Restore to a previous session",
             "/latest": "Restore to the latest session",
+            "/sessions": "List resumable sessions",
+            "/sessions show": "Show a resumable session",
             "/exit": "Exit chat",
             "/switch": "Switch to another agent",
             "/cost": "View query history (current session)",
@@ -517,6 +520,103 @@ class AWorldCLI:
         words.add("exit")
 
         return sorted(words), meta_dict
+
+    def _format_sessions_list(self, records: list[Any], current_cwd: str | None = None) -> str:
+        if not records:
+            return "No resumable sessions found."
+
+        normalized_cwd = str(Path(current_cwd or os.getcwd()).expanduser().resolve())
+        lines = ["Sessions:"]
+        for record in records:
+            cwd_marker = "current" if getattr(record, "cwd", None) == normalized_cwd else "other"
+            prompt = getattr(record, "last_prompt", None) or "(no prompt recorded)"
+            updated_at = getattr(record, "updated_at", "")
+            lines.append(
+                f"- {record.session_id} | {record.agent_name} | {record.mode} | "
+                f"{cwd_marker} | {updated_at} | {prompt}"
+            )
+        return "\n".join(lines)
+
+    def _format_session_show(self, record: Any) -> str:
+        lines = [
+            f"Session: {record.session_id}",
+            f"Agent: {record.agent_name}",
+            f"Mode: {record.mode}",
+            f"CWD: {record.cwd}",
+            f"Created: {record.created_at}",
+            f"Updated: {record.updated_at}",
+            f"Turns: {record.turn_count}",
+        ]
+        if getattr(record, "source_type", None):
+            lines.append(f"Source: {record.source_type}")
+        if getattr(record, "source_location", None):
+            lines.append(f"Source location: {record.source_location}")
+        if getattr(record, "last_task_id", None):
+            lines.append(f"Last task: {record.last_task_id}")
+        if getattr(record, "last_prompt", None):
+            lines.append(f"Last prompt: {record.last_prompt}")
+        return "\n".join(lines)
+
+    def _format_resume_command_hint(self, executor_instance: Any = None) -> str | None:
+        session_id = getattr(executor_instance, "session_id", None)
+        if not session_id:
+            return None
+        return f"Resume this session with: aworld-cli resume {session_id}"
+
+    def _print_resume_command_hint(self, executor_instance: Any = None) -> None:
+        hint = self._format_resume_command_hint(executor_instance)
+        if hint:
+            self.console.print(f"[dim]{hint}[/dim]")
+
+    def _consume_restored_transcript_text(self, executor_instance: Any = None) -> str | None:
+        replay = getattr(executor_instance, "_aworld_cli_restored_transcript", None)
+        if replay is None:
+            return None
+        try:
+            executor_instance._aworld_cli_restored_transcript = None
+        except Exception:
+            pass
+        rendered = getattr(replay, "rendered_text", None)
+        return str(rendered).strip() if rendered else None
+
+    def _print_restored_transcript(self, executor_instance: Any = None) -> None:
+        rendered = self._consume_restored_transcript_text(executor_instance)
+        if rendered:
+            self.console.print(rendered)
+            self.console.print()
+
+    def _restore_cli_session(
+        self,
+        session_id: str,
+        *,
+        executor_instance: Any,
+        current_agent_name: str,
+        session_store: Any,
+    ) -> str:
+        if executor_instance is None:
+            return "[yellow]No executor instance available.[/yellow]"
+
+        record = session_store.get(session_id)
+        if record is None:
+            return f"[red]Session not found: {session_id}[/red]"
+
+        try:
+            result = restore_session_to_executor(
+                record=record,
+                executor_instance=executor_instance,
+                current_agent_name=current_agent_name,
+                session_store=session_store,
+            )
+        except SessionRestoreError as exc:
+            return f"[yellow]{exc}[/yellow]"
+
+        message = f"[green]{result.message}[/green]"
+        if result.warning:
+            message = f"{message}\n[yellow]{result.warning}[/yellow]"
+        restored_transcript = self._consume_restored_transcript_text(executor_instance)
+        if restored_transcript:
+            message = f"{message}\n\n{restored_transcript}"
+        return message
 
     def _build_session_completer(
         self,
@@ -3360,7 +3460,7 @@ class AWorldCLI:
             current_agent = next((a for a in available_agents if a.name == agent_name), None)
             if current_agent and current_agent.metadata:
                 metadata = current_agent.metadata
-                
+
                 # Check PTC status - only show if enabled
                 ptc_tools = metadata.get("ptc_tools", [])
                 ptc_info = ""
@@ -3405,6 +3505,7 @@ class AWorldCLI:
         # Display welcome message with configuration details
         self.console.print(f"Starting chat with [bold]{agent_name}[/bold].{session_id_info}{config_info}{skill_info}")
         self.console.print("[dim]Type /help for available commands.[/dim]\n")
+        self._print_restored_transcript(executor_instance)
 
         # Build help text with both built-in and registered commands
         help_lines = [
@@ -3537,6 +3638,7 @@ class AWorldCLI:
                                     user_args=cmd_args,
                                     sandbox=None,  # TODO: Pass actual sandbox if available
                                     agent_config=None,  # TODO: Pass agent config if needed
+                                    executor=executor_instance,
                                     runtime=runtime,
                                     session_id=getattr(executor_instance, "session_id", None),
                                 )
@@ -3562,6 +3664,7 @@ class AWorldCLI:
                                             user_args=cmd_args,
                                             sandbox=None,
                                             agent_config=None,
+                                            executor=executor_instance,
                                             runtime=runtime,
                                             session_id=new_session_id,
                                         )
@@ -3656,6 +3759,7 @@ class AWorldCLI:
                                 follow_up_prompt=follow_up_prompt,
                             )
                         continue
+                    self._print_resume_command_hint(executor_instance)
                     self.console.print("[dim]Bye[/dim]")
                     await self._stop_notification_poller()
                     return False
@@ -3677,13 +3781,35 @@ class AWorldCLI:
                     continue
                 
                 # Handle restore session command
-                if user_input.lower() in ("/restore", "restore", "/latest", "latest"):
-                    if executor_instance and hasattr(executor_instance, 'restore_session'):
-                        restored_id = executor_instance.restore_session()
-                        # Update session_id_info display
-                        self.console.print(f"[dim]Current session: {restored_id}[/dim]")
-                    else:
-                        self.console.print("[yellow]⚠️ Session restore not available for this executor.[/yellow]")
+                restore_input = user_input.strip()
+                restore_lower = restore_input.lower()
+                if (
+                    restore_lower in ("/restore", "restore", "/latest", "latest")
+                    or restore_lower.startswith("/restore ")
+                    or restore_lower.startswith("restore ")
+                ):
+                    try:
+                        from .core.session_store import CliSessionStore
+
+                        session_store = CliSessionStore()
+                        parts = restore_input.split(maxsplit=1)
+                        requested_id = parts[1].strip() if len(parts) > 1 and "latest" not in restore_lower else None
+                        if requested_id is None:
+                            record = session_store.latest(cwd=os.getcwd())
+                            requested_id = record.session_id if record else None
+                        if requested_id is None:
+                            self.console.print("[yellow]No resumable sessions found.[/yellow]")
+                        else:
+                            self.console.print(
+                                self._restore_cli_session(
+                                    requested_id,
+                                    executor_instance=executor_instance,
+                                    current_agent_name=agent_name,
+                                    session_store=session_store,
+                                )
+                            )
+                    except Exception as e:
+                        self.console.print(f"[red]Error restoring session: {e}[/red]")
                     continue
                 
                 # Handle switch command
@@ -3980,20 +4106,34 @@ class AWorldCLI:
                     continue
 
                 # Handle sessions command
-                if user_input.lower() in ("/sessions", "sessions"):
-                    if executor_instance:
-                        # Debug: Print session related attributes
-                        session_attrs = {k: v for k, v in executor_instance.__dict__.items() if 'session' in k.lower()}
-                        # Also check if context has session info
-                        if hasattr(executor_instance, 'context') and executor_instance.context:
-                            context_session_attrs = {k: v for k, v in executor_instance.context.__dict__.items() if
-                                                     'session' in k.lower()}
-                            session_attrs.update({f"context.{k}": v for k, v in context_session_attrs.items()})
+                if user_input.lower() in ("/sessions", "sessions", "/sessions list", "sessions list"):
+                    try:
+                        from .core.session_store import CliSessionStore
 
-                        if session_attrs:
-                            self.console.print(f"[dim]Session Info: {session_attrs}[/dim]")
-                    else:
-                        self.console.print("[yellow]No executor instance available.[/yellow]")
+                        session_store = CliSessionStore()
+                        self.console.print(
+                            self._format_sessions_list(
+                                session_store.list(cwd=os.getcwd()),
+                                current_cwd=os.getcwd(),
+                            )
+                        )
+                    except Exception as e:
+                        self.console.print(f"[red]Error listing sessions: {e}[/red]")
+                    continue
+
+                if user_input.lower().startswith(("/sessions show ", "sessions show ")):
+                    try:
+                        from .core.session_store import CliSessionStore
+
+                        session_id = user_input.split(maxsplit=2)[2].strip()
+                        session_store = CliSessionStore()
+                        record = session_store.get(session_id)
+                        if record is None:
+                            self.console.print(f"[red]Session not found: {session_id}[/red]")
+                        else:
+                            self.console.print(self._format_session_show(record))
+                    except Exception as e:
+                        self.console.print(f"[red]Error showing session: {e}[/red]")
                     continue
 
                 # Print agent name before response
@@ -4064,6 +4204,7 @@ class AWorldCLI:
                             )
                         continue
                     logger.info("\n[yellow]Interrupted. Exiting...[/yellow]")
+                    self._print_resume_command_hint(executor_instance)
                     self.console.print("[dim]Bye[/dim]")
                     await self._stop_notification_poller()
                     return False  # Exit CLI when buffer is empty

--- a/aworld-cli/src/aworld_cli/core/command_system.py
+++ b/aworld-cli/src/aworld_cli/core/command_system.py
@@ -31,6 +31,7 @@ class CommandContext:
     user_args: str
     sandbox: Optional[Any] = None
     agent_config: Optional[Any] = None
+    executor: Optional[Any] = None
     runtime: Optional[Any] = None
     session_id: Optional[str] = None
 
@@ -39,6 +40,18 @@ class CommandContext:
         if not self.cwd:
             import os
             self.cwd = os.getcwd()
+
+    @property
+    def background_task_manager(self) -> Optional[Any]:
+        """
+        Get background task manager from executor.
+
+        Returns:
+            BackgroundTaskManager instance or None if executor not available
+        """
+        if self.executor and hasattr(self.executor, 'background_task_manager'):
+            return self.executor.background_task_manager
+        return None
 
 
 class Command(ABC):

--- a/aworld-cli/src/aworld_cli/core/session_restore.py
+++ b/aworld-cli/src/aworld_cli/core/session_restore.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .session_store import CliSessionRecord, CliSessionStore
+from .session_transcript import CliSessionTranscript
+
+
+@dataclass(frozen=True)
+class SessionRestoreResult:
+    record: CliSessionRecord
+    message: str
+    warning: str | None = None
+
+
+class SessionRestoreError(Exception):
+    """Raised when a stored session cannot be restored to an executor."""
+
+
+def resolve_session_record(
+    *,
+    session_store: CliSessionStore,
+    session_id: str | None,
+    cwd: str,
+    use_latest: bool = False,
+    include_all_cwds: bool = False,
+    include_non_interactive: bool = False,
+) -> CliSessionRecord | None:
+    if session_id:
+        return session_store.get(session_id)
+    if use_latest:
+        return session_store.latest(
+            cwd=cwd,
+            include_all_cwds=include_all_cwds,
+            include_non_interactive=include_non_interactive,
+        )
+    return None
+
+
+def restore_session_to_executor(
+    *,
+    record: CliSessionRecord,
+    executor_instance: Any,
+    session_store: CliSessionStore,
+    current_agent_name: str | None = None,
+    current_cwd: str | None = None,
+    require_same_agent: bool = True,
+) -> SessionRestoreResult:
+    if executor_instance is None:
+        raise SessionRestoreError("No executor instance available.")
+
+    if (
+        require_same_agent
+        and record.agent_name
+        and current_agent_name
+        and record.agent_name != current_agent_name
+    ):
+        raise SessionRestoreError(
+            f"Session {record.session_id} belongs to agent {record.agent_name}. "
+            "Switch to that agent before restoring."
+        )
+
+    executor_instance.session_id = record.session_id
+    try:
+        transcript = CliSessionTranscript(root=session_store.root)
+        replay = transcript.build_replay(record.session_id)
+        executor_instance._aworld_cli_restored_transcript = replay
+        executor_instance._aworld_cli_restored_messages = transcript.render_for_openai_messages(record.session_id)
+    except Exception:
+        executor_instance._aworld_cli_restored_transcript = None
+        executor_instance._aworld_cli_restored_messages = []
+
+    if hasattr(executor_instance, "_start_tool_logging"):
+        try:
+            executor_instance._start_tool_logging()
+        except Exception:
+            pass
+
+    runtime = getattr(executor_instance, "_base_runtime", None)
+    if runtime is not None and hasattr(runtime, "reset_hud_session"):
+        try:
+            runtime.reset_hud_session(record.session_id)
+        except Exception:
+            pass
+
+    session_store.touch(record.session_id)
+    warnings = []
+    if current_cwd:
+        normalized_current = str(Path(current_cwd).expanduser().resolve())
+        if record.cwd != normalized_current:
+            warnings.append(
+                f"Session {record.session_id} belongs to {record.cwd}; current cwd is {normalized_current}. "
+                "Continuing because the session id was explicit."
+            )
+    context_warning = session_store.context_warning(record)
+    if context_warning:
+        warnings.append(context_warning)
+    return SessionRestoreResult(
+        record=record,
+        message=f"Restored to session: {record.session_id}",
+        warning="\n".join(warnings) if warnings else None,
+    )

--- a/aworld-cli/src/aworld_cli/core/session_store.py
+++ b/aworld-cli/src/aworld_cli/core/session_store.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SESSION_INDEX_RELATIVE_PATH = Path(".aworld") / "sessions" / "index.json"
+LEGACY_SESSION_HISTORY_RELATIVE_PATH = Path(".aworld") / "workspaces" / ".session_history.json"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_cwd(cwd: str | os.PathLike[str] | None) -> str:
+    return str(Path(cwd or os.getcwd()).expanduser().resolve())
+
+
+def default_session_store_root() -> Path:
+    override = os.environ.get("AWORLD_CLI_SESSION_STORE_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+@contextmanager
+def _locked_index_file(index_path: Path):
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = index_path.with_name(f"{index_path.name}.lock")
+    with lock_path.open("a+b") as lock_handle:
+        try:
+            import fcntl
+
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        except ImportError:
+            fcntl = None
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+@dataclass
+class CliSessionRecord:
+    session_id: str
+    created_at: str
+    updated_at: str
+    cwd: str
+    agent_name: str
+    mode: str
+    source_type: str | None = None
+    source_location: str | None = None
+    title: str | None = None
+    last_prompt: str | None = None
+    last_task_id: str | None = None
+    turn_count: int = 0
+    archived: bool = False
+    deleted_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.cwd = normalize_cwd(self.cwd)
+        self.mode = self.mode or "interactive"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "cwd": self.cwd,
+            "agent_name": self.agent_name,
+            "mode": self.mode,
+            "source_type": self.source_type,
+            "source_location": self.source_location,
+            "title": self.title,
+            "last_prompt": self.last_prompt,
+            "last_task_id": self.last_task_id,
+            "turn_count": self.turn_count,
+            "archived": self.archived,
+            "deleted_at": self.deleted_at,
+            "metadata": dict(self.metadata or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CliSessionRecord":
+        now = utc_now_iso()
+        return cls(
+            session_id=str(data["session_id"]),
+            created_at=str(data.get("created_at") or now),
+            updated_at=str(data.get("updated_at") or data.get("last_used_at") or now),
+            cwd=str(data.get("cwd") or os.getcwd()),
+            agent_name=str(data.get("agent_name") or "Aworld"),
+            mode=str(data.get("mode") or "interactive"),
+            source_type=data.get("source_type"),
+            source_location=data.get("source_location"),
+            title=data.get("title"),
+            last_prompt=data.get("last_prompt"),
+            last_task_id=data.get("last_task_id"),
+            turn_count=int(data.get("turn_count") or 0),
+            archived=bool(data.get("archived") or False),
+            deleted_at=data.get("deleted_at"),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+class CliSessionStore:
+    def __init__(self, root: str | os.PathLike[str] | None = None) -> None:
+        self.root = Path(root).expanduser().resolve() if root is not None else default_session_store_root()
+        self.index_path = self.root / SESSION_INDEX_RELATIVE_PATH
+        self._records: dict[str, CliSessionRecord] = {}
+        self._load()
+
+    def _load(self) -> None:
+        records = self._read_index_records()
+        if records:
+            self._records = records
+            return
+        if self.index_path.exists():
+            self._records = {}
+            return
+
+        self._import_legacy_if_available()
+
+    def _read_index_records(self) -> dict[str, CliSessionRecord]:
+        if not self.index_path.exists():
+            return {}
+        records: dict[str, CliSessionRecord] = {}
+        try:
+            payload = json.loads(self.index_path.read_text(encoding="utf-8"))
+            for raw in payload.get("sessions", []):
+                record = CliSessionRecord.from_dict(raw)
+                if not record.deleted_at:
+                    records[record.session_id] = record
+        except Exception:
+            return {}
+        return records
+
+    def _import_legacy_if_available(self) -> None:
+        legacy_path = self.root / LEGACY_SESSION_HISTORY_RELATIVE_PATH
+        if not legacy_path.exists():
+            return
+        try:
+            payload = json.loads(legacy_path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+
+        for session_id, raw in payload.items():
+            if not isinstance(raw, dict):
+                continue
+            created_at = str(raw.get("created_at") or utc_now_iso())
+            updated_at = str(raw.get("last_used_at") or raw.get("updated_at") or created_at)
+            record = CliSessionRecord(
+                session_id=str(raw.get("session_id") or session_id),
+                created_at=created_at,
+                updated_at=updated_at,
+                cwd=str(self.root),
+                agent_name=str(raw.get("agent_name") or "Aworld"),
+                mode=str(raw.get("mode") or "interactive"),
+                metadata={"imported_from": str(LEGACY_SESSION_HISTORY_RELATIVE_PATH)},
+            )
+            self._records[record.session_id] = record
+        if self._records:
+            self._save()
+
+    def _save(self, dirty_session_ids: set[str] | None = None) -> None:
+        dirty_session_ids = set(dirty_session_ids or self._records.keys())
+        with _locked_index_file(self.index_path):
+            merged_records = self._read_index_records()
+            for session_id in dirty_session_ids:
+                record = self._records.get(session_id)
+                if record is None:
+                    continue
+                if record.deleted_at:
+                    merged_records.pop(session_id, None)
+                else:
+                    merged_records[session_id] = record
+            payload = {
+                "version": 1,
+                "updated_at": utc_now_iso(),
+                "sessions": [
+                    record.to_dict()
+                    for record in sorted(merged_records.values(), key=lambda item: item.updated_at)
+                ],
+            }
+            temp_path = self.index_path.with_name(
+                f"{self.index_path.name}.{os.getpid()}.{id(self)}.tmp"
+            )
+            temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(temp_path, self.index_path)
+            self._records = merged_records
+
+    def upsert_session(self, record: CliSessionRecord) -> CliSessionRecord:
+        self._records[record.session_id] = record
+        self._save({record.session_id})
+        return record
+
+    def ensure_session(
+        self,
+        *,
+        session_id: str,
+        cwd: str | None,
+        agent_name: str,
+        mode: str = "interactive",
+        source_type: str | None = None,
+        source_location: str | None = None,
+    ) -> CliSessionRecord:
+        existing = self._records.get(session_id)
+        now = utc_now_iso()
+        if existing is not None:
+            existing.cwd = normalize_cwd(cwd or existing.cwd)
+            existing.agent_name = agent_name or existing.agent_name
+            existing.mode = mode or existing.mode
+            existing.source_type = source_type if source_type is not None else existing.source_type
+            existing.source_location = (
+                source_location if source_location is not None else existing.source_location
+            )
+            existing.updated_at = now
+            self._save({existing.session_id})
+            return existing
+
+        return self.upsert_session(
+            CliSessionRecord(
+                session_id=session_id,
+                created_at=now,
+                updated_at=now,
+                cwd=normalize_cwd(cwd),
+                agent_name=agent_name or "Aworld",
+                mode=mode or "interactive",
+                source_type=source_type,
+                source_location=source_location,
+            )
+        )
+
+    def record_turn(
+        self,
+        *,
+        session_id: str,
+        cwd: str,
+        agent_name: str,
+        mode: str,
+        prompt: str,
+        task_id: str | None,
+        source_type: str | None,
+        source_location: str | None,
+    ) -> CliSessionRecord:
+        now = utc_now_iso()
+        record = self._records.get(session_id)
+        if record is None:
+            record = CliSessionRecord(
+                session_id=session_id,
+                created_at=now,
+                updated_at=now,
+                cwd=normalize_cwd(cwd),
+                agent_name=agent_name or "Aworld",
+                mode=mode or "interactive",
+                source_type=source_type,
+                source_location=source_location,
+            )
+        record.updated_at = now
+        record.cwd = normalize_cwd(cwd)
+        record.agent_name = agent_name or record.agent_name
+        record.mode = mode or record.mode
+        record.source_type = source_type if source_type is not None else record.source_type
+        record.source_location = source_location if source_location is not None else record.source_location
+        record.last_prompt = self._prompt_preview(prompt)
+        record.last_task_id = task_id
+        record.turn_count += 1
+        self._records[record.session_id] = record
+        self._save({record.session_id})
+        return record
+
+    def touch(self, session_id: str) -> CliSessionRecord | None:
+        record = self._records.get(session_id)
+        if record is None:
+            return None
+        record.updated_at = utc_now_iso()
+        self._save({record.session_id})
+        return record
+
+    def get(self, session_id: str) -> CliSessionRecord | None:
+        return self._records.get(session_id)
+
+    def list(
+        self,
+        *,
+        cwd: str | None,
+        include_all_cwds: bool = False,
+        include_non_interactive: bool = False,
+        include_archived: bool = False,
+    ) -> list[CliSessionRecord]:
+        normalized = normalize_cwd(cwd) if cwd else None
+        records = []
+        for record in self._records.values():
+            if record.deleted_at:
+                continue
+            if record.archived and not include_archived:
+                continue
+            if record.mode != "interactive" and not include_non_interactive:
+                continue
+            if not include_all_cwds and normalized is not None and record.cwd != normalized:
+                continue
+            records.append(record)
+        return sorted(records, key=lambda item: item.updated_at, reverse=True)
+
+    def latest(
+        self,
+        *,
+        cwd: str | None,
+        include_all_cwds: bool = False,
+        include_non_interactive: bool = False,
+    ) -> CliSessionRecord | None:
+        records = self.list(
+            cwd=cwd,
+            include_all_cwds=include_all_cwds,
+            include_non_interactive=include_non_interactive,
+        )
+        return records[0] if records else None
+
+    def context_warning(self, record: CliSessionRecord) -> str | None:
+        artifact = (record.metadata or {}).get("context_artifact")
+        artifacts = [artifact] if artifact else []
+        if not artifacts and record.turn_count > 0:
+            artifacts = self._default_context_artifacts(record.session_id)
+        if not artifacts:
+            return None
+        for candidate in artifacts:
+            artifact_path = Path(candidate)
+            if not artifact_path.is_absolute():
+                artifact_path = self.root / artifact_path
+            if artifact_path.exists():
+                return None
+        artifact = artifacts[0]
+        return (
+            f"Session {record.session_id} is missing context artifact {artifact}; "
+            "resume will continue with limited context."
+        )
+
+    @staticmethod
+    def _safe_session_filename(session_id: str) -> str:
+        safe_id = "".join(c for c in str(session_id) if c.isalnum() or c in ("-", "_")).strip()
+        return safe_id or "default"
+
+    def _default_context_artifacts(self, session_id: str) -> list[str]:
+        safe_id = self._safe_session_filename(session_id)
+        artifacts = [str(Path(".aworld") / "memory" / "sessions" / f"{safe_id}.jsonl")]
+        runtime_root = os.environ.get("AWORLD_MEMORY_ROOT")
+        if runtime_root:
+            artifacts.append(str(Path(runtime_root).expanduser() / "sessions" / f"{safe_id}.jsonl"))
+        else:
+            artifacts.append(str(Path.home() / ".aworld" / "memory" / "sessions" / f"{safe_id}.jsonl"))
+        return artifacts
+
+    @staticmethod
+    def _prompt_preview(prompt: str, limit: int = 200) -> str:
+        normalized = " ".join(str(prompt or "").split())
+        if len(normalized) <= limit:
+            return normalized
+        return normalized[: limit - 3].rstrip() + "..."

--- a/aworld-cli/src/aworld_cli/core/session_transcript.py
+++ b/aworld-cli/src/aworld_cli/core/session_transcript.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+TRANSCRIPT_RELATIVE_DIR = Path(".aworld") / "sessions" / "transcripts"
+MODEL_CONTEXT_MAX_CHARS = 12000
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_session_filename(session_id: str) -> str:
+    safe_id = "".join(c for c in str(session_id) if c.isalnum() or c in ("-", "_")).strip()
+    return safe_id or "default"
+
+
+@dataclass(frozen=True)
+class TranscriptReplay:
+    session_id: str
+    rendered_text: str
+    source: str
+
+
+class CliSessionTranscript:
+    """Durable CLI-visible transcript used to repaint a resumed terminal."""
+
+    def __init__(
+        self,
+        root: str | os.PathLike[str] | None = None,
+        history_path: str | os.PathLike[str] | None = None,
+    ) -> None:
+        self.root = Path(root).expanduser().resolve() if root is not None else Path.cwd().resolve()
+        self.history_path = (
+            Path(history_path).expanduser().resolve()
+            if history_path is not None
+            else Path.home() / ".aworld" / "cli_history.jsonl"
+        )
+
+    def path_for(self, session_id: str) -> Path:
+        return self.root / TRANSCRIPT_RELATIVE_DIR / f"{_safe_session_filename(session_id)}.jsonl"
+
+    def record_turn(
+        self,
+        *,
+        session_id: str,
+        user_input: str,
+        assistant_output: str,
+        agent_name: str,
+        task_id: str | None = None,
+    ) -> None:
+        if not session_id:
+            return
+        if not str(assistant_output or "").strip():
+            return
+        now = _utc_now_iso()
+        events = [
+            {
+                "recorded_at": now,
+                "event": "user",
+                "session_id": session_id,
+                "task_id": task_id,
+                "content": str(user_input or ""),
+            },
+            {
+                "recorded_at": now,
+                "event": "assistant",
+                "session_id": session_id,
+                "task_id": task_id,
+                "agent_name": agent_name or "Assistant",
+                "content": str(assistant_output or ""),
+            },
+        ]
+        path = self.path_for(session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("ab") as handle:
+            for event in events:
+                handle.write(json.dumps(event, ensure_ascii=False).encode("utf-8") + b"\n")
+
+    def build_replay(self, session_id: str) -> TranscriptReplay | None:
+        rendered = self.render_for_terminal(session_id)
+        if not rendered:
+            return None
+        source = "transcript" if self.path_for(session_id).exists() else "legacy"
+        return TranscriptReplay(session_id=session_id, rendered_text=rendered, source=source)
+
+    def render_for_terminal(self, session_id: str) -> str:
+        transcript_events = self._read_transcript_events(session_id)
+        legacy_events = self._recover_legacy_events(session_id)
+        events = self._dedupe_events(legacy_events + transcript_events)
+        if events and transcript_events:
+            return self._render_events(events, title="Previous session transcript")
+        if events:
+            return self._render_events(
+                events,
+                title="Recovered from session history and memory",
+            )
+        return ""
+
+    def render_for_openai_messages(
+        self,
+        session_id: str,
+        *,
+        max_chars: int = MODEL_CONTEXT_MAX_CHARS,
+    ) -> list[dict[str, str]]:
+        events = self._dedupe_events(
+            self._recover_legacy_events(session_id) + self._read_transcript_events(session_id)
+        )
+        messages: list[dict[str, str]] = []
+        total_chars = 0
+        for event in reversed(events):
+            kind = str(event.get("event") or "")
+            if kind not in ("user", "assistant"):
+                continue
+            content = str(event.get("content") or "").strip()
+            if not content:
+                continue
+            total_chars += len(content)
+            if total_chars > max_chars and messages:
+                break
+            messages.append({"role": kind, "content": content})
+        return list(reversed(messages))
+
+    @staticmethod
+    def _dedupe_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        deduped: list[dict[str, Any]] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        rich_content_keys = {
+            (str(event.get("event") or ""), str(event.get("content") or "").strip())
+            for event in events
+            if str(event.get("content") or "").strip()
+            and (str(event.get("task_id") or "") or str(event.get("recorded_at") or ""))
+        }
+        dangling_task_ids = {
+            str(event.get("task_id") or "")
+            for event in events
+            if str(event.get("event") or "") == "assistant"
+            and not str(event.get("content") or "").strip()
+            and str(event.get("task_id") or "")
+        }
+        for event in events:
+            kind = str(event.get("event") or "")
+            content = str(event.get("content") or "").strip()
+            if not content:
+                continue
+            if kind == "user" and str(event.get("task_id") or "") in dangling_task_ids:
+                continue
+            if (
+                not str(event.get("task_id") or "")
+                and not str(event.get("recorded_at") or "")
+                and (kind, content) in rich_content_keys
+            ):
+                continue
+            key = (
+                kind,
+                content,
+                str(event.get("task_id") or ""),
+                str(event.get("recorded_at") or ""),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(event)
+        return deduped
+
+    def _read_transcript_events(self, session_id: str) -> list[dict[str, Any]]:
+        path = self.path_for(session_id)
+        if not path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("session_id") == session_id:
+                    events.append(event)
+        except OSError:
+            return []
+        return events
+
+    def _recover_legacy_events(self, session_id: str) -> list[dict[str, Any]]:
+        users = self._read_legacy_user_inputs(session_id)
+        answers = self._read_session_memory_answers(session_id)
+        events: list[dict[str, Any]] = []
+        used_user_indexes: set[int] = set()
+        previous_answer_ts = -1
+        for answer_ts, answer in answers:
+            user_index = self._find_user_for_answer(
+                users,
+                used_user_indexes=used_user_indexes,
+                previous_answer_ts=previous_answer_ts,
+                answer_ts=answer_ts,
+            )
+            if user_index is not None:
+                used_user_indexes.add(user_index)
+                events.append(
+                    {
+                        "event": "user",
+                        "session_id": session_id,
+                        "content": users[user_index][1],
+                    }
+                )
+            events.append(
+                {
+                    "event": "assistant",
+                    "session_id": session_id,
+                    "agent_name": "Aworld",
+                    "content": answer,
+                }
+            )
+            previous_answer_ts = answer_ts
+        for index, (timestamp, prompt) in enumerate(users):
+            if index in used_user_indexes:
+                continue
+            if timestamp <= previous_answer_ts:
+                continue
+            events.append(
+                {
+                    "event": "user",
+                    "session_id": session_id,
+                    "content": prompt,
+                }
+            )
+        return events
+
+    @staticmethod
+    def _find_user_for_answer(
+        users: list[tuple[int, str]],
+        *,
+        used_user_indexes: set[int],
+        previous_answer_ts: int,
+        answer_ts: int,
+    ) -> int | None:
+        candidates = [
+            index
+            for index, (timestamp, _) in enumerate(users)
+            if index not in used_user_indexes and previous_answer_ts < timestamp <= answer_ts
+        ]
+        if candidates:
+            return candidates[-1]
+        for index, _ in enumerate(users):
+            if index not in used_user_indexes:
+                return index
+        return None
+
+    def _read_legacy_user_inputs(self, session_id: str) -> list[tuple[int, str]]:
+        if not self.history_path.exists():
+            return []
+        prompts: list[tuple[int, str]] = []
+        try:
+            for line in self.history_path.read_text(encoding="utf-8").splitlines():
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if record.get("sessionId") != session_id:
+                    continue
+                display = str(record.get("display") or "").strip()
+                if display:
+                    prompts.append((int(record.get("timestamp") or 0), display))
+        except OSError:
+            return []
+        return sorted(prompts, key=lambda item: item[0])
+
+    def _read_session_memory_answers(self, session_id: str) -> list[tuple[int, str]]:
+        answers: list[tuple[int, str]] = []
+        for path in self._session_memory_paths(session_id):
+            if not path.exists():
+                continue
+            try:
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if record.get("session_id") != session_id:
+                        continue
+                    if record.get("event") != "task_completed":
+                        continue
+                    answer = str(record.get("final_answer") or "").strip()
+                    if answer:
+                        answers.append((self._timestamp_ms(record.get("recorded_at")), answer))
+            except OSError:
+                continue
+            if answers:
+                break
+        return sorted(answers, key=lambda item: item[0])
+
+    @staticmethod
+    def _timestamp_ms(value: Any) -> int:
+        if isinstance(value, (int, float)):
+            return int(value)
+        if not value:
+            return 0
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return 0
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return int(parsed.timestamp() * 1000)
+
+    def _session_memory_paths(self, session_id: str) -> list[Path]:
+        filename = f"{_safe_session_filename(session_id)}.jsonl"
+        paths = [self.root / ".aworld" / "memory" / "sessions" / filename]
+        runtime_root = os.environ.get("AWORLD_MEMORY_ROOT")
+        if runtime_root:
+            paths.append(Path(runtime_root).expanduser() / "sessions" / filename)
+        paths.append(Path.home() / ".aworld" / "memory" / "sessions" / filename)
+        return paths
+
+    @staticmethod
+    def _render_events(events: list[dict[str, Any]], *, title: str) -> str:
+        lines = [f"── {title} ──"]
+        for event in events:
+            kind = event.get("event")
+            content = str(event.get("content") or "").strip()
+            if not content:
+                continue
+            if kind == "user":
+                lines.append(f"You: {content}")
+            elif kind == "assistant":
+                agent_name = str(event.get("agent_name") or "Assistant").strip() or "Assistant"
+                lines.append(f"{agent_name}:")
+                lines.append(content)
+            elif kind == "system":
+                lines.append(content)
+            lines.append("")
+        return "\n".join(lines).rstrip()

--- a/aworld-cli/src/aworld_cli/executors/continuous.py
+++ b/aworld-cli/src/aworld_cli/executors/continuous.py
@@ -123,6 +123,7 @@ class ContinuousExecutor:
         prompt: Union[str, tuple[str, List[str]]],
         completion_signal: Optional[str] = None,
         agent_name: Optional[str] = None,
+        show_iteration_header: bool = True,
         **chat_kwargs,
     ) -> Dict[str, Any]:
         """
@@ -138,7 +139,8 @@ class ContinuousExecutor:
         """
 
         session_id = getattr(self.agent_executor, 'session_id', 'unknown')
-        self.console.print(f"\n[bold cyan]🔄({iteration}) Starting iteration  session: {session_id}[/bold cyan]")
+        if show_iteration_header:
+            self.console.print(f"\n[bold cyan]🔄({iteration}) Starting iteration  session: {session_id}[/bold cyan]")
         
         try:
             # Ensure agent_executor uses the same console for output rendering
@@ -320,6 +322,9 @@ class ContinuousExecutor:
         max_duration: Optional[str] = None,
         completion_signal: Optional[str] = None,
         completion_threshold: int = 3,
+        show_start_banner: bool = True,
+        show_iteration_header: bool = True,
+        echo_prompt_as_turn: bool = False,
         **kwargs
     ) -> Dict[str, Any]:
         """
@@ -360,27 +365,29 @@ class ContinuousExecutor:
         else:
             prompt_display = prompt
         
-        # Display start banner with adaptive layout
-        from rich.table import Table
-        from rich import box
+        if echo_prompt_as_turn:
+            self.console.print(f"You: {prompt_display}")
+            self.console.print()
 
-        start_table = Table(show_header=False, box=None, padding=(0, 1))
-        start_table.add_column("Label", style="bold", no_wrap=True)
-        start_table.add_column("Value", style="cyan")
+        if show_start_banner:
+            # Display start banner with adaptive layout
+            start_table = Table(show_header=False, box=None, padding=(0, 1))
+            start_table.add_column("Label", style="bold", no_wrap=True)
+            start_table.add_column("Value", style="cyan")
 
-        start_table.add_row("Mode", "Continuous Execution")
-        start_table.add_row("Agent", f"[cyan]{agent_name}[/cyan]")
-        start_table.add_row("Prompt", f"[yellow]{prompt_display}[/yellow]")
-        start_table.add_row("Max Runs", str(max_runs if max_runs else '∞'))
-        start_table.add_row("Max Cost", f"${max_cost if max_cost else '∞'}")
-        start_table.add_row("Max Duration", str(max_duration if max_duration else '∞'))
+            start_table.add_row("Mode", "Continuous Execution")
+            start_table.add_row("Agent", f"[cyan]{agent_name}[/cyan]")
+            start_table.add_row("Prompt", f"[yellow]{prompt_display}[/yellow]")
+            start_table.add_row("Max Runs", str(max_runs if max_runs else '∞'))
+            start_table.add_row("Max Cost", f"${max_cost if max_cost else '∞'}")
+            start_table.add_row("Max Duration", str(max_duration if max_duration else '∞'))
 
-        self.console.print(Panel(
-            start_table,
-            title="🚀 Starting",
-            border_style="blue",
-            expand=False
-        ))
+            self.console.print(Panel(
+                start_table,
+                title="🚀 Starting",
+                border_style="blue",
+                expand=False
+            ))
         
         iteration = 0
         consecutive_completions = 0
@@ -409,6 +416,7 @@ class ContinuousExecutor:
                     prompt,
                     completion_signal,
                     agent_name=agent_name,
+                    show_iteration_header=show_iteration_header,
                     **kwargs,
                 )
                 results.append(result)

--- a/aworld-cli/src/aworld_cli/executors/local.py
+++ b/aworld-cli/src/aworld_cli/executors/local.py
@@ -119,6 +119,27 @@ class LocalAgentExecutor(BaseAgentExecutor):
         )
         self._last_task_progress_hook_at: float | None = None
 
+    def _record_cli_session_transcript_turn(
+        self,
+        *,
+        task_content: str,
+        answer: str,
+        task_id: str | None,
+    ) -> None:
+        try:
+            from aworld_cli.core.session_transcript import CliSessionTranscript
+
+            agent_name = getattr(getattr(self.swarm, "conf", None), "name", None) or "Aworld"
+            CliSessionTranscript().record_turn(
+                session_id=self.session_id,
+                user_input=task_content,
+                assistant_output=answer,
+                agent_name=agent_name,
+                task_id=task_id,
+            )
+        except Exception as exc:
+            logger.debug(f"Failed to record CLI session transcript: {exc}")
+
     def _load_hooks(self) -> Dict[str, List[ExecutorHook]]:
         """
         Load hooks from configuration.
@@ -696,6 +717,11 @@ class LocalAgentExecutor(BaseAgentExecutor):
             if agent_conf is not None:
                 agent_conf.skill_configs = result.skill_configs
 
+    def _consume_restored_messages(self) -> list[dict[str, Any]]:
+        restored_messages = getattr(self, "_aworld_cli_restored_messages", None) or []
+        self._aworld_cli_restored_messages = []
+        return [dict(message) for message in restored_messages if isinstance(message, dict)]
+
     async def _build_task(
         self, 
         task_content: str, 
@@ -744,6 +770,7 @@ class LocalAgentExecutor(BaseAgentExecutor):
         task_content = hook_kwargs.get('task_content', task_content) or hook_kwargs.get('user_message', task_content)
         # Get updated image_urls from kwargs (FileParseHook may have added images)
         image_urls = hook_kwargs.get('image_urls', image_urls) or []
+        restored_messages = self._consume_restored_messages()
 
         # 1. Build task input
         task_input = TaskInput(
@@ -752,6 +779,7 @@ class LocalAgentExecutor(BaseAgentExecutor):
             task_id=task_id,
             task_content=task_content,
             origin_user_input=original_task_content,
+            messages=restored_messages,
             metadata={
                 "requested_skill_names": list(requested_skill_names or []),
             },
@@ -920,6 +948,21 @@ class LocalAgentExecutor(BaseAgentExecutor):
                 image_urls=image_urls,
                 requested_skill_names=requested_skill_names,
             )
+            try:
+                from aworld_cli.core.session_store import CliSessionStore
+
+                CliSessionStore().record_turn(
+                    session_id=self.session_id,
+                    cwd=os.getcwd(),
+                    agent_name=getattr(getattr(self.swarm, "conf", None), "name", None) or "Aworld",
+                    mode=getattr(self, "_session_mode", "interactive"),
+                    prompt=task_content,
+                    task_id=getattr(task, "id", None),
+                    source_type=getattr(self, "_session_source_type", None),
+                    source_location=getattr(self, "_session_source_location", None),
+                )
+            except Exception as exc:
+                logger.debug(f"Failed to record CLI session turn: {exc}")
             self.context = getattr(task, "context", None)
             runtime = getattr(self, "_base_runtime", None)
             steering = getattr(runtime, "_steering", None) if runtime is not None else None
@@ -1797,6 +1840,11 @@ class LocalAgentExecutor(BaseAgentExecutor):
                 )
                 self._publish_hud_task_finished(task.id, task_status="idle")
                 self._reset_active_steering_buffer()
+                self._record_cli_session_transcript_turn(
+                    task_content=task_content,
+                    answer=answer,
+                    task_id=task.id,
+                )
                 for _, result in task_completed_results:
                     system_message = getattr(result, "system_message", None)
                     if system_message:

--- a/aworld-cli/src/aworld_cli/main.py
+++ b/aworld-cli/src/aworld_cli/main.py
@@ -755,7 +755,13 @@ async def _run_interactive_mode(
     requested_skill_names: Optional[list[str]] = None,
     remote_backends: Optional[list[str]] = None,
     local_dirs: Optional[list[str]] = None,
-    agent_files: Optional[list[str]] = None
+    agent_files: Optional[list[str]] = None,
+    session_id: Optional[str] = None,
+    resume_record=None,
+    session_store=None,
+    require_same_resume_agent: bool = True,
+    resume_cwd: str | None = None,
+    fail_on_missing_agent: bool = False,
 ):
     """
     Run interactive mode using CliRuntime directly.
@@ -775,7 +781,17 @@ async def _run_interactive_mode(
             except Exception as e:
                 print(f"⚠️ Failed to load agent file {agent_file}: {e}")
     
-    runtime = CliRuntime(agent_name=agent_name, remote_backends=remote_backends, local_dirs=local_dirs)
+    runtime = CliRuntime(
+        agent_name=agent_name,
+        remote_backends=remote_backends,
+        local_dirs=local_dirs,
+        session_id=session_id,
+        resume_record=resume_record,
+        session_store=session_store,
+        require_same_resume_agent=require_same_resume_agent,
+        resume_cwd=resume_cwd,
+        fail_on_missing_agent=fail_on_missing_agent,
+    )
     runtime.cli._pending_skill_overrides = list(requested_skill_names or [])
     try:
         await runtime.start()
@@ -903,7 +919,16 @@ async def _run_direct_mode(
     session_id: Optional[str] = None,
     remote_backends: Optional[list[str]] = None,
     local_dirs: Optional[list[str]] = None,
-    agent_files: Optional[list[str]] = None
+    agent_files: Optional[list[str]] = None,
+    session_mode: str = "direct",
+    resume_record=None,
+    session_store=None,
+    require_same_resume_agent: bool = True,
+    resume_cwd: str | None = None,
+    fail_on_missing_agent: bool = False,
+    show_start_banner: bool = True,
+    show_iteration_header: bool = True,
+    echo_prompt_as_turn: bool = False,
 ) -> None:
     """
     Run agent in direct mode (non-interactive).
@@ -938,7 +963,12 @@ async def _run_direct_mode(
     runtime = CliRuntime(
         remote_backends=remote_backends, 
         local_dirs=local_dirs,
-        session_id=session_id
+        session_id=session_id,
+        resume_record=resume_record,
+        session_store=session_store,
+        require_same_resume_agent=require_same_resume_agent,
+        resume_cwd=resume_cwd,
+        fail_on_missing_agent=fail_on_missing_agent,
     )
     all_agents = await runtime._load_agents()
 
@@ -966,9 +996,22 @@ async def _run_direct_mode(
     # Match interactive mode so direct runs can access runtime-scoped features
     # such as steering checkpoints and HUD state.
     agent_executor._base_runtime = runtime
+    agent_executor._session_mode = session_mode
+    runtime._restore_executor_session(agent_executor, current_agent_name=selected_agent.name)
+    restored_replay = getattr(agent_executor, "_aworld_cli_restored_transcript", None)
+    restored_text = getattr(restored_replay, "rendered_text", None)
+    if restored_text:
+        try:
+            agent_executor._aworld_cli_restored_transcript = None
+        except Exception:
+            pass
+        console.print(str(restored_text).strip())
+        console.print()
     
-    # If session_id was provided, ensure it's properly restored (for session history management)
-    if session_id and hasattr(agent_executor, 'restore_session'):
+    # If session_id was provided, ensure it's properly restored for legacy direct runs.
+    # Resume mode already selected a known session from CliSessionStore; BaseAgentExecutor
+    # would create a fresh session when the ID is not present in its legacy local history.
+    if session_id and session_mode != "interactive" and hasattr(agent_executor, 'restore_session'):
         try:
             # Restore session to ensure it's added to history if needed
             agent_executor.restore_session(session_id)
@@ -1004,7 +1047,10 @@ async def _run_direct_mode(
         max_cost=max_cost,
         max_duration=max_duration,
         completion_signal=completion_signal,
-        completion_threshold=completion_threshold
+        completion_threshold=completion_threshold,
+        show_start_banner=show_start_banner,
+        show_iteration_header=show_iteration_header,
+        echo_prompt_as_turn=echo_prompt_as_turn,
     )
 
 

--- a/aworld-cli/src/aworld_cli/runtime/base.py
+++ b/aworld-cli/src/aworld_cli/runtime/base.py
@@ -62,6 +62,7 @@ class BaseCliRuntime:
         self._hud_snapshot_store = HudSnapshotStore()
         self._steering = SteeringCoordinator()
         self._current_root_agent_name: Optional[str] = None
+        self._fail_on_missing_agent = False
     
     async def start(self) -> None:
         """Start the CLI interaction loop."""
@@ -100,6 +101,7 @@ class BaseCliRuntime:
                 # Store runtime reference in executor for notification access
                 if executor:
                     executor._base_runtime = self
+                    self._restore_executor_session(executor, current_agent_name=selected_agent.name)
 
                 result = await self.cli.run_chat_session(
                     selected_agent.name,
@@ -136,6 +138,10 @@ class BaseCliRuntime:
 
         # Stop cron scheduler
         await self._stop_scheduler()
+
+    def _restore_executor_session(self, executor: AgentExecutor, current_agent_name: str | None = None) -> None:
+        """Hook for runtimes that need to restore a selected session after executor creation."""
+        return None
 
     def _initialize_plugin_framework(self) -> None:
         plugin_dirs = getattr(self, "plugin_dirs", None) or []
@@ -566,6 +572,12 @@ class BaseCliRuntime:
                     selected_agent = agent
                     break
             if not selected_agent:
+                if self._fail_on_missing_agent:
+                    self.cli.console.print(
+                        f"[red]Session was created with agent {self.agent_name}, but that agent is not available.[/red]"
+                    )
+                    self.cli.console.print("[yellow]Pass `--agent <name>` to resume with a different agent.[/yellow]")
+                    return None
                 self.cli.console.print(f"[red]❌ Agent '{self.agent_name}' not found.[/red]")
             # Clear it so next loop we select
             self.agent_name = None

--- a/aworld-cli/src/aworld_cli/runtime/cli.py
+++ b/aworld-cli/src/aworld_cli/runtime/cli.py
@@ -21,6 +21,8 @@ from ..models import AgentInfo
 from ..executors import AgentExecutor
 from ..executors.local import LocalAgentExecutor
 from ..executors.remote import RemoteAgentExecutor
+from ..core.session_restore import restore_session_to_executor
+from ..core.session_store import CliSessionRecord, CliSessionStore
 from ..core.agent_registry import LocalAgentRegistry
 from aworld.core.context.amni import ApplicationContext, TaskInput
 from aworld.core.context.amni.config import AmniConfigFactory, AmniConfigLevel
@@ -61,6 +63,11 @@ class CliRuntime(BaseCliRuntime):
         local_dirs: Optional[List[str]] = None,
         session_id: Optional[str] = None,
         disable_live_display: bool = False,
+        resume_record: CliSessionRecord | None = None,
+        session_store: CliSessionStore | None = None,
+        require_same_resume_agent: bool = True,
+        resume_cwd: str | None = None,
+        fail_on_missing_agent: bool = False,
     ):
         """
         Initialize CLI Runtime.
@@ -72,6 +79,11 @@ class CliRuntime(BaseCliRuntime):
             session_id: Optional session ID to use when creating executors
             disable_live_display: If True, remote executors will not use Rich Status/Live
                 (for batch/concurrent mode to avoid "Only one live display may be active at once")
+            resume_record: Optional session record to restore into created executors
+            session_store: Store that owns resume_record
+            require_same_resume_agent: Whether restored executor must use record.agent_name
+            resume_cwd: Current cwd used for explicit cross-workspace warnings
+            fail_on_missing_agent: Return without selecting a fallback agent when agent_name is unavailable
         """
         super().__init__(agent_name)
         self._parse_config(remote_backends, local_dirs)
@@ -81,6 +93,11 @@ class CliRuntime(BaseCliRuntime):
         # Store session_id for executor creation
         self._session_id = session_id
         self._disable_live_display = disable_live_display
+        self._resume_record = resume_record
+        self._session_store = session_store
+        self._require_same_resume_agent = require_same_resume_agent
+        self._resume_cwd = resume_cwd
+        self._fail_on_missing_agent = fail_on_missing_agent
     
     def _parse_config(
         self, 
@@ -327,13 +344,15 @@ class CliRuntime(BaseCliRuntime):
                 # Get swarm with context
                 swarm = await local_agent.get_swarm(temp_context)
             
-            return LocalAgentExecutor(
+            executor = LocalAgentExecutor(
                 swarm, 
                 context_config=context_config, 
                 console=self.cli.console,
                 session_id=self._session_id,
                 hooks=hooks
             )
+            self._annotate_executor_source(executor, source_info)
+            return executor
             
         except Exception as e:
             self.cli.console.print(f"[red]❌ Failed to initialize local agent session: {e}[/red]")
@@ -357,13 +376,47 @@ class CliRuntime(BaseCliRuntime):
             RemoteAgentExecutor instance
         """
         backend_url = source_info["location"]
-        return RemoteAgentExecutor(
+        executor = RemoteAgentExecutor(
             backend_url,
             agent.name,
             console=self.cli.console,
             session_id=self._session_id,
             disable_live_display=self._disable_live_display,
         )
+        self._annotate_executor_source(executor, source_info)
+        return executor
+
+    def _annotate_executor_source(self, executor: AgentExecutor, source_info: Dict) -> None:
+        executor._session_source_type = source_info.get("type")
+        executor._session_source_location = source_info.get("location")
+
+    def _restore_executor_session(self, executor: AgentExecutor, current_agent_name: str | None = None) -> None:
+        if self._resume_record is None or self._session_store is None:
+            session_id = getattr(executor, "session_id", None)
+            if not session_id:
+                return
+            try:
+                CliSessionStore().ensure_session(
+                    session_id=session_id,
+                    cwd=os.getcwd(),
+                    agent_name=current_agent_name or self.agent_name or "Aworld",
+                    mode=getattr(executor, "_session_mode", "interactive"),
+                    source_type=getattr(executor, "_session_source_type", None),
+                    source_location=getattr(executor, "_session_source_location", None),
+                )
+            except Exception:
+                pass
+            return
+        result = restore_session_to_executor(
+            record=self._resume_record,
+            executor_instance=executor,
+            session_store=self._session_store,
+            current_agent_name=current_agent_name,
+            current_cwd=self._resume_cwd,
+            require_same_agent=self._require_same_resume_agent,
+        )
+        if result.warning and hasattr(self, "cli") and getattr(self.cli, "console", None):
+            self.cli.console.print(f"[yellow]{result.warning}[/yellow]")
     
     def _get_source_type(self) -> str:
         """Get source type for display."""

--- a/aworld-cli/src/aworld_cli/top_level_commands/__init__.py
+++ b/aworld-cli/src/aworld_cli/top_level_commands/__init__.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
 
 def register_builtin_top_level_commands(registry) -> None:
-    return None
+    from .resume_cmd import ResumeTopLevelCommand
+
+    registry.register(ResumeTopLevelCommand(), source="builtin")

--- a/aworld-cli/src/aworld_cli/top_level_commands/interactive_cmd.py
+++ b/aworld-cli/src/aworld_cli/top_level_commands/interactive_cmd.py
@@ -96,6 +96,7 @@ class InteractiveTopLevelCommand:
                 remote_backends=invocation_args.remote_backend,
                 local_dirs=_resolve_agent_dirs(invocation_args.agent_dir),
                 agent_files=invocation_args.agent_file,
+                session_id=None,
             )
         )
         return 0

--- a/aworld-cli/src/aworld_cli/top_level_commands/resume_cmd.py
+++ b/aworld-cli/src/aworld_cli/top_level_commands/resume_cmd.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from aworld_cli.core.session_restore import resolve_session_record
+from aworld_cli.core.session_store import CliSessionStore
+from aworld_cli.runtime_bootstrap import RuntimeBootstrapError, bootstrap_runtime
+from aworld_cli.top_level_commands.invocation import find_command_index
+
+
+def _register_resume_options(parser: argparse.ArgumentParser, *, include_prompt_remainder: bool = True) -> None:
+    parser.add_argument("session_id", nargs="?")
+    parser.add_argument("--last", action="store_true", help="Resume the latest session.")
+    parser.add_argument("--all", action="store_true", help="Search sessions from all working directories.")
+    parser.add_argument(
+        "--include-non-interactive",
+        action="store_true",
+        help="Include direct/non-interactive sessions when selecting the latest session.",
+    )
+    parser.add_argument("--agent", type=str, help="Override the agent used for the resumed session.")
+    parser.add_argument("--skill", dest="skill", action="append")
+    parser.add_argument("--env-file", type=str, default=".env")
+    parser.add_argument("--remote-backend", type=str, action="append")
+    parser.add_argument("--agent-dir", type=str, action="append")
+    parser.add_argument("--agent-file", type=str, action="append")
+    parser.add_argument("--skill-path", type=str, action="append")
+    if include_prompt_remainder:
+        parser.add_argument("prompt_parts", nargs=argparse.REMAINDER)
+
+
+def _build_resume_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aworld-cli resume",
+        description="Resume a previous interactive CLI session.",
+        add_help=add_help,
+    )
+    _register_resume_options(parser, include_prompt_remainder=False)
+    return parser
+
+
+def _normalize_prompt(args: argparse.Namespace) -> argparse.Namespace:
+    prompt_parts = list(getattr(args, "prompt_parts", None) or [])
+    if getattr(args, "last", False) and getattr(args, "session_id", None):
+        prompt_parts.insert(0, args.session_id)
+        args.session_id = None
+    args.prompt = " ".join(item for item in prompt_parts if item).strip() or None
+    return args
+
+
+def _parse_resume_invocation_args(argv) -> argparse.Namespace:
+    from aworld_cli.main import _GLOBAL_OPTIONS_WITH_VALUES
+
+    command_index = find_command_index(
+        argv,
+        command_name="resume",
+        options_with_values=_GLOBAL_OPTIONS_WITH_VALUES,
+    )
+    parser = _build_resume_parser(add_help=False)
+    if command_index is None:
+        args, prompt_parts = parser.parse_known_args([])
+    else:
+        parse_argv = list(argv[1:command_index]) + list(argv[command_index + 1:])
+        args, prompt_parts = parser.parse_known_args(parse_argv)
+    args.prompt_parts = prompt_parts
+    return _normalize_prompt(args)
+
+
+def _choose_resume_record(records, *, input_fn=None, output_fn=print):
+    if input_fn is None:
+        import builtins
+
+        input_fn = builtins.input
+    if not records:
+        return None
+    output_fn("Resumable sessions:")
+    for index, record in enumerate(records, start=1):
+        prompt = record.last_prompt or "(no prompt recorded)"
+        output_fn(f"{index}. {record.session_id} | {record.agent_name} | {record.updated_at} | {prompt}")
+    raw = input_fn("Select session: ").strip()
+    try:
+        selected = int(raw)
+    except ValueError:
+        return None
+    if selected < 1 or selected > len(records):
+        return None
+    return records[selected - 1]
+
+
+async def _run_resume_mode(
+    *,
+    session_id: str,
+    agent_name: str,
+    requested_skill_names: list[str] | None,
+    initial_prompt: str | None,
+    remote_backends: list[str] | None,
+    local_dirs: list[str] | None,
+    agent_files: list[str] | None,
+    resume_record,
+    session_store: CliSessionStore,
+    require_same_resume_agent: bool,
+    resume_cwd: str,
+    fail_on_missing_agent: bool,
+) -> None:
+    from aworld_cli.main import _run_direct_mode, _run_interactive_mode
+
+    if initial_prompt:
+        await _run_direct_mode(
+            prompt=initial_prompt,
+            agent_name=agent_name,
+            requested_skill_names=requested_skill_names,
+            max_runs=1,
+            non_interactive=False,
+            session_id=session_id,
+            remote_backends=remote_backends,
+            local_dirs=local_dirs,
+            agent_files=agent_files,
+            session_mode="interactive",
+            resume_record=resume_record,
+            session_store=session_store,
+            require_same_resume_agent=require_same_resume_agent,
+            resume_cwd=resume_cwd,
+            fail_on_missing_agent=fail_on_missing_agent,
+            show_start_banner=False,
+            show_iteration_header=False,
+            echo_prompt_as_turn=True,
+        )
+
+    await _run_interactive_mode(
+        agent_name=agent_name,
+        requested_skill_names=requested_skill_names,
+        remote_backends=remote_backends,
+        local_dirs=local_dirs,
+        agent_files=agent_files,
+        session_id=session_id,
+        resume_record=resume_record,
+        session_store=session_store,
+        require_same_resume_agent=require_same_resume_agent,
+        resume_cwd=resume_cwd,
+        fail_on_missing_agent=fail_on_missing_agent,
+    )
+
+
+class ResumeTopLevelCommand:
+    @property
+    def name(self) -> str:
+        return "resume"
+
+    @property
+    def description(self) -> str:
+        return "Resume a previous interactive CLI session."
+
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        return tuple()
+
+    def register_parser(self, subparsers) -> None:
+        parser = subparsers.add_parser(
+            "resume",
+            help=self.description,
+            description=self.description,
+            prog="aworld-cli resume",
+        )
+        _register_resume_options(parser)
+
+    def run(self, args, context) -> int | None:
+        from aworld_cli.main import (
+            _resolve_agent_dirs,
+            _show_banner,
+            init_middlewares,
+        )
+
+        invocation_args = _parse_resume_invocation_args(context.argv)
+        try:
+            bootstrap_runtime(
+                env_file=invocation_args.env_file,
+                skill_paths=invocation_args.skill_path,
+                show_banner="--no-banner" not in context.argv,
+                init_middlewares_fn=init_middlewares,
+                show_banner_fn=_show_banner,
+            )
+        except RuntimeBootstrapError:
+            return 1
+
+        session_store = CliSessionStore()
+        record = resolve_session_record(
+            session_store=session_store,
+            session_id=invocation_args.session_id,
+            cwd=context.cwd,
+            use_latest=invocation_args.last,
+            include_all_cwds=invocation_args.all,
+            include_non_interactive=invocation_args.include_non_interactive,
+        )
+        if record is None and not invocation_args.session_id and not invocation_args.last and sys.stdin.isatty():
+            record = _choose_resume_record(
+                session_store.list(
+                    cwd=context.cwd,
+                    include_all_cwds=invocation_args.all,
+                    include_non_interactive=invocation_args.include_non_interactive,
+                )
+            )
+        if record is None:
+            if invocation_args.session_id:
+                print(f"Session not found: {invocation_args.session_id}")
+                print("Use `aworld-cli resume --all` to include sessions from other workspaces, or `/sessions list`.")
+            elif invocation_args.last:
+                print(f"No resumable sessions found for {context.cwd}.")
+                print("Start a session with `aworld-cli interactive`, or use `--all` to search all workspaces.")
+            else:
+                print("Error: no session selected. Use 'aworld-cli resume SESSION_ID' or 'aworld-cli resume --last'.")
+            return 1
+
+        agent_name = invocation_args.agent or record.agent_name or "Aworld"
+        local_dirs = _resolve_agent_dirs(invocation_args.agent_dir)
+        asyncio.run(
+            _run_resume_mode(
+                session_id=record.session_id,
+                agent_name=agent_name,
+                requested_skill_names=invocation_args.skill,
+                initial_prompt=invocation_args.prompt,
+                remote_backends=invocation_args.remote_backend,
+                local_dirs=local_dirs,
+                agent_files=invocation_args.agent_file,
+                resume_record=record,
+                session_store=session_store,
+                require_same_resume_agent=invocation_args.agent is None,
+                resume_cwd=context.cwd,
+                fail_on_missing_agent=invocation_args.agent is None,
+            )
+        )
+        return 0

--- a/aworld-cli/tests/test_session_transcript.py
+++ b/aworld-cli/tests/test_session_transcript.py
@@ -1,0 +1,308 @@
+from aworld_cli.core.session_restore import restore_session_to_executor
+from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+from aworld_cli.core.session_transcript import CliSessionTranscript
+from aworld_cli.executors.local import LocalAgentExecutor
+from aworld.agents.llm_agent import LLMAgent
+from aworld.core.context.amni import TaskInput
+
+
+def test_session_transcript_records_turn_and_renders_terminal_view(tmp_path):
+    transcript = CliSessionTranscript(root=tmp_path)
+
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="hello",
+        assistant_output="hi there",
+        agent_name="Aworld",
+        task_id="task_1",
+    )
+
+    restored = transcript.render_for_terminal("session_test")
+
+    assert "Previous session transcript" in restored
+    assert "You: hello" in restored
+    assert "Aworld:" in restored
+    assert "hi there" in restored
+
+
+def test_session_transcript_preserves_repeated_turns(tmp_path):
+    transcript = CliSessionTranscript(root=tmp_path)
+
+    for task_id in ("task_1", "task_2"):
+        transcript.record_turn(
+            session_id="session_test",
+            user_input="continue",
+            assistant_output="same summary",
+            agent_name="Aworld",
+            task_id=task_id,
+        )
+
+    restored = transcript.render_for_terminal("session_test")
+    restored_messages = transcript.render_for_openai_messages("session_test")
+
+    assert restored.count("You: continue") == 2
+    assert restored.count("same summary") == 2
+    assert restored_messages == [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "same summary"},
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "same summary"},
+    ]
+
+
+def test_session_transcript_ignores_dangling_user_with_empty_assistant(tmp_path):
+    transcript = CliSessionTranscript(root=tmp_path)
+    path = transcript.path_for("session_test")
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '{"recorded_at":"2026-07-02T00:00:00+00:00","event":"user",'
+        '"session_id":"session_test","task_id":"task_empty","content":"old prompt"}\n'
+        '{"recorded_at":"2026-07-02T00:00:00+00:00","event":"assistant",'
+        '"session_id":"session_test","task_id":"task_empty","agent_name":"Aworld","content":""}\n',
+        encoding="utf-8",
+    )
+
+    assert transcript.render_for_terminal("session_test") == ""
+    assert transcript.render_for_openai_messages("session_test") == []
+
+
+def test_session_transcript_does_not_record_empty_assistant_turn(tmp_path):
+    transcript = CliSessionTranscript(root=tmp_path)
+
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="old prompt",
+        assistant_output="",
+        agent_name="Aworld",
+        task_id="task_empty",
+    )
+
+    assert transcript.render_for_terminal("session_test") == ""
+    assert transcript.render_for_openai_messages("session_test") == []
+
+
+def test_session_transcript_falls_back_to_legacy_history_and_memory(tmp_path):
+    history_path = tmp_path / "cli_history.jsonl"
+    history_path.write_text(
+        '{"display": "first question", "sessionId": "session_test", "timestamp": 1}\n',
+        encoding="utf-8",
+    )
+    memory_path = tmp_path / ".aworld" / "memory" / "sessions" / "session_test.jsonl"
+    memory_path.parent.mkdir(parents=True)
+    memory_path.write_text(
+        '{"event": "task_completed", "session_id": "session_test", '
+        '"task_id": "task_1", "final_answer": "first answer"}\n',
+        encoding="utf-8",
+    )
+
+    transcript = CliSessionTranscript(root=tmp_path, history_path=history_path)
+
+    restored = transcript.render_for_terminal("session_test")
+
+    assert "Recovered from session history and memory" in restored
+    assert "You: first question" in restored
+    assert "first answer" in restored
+
+
+def test_session_transcript_combines_legacy_history_with_new_transcript(tmp_path):
+    history_path = tmp_path / "cli_history.jsonl"
+    history_path.write_text(
+        '{"display": "legacy question", "sessionId": "session_test", "timestamp": 1}\n',
+        encoding="utf-8",
+    )
+    memory_path = tmp_path / ".aworld" / "memory" / "sessions" / "session_test.jsonl"
+    memory_path.parent.mkdir(parents=True)
+    memory_path.write_text(
+        '{"event": "task_completed", "session_id": "session_test", '
+        '"task_id": "task_legacy", "recorded_at": "2026-07-02T00:00:00+00:00", '
+        '"final_answer": "legacy answer"}\n',
+        encoding="utf-8",
+    )
+    transcript = CliSessionTranscript(root=tmp_path, history_path=history_path)
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="new question",
+        assistant_output="new answer",
+        agent_name="Aworld",
+        task_id="task_new",
+    )
+
+    restored = transcript.render_for_terminal("session_test")
+
+    assert "legacy question" in restored
+    assert "legacy answer" in restored
+    assert "new question" in restored
+    assert "new answer" in restored
+
+
+def test_session_transcript_dedupes_legacy_prompt_when_transcript_has_same_turn(tmp_path):
+    history_path = tmp_path / "cli_history.jsonl"
+    history_path.write_text(
+        '{"display": "same question", "sessionId": "session_test", "timestamp": 1}\n',
+        encoding="utf-8",
+    )
+    transcript = CliSessionTranscript(root=tmp_path, history_path=history_path)
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="same question",
+        assistant_output="same answer",
+        agent_name="Aworld",
+        task_id="task_new",
+    )
+
+    restored = transcript.render_for_terminal("session_test")
+    restored_messages = transcript.render_for_openai_messages("session_test")
+
+    assert restored.count("You: same question") == 1
+    assert restored_messages == [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "same answer"},
+    ]
+
+
+def test_restore_session_to_executor_marks_transcript_for_replay(tmp_path):
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_test",
+            created_at="2026-07-02T00:00:00+00:00",
+            updated_at="2026-07-02T00:00:00+00:00",
+            cwd=str(tmp_path),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+    transcript = CliSessionTranscript(root=tmp_path)
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="old question",
+        assistant_output="old answer",
+        agent_name="Aworld",
+        task_id="task_1",
+    )
+
+    class FakeExecutor:
+        session_id = "fresh"
+
+    executor = FakeExecutor()
+
+    restore_session_to_executor(
+        record=record,
+        executor_instance=executor,
+        session_store=store,
+        current_agent_name="Aworld",
+        current_cwd=str(tmp_path),
+    )
+
+    replay = getattr(executor, "_aworld_cli_restored_transcript", None)
+    assert replay is not None
+    assert replay.session_id == "session_test"
+    assert "old question" in replay.rendered_text
+
+
+def test_restore_session_to_executor_marks_messages_for_model_prompt(tmp_path):
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_test",
+            created_at="2026-07-02T00:00:00+00:00",
+            updated_at="2026-07-02T00:00:00+00:00",
+            cwd=str(tmp_path),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+    transcript = CliSessionTranscript(root=tmp_path)
+    transcript.record_turn(
+        session_id="session_test",
+        user_input="old question",
+        assistant_output="old answer",
+        agent_name="Aworld",
+        task_id="task_1",
+    )
+
+    class FakeExecutor:
+        session_id = "fresh"
+
+    executor = FakeExecutor()
+
+    restore_session_to_executor(
+        record=record,
+        executor_instance=executor,
+        session_store=store,
+        current_agent_name="Aworld",
+        current_cwd=str(tmp_path),
+    )
+
+    restored_messages = getattr(executor, "_aworld_cli_restored_messages", None)
+    assert restored_messages == [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+
+def test_local_executor_consumes_restored_messages_once():
+    executor = object.__new__(LocalAgentExecutor)
+    executor._aworld_cli_restored_messages = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+    first = executor._consume_restored_messages()
+    second = executor._consume_restored_messages()
+
+    assert first == [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    assert second == []
+
+
+def test_llm_agent_inserts_task_input_messages_after_system_message():
+    class FakeTaskInput:
+        messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+
+    class FakeContext:
+        task_input_object = FakeTaskInput()
+
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "new question"},
+    ]
+
+    restored = LLMAgent._prepend_task_input_messages(messages, FakeContext())
+
+    assert restored == [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "new question"},
+    ]
+
+
+def test_llm_agent_inserts_pydantic_task_input_messages():
+    task_input = TaskInput(
+        session_id="session_test",
+        task_id="task_test",
+        task_content="new question",
+        messages=[
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ],
+    )
+
+    class FakeContext:
+        task_input_object = task_input
+
+    restored = LLMAgent._prepend_task_input_messages(
+        [{"role": "system", "content": "system prompt"}, {"role": "user", "content": "new question"}],
+        FakeContext(),
+    )
+
+    assert restored[1:3] == [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]

--- a/aworld/agents/llm_agent.py
+++ b/aworld/agents/llm_agent.py
@@ -78,7 +78,6 @@ class LlmOutputParser(ModelOutputParser[ModelResponse, AgentResult]):
             f"🔍 [Agent:{agent_id}] Starting to parse model response, has_tool_calls={bool(resp.tool_calls)}, content_length={len(content)}")
 
         if resp.tool_calls:
-            is_call_tool = True
             logger.info(f"🛠️ [Agent:{agent_id}] Processing {len(resp.tool_calls)} tool call(s)")
             for idx, tool_call in enumerate(resp.tool_calls):
                 full_name: str = tool_call.function.name
@@ -90,13 +89,19 @@ class LlmOutputParser(ModelOutputParser[ModelResponse, AgentResult]):
                     f"🔧 [Agent:{agent_id}] Processing tool call #{idx + 1}: {full_name}, call_id={tool_call.id}")
 
                 try:
-                    params = json.loads(tool_call.function.arguments)
+                    raw_arguments = tool_call.function.arguments
+                    if not isinstance(raw_arguments, str) or not raw_arguments.strip():
+                        logger.warning(
+                            f"⚠️ [Agent:{agent_id}] Tool call #{idx + 1} for {full_name} has invalid arguments: {raw_arguments!r}, skipping.")
+                        continue
+
+                    params = json.loads(raw_arguments)
                     logger.debug(
                         f"✅ [Agent:{agent_id}] Successfully parsed tool arguments for {full_name}: {len(params)} param(s)")
                 except Exception as e:
                     logger.warning(
                         f"⚠️ [Agent:{agent_id}] Failed to parse tool arguments for {full_name}: {tool_call.function.arguments}, error={str(e)}")
-                    params = {}
+                    continue
 
                 # format in framework
                 # agent_info = AgentFactory.agent_instance(agent_id)
@@ -129,6 +134,7 @@ class LlmOutputParser(ModelOutputParser[ModelResponse, AgentResult]):
                                                agent_name=agent_id,
                                                params=params,
                                                policy_info=content + param_info))
+                    is_call_tool = True
                     logger.debug(f"🤖 [Agent:{agent_id}] Added agent action: {full_name}")
                 else:
                     action_name = '__'.join(names[1:]) if len(names) > 1 else ''
@@ -138,8 +144,9 @@ class LlmOutputParser(ModelOutputParser[ModelResponse, AgentResult]):
                                                agent_name=agent_id,
                                                params=params,
                                                policy_info=content))
+                    is_call_tool = True
                     logger.info(f"🔨 [Agent:{agent_id}] Added tool action: {tool_name}_{action_name}")
-        else:
+        if not is_call_tool:
             if not content and resp.reasoning_content:
                 logger.info(f"💬 [Agent:{agent_id}] No tool calls or content, added reasoning content to action")
                 content = resp.reasoning_content
@@ -960,7 +967,31 @@ class LLMAgent(BaseAgent[Observation, List[ActionModel]]):
             else:
                 _drop_incomplete_tool_call_turn("end of history reached")
 
-        return messages
+        return self._prepend_task_input_messages(messages, message.context)
+
+    @staticmethod
+    def _prepend_task_input_messages(messages: List[Dict[str, Any]], context: Context = None) -> List[Dict[str, Any]]:
+        task_input = getattr(context, "task_input_object", None) if context is not None else None
+        task_messages = getattr(task_input, "messages", None) or []
+        restored_messages = []
+        for item in task_messages:
+            if isinstance(item, dict):
+                message = dict(item)
+            elif hasattr(item, "model_dump"):
+                message = item.model_dump()
+            else:
+                continue
+            if message.get("role") in {"user", "assistant", "tool"}:
+                restored_messages.append(message)
+        if not restored_messages:
+            return messages
+
+        insert_at = 0
+        for index, item in enumerate(messages):
+            if not isinstance(item, dict) or item.get("role") != "system":
+                break
+            insert_at = index + 1
+        return messages[:insert_at] + restored_messages + messages[insert_at:]
 
     async def init_observation(self, observation: Observation) -> Observation:
         # default use origin observation

--- a/aworld/logs/prompt_log.py
+++ b/aworld/logs/prompt_log.py
@@ -20,6 +20,18 @@ BORDER_PADDING = 4  # Left padding width
 TOTAL_WIDTH = BORDER_WIDTH + BORDER_PADDING + 4  # Total width (including border characters)
 
 
+def _truncate_for_log(text: Any, max_length: int) -> str:
+    """Return a single log field clipped to the configured display width."""
+    text = str(text)
+    if max_length <= 3 or len(text) <= max_length:
+        return text
+    return text[:max_length - 3] + "..."
+
+
+def _should_log_message_content_at_info(role: str, message_index: int, total_messages: int) -> bool:
+    return role in ['user', 'assistant'] or (role == 'system' and total_messages <= 2) or message_index == total_messages
+
+
 def _generate_separator(style: str = "─") -> str:
     """Generate a separator line with the configured border width.
     
@@ -548,22 +560,22 @@ class PromptLogger:
                                         for line in text_lines:
                                             if line.strip():
                                                 # Ensure each line is the configured width, maintain border alignment
-                                                padded_line = line.ljust(BORDER_WIDTH - 8)
-                                                # Use info level for user input text to make it visible in regular logs
-                                                if role == 'user':
+                                                display_line = _truncate_for_log(line, BORDER_WIDTH - 8)
+                                                padded_line = display_line.ljust(BORDER_WIDTH - 8)
+                                                if _should_log_message_content_at_info(role, i, len(messages)):
                                                     prompt_logger.info(f"    {padded_line}")
                                                 else:
                                                     prompt_logger.debug(f"    {padded_line}")
                                             else:
                                                 # Also display empty lines to maintain consistent format
                                                 empty_line = " " * (BORDER_WIDTH - 8)
-                                                if role == 'user':
+                                                if _should_log_message_content_at_info(role, i, len(messages)):
                                                     prompt_logger.info(f"    {empty_line}")
                                                 else:
                                                     prompt_logger.debug(f"    {empty_line}")
                                     else:
                                         empty_text = "<empty text>".ljust(BORDER_WIDTH - 8)
-                                        if role == 'user':
+                                        if _should_log_message_content_at_info(role, i, len(messages)):
                                             prompt_logger.info(f"    {empty_text}")
                                         else:
                                             prompt_logger.debug(f"    {empty_text}")
@@ -616,16 +628,16 @@ class PromptLogger:
                         for line in content_lines:
                             if line.strip():  # Skip empty lines
                                 # Ensure each line is the configured width, maintain border alignment
-                                padded_line = line.ljust(BORDER_WIDTH)
-                                # Use info level for user input text to make it visible in regular logs
-                                if role in ['user'] or (role == 'system' and len(messages) <= 2) or i == len(messages):
+                                display_line = _truncate_for_log(line, BORDER_WIDTH)
+                                padded_line = display_line.ljust(BORDER_WIDTH)
+                                if _should_log_message_content_at_info(role, i, len(messages)):
                                     prompt_logger.info(f"{padded_line}")
                                 else:
                                     prompt_logger.debug(f"{padded_line}")
                             else:
                                 # Also display empty lines to maintain consistent format
                                 empty_line = " " * BORDER_WIDTH
-                                if role == 'user':
+                                if _should_log_message_content_at_info(role, i, len(messages)):
                                     prompt_logger.info(f"{empty_line}")
                                 else:
                                     prompt_logger.debug(f"{empty_line}")

--- a/docs/features/parallel-subagent-spawning.md
+++ b/docs/features/parallel-subagent-spawning.md
@@ -1,0 +1,1110 @@
+# Parallel Subagent Spawning
+
+**Version:** 1.0  
+**Status:** Production Ready  
+**Feature Type:** Tool Enhancement
+
+---
+
+## Overview
+
+The **Parallel Subagent Spawning** feature extends the `spawn_subagent` tool with a new `spawn_parallel` action that enables concurrent execution of multiple independent subagent tasks. This significantly improves performance when dealing with parallelizable workloads.
+
+**Key Benefits:**
+- ⚡ **Faster Execution:** Run multiple subagents concurrently instead of sequentially
+- 🎯 **Efficient Resource Usage:** Control concurrency with semaphore-based throttling
+- 🛡️ **Robust Error Handling:** Continue-on-failure or fail-fast modes
+- 📊 **Flexible Output:** Human-readable summaries or structured JSON
+
+---
+
+## Quick Start
+
+### Basic Example
+
+```python
+# In agent's system prompt or directive
+spawn_subagent(
+    action="spawn_parallel",
+    tasks=[
+        {"name": "analyzer1", "directive": "Analyze dataset A"},
+        {"name": "analyzer2", "directive": "Analyze dataset B"},
+        {"name": "reporter", "directive": "Generate summary report"}
+    ],
+    max_concurrent=3,
+    aggregate=True
+)
+```
+
+### Prerequisites
+
+1. **Enable Subagent Functionality:**
+   ```python
+   agent = Agent(
+       name="coordinator",
+       enable_subagent=True,  # Required
+       ...
+   )
+   ```
+
+2. **Configure Subagents:**
+   - Add agents to TeamSwarm, OR
+   - Create `agent.md` files in `.aworld/agents/`
+
+3. **Set Up Tools:**
+   - Parent agent must have `spawn_subagent` tool
+   - Subagents must have required tools configured
+
+---
+
+## API Reference
+
+### Action: `spawn_parallel`
+
+**Tool Name:** `spawn_subagent`  
+**Action Name:** `spawn_parallel`
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `tasks` | Array[Object] | Yes | - | Array of task configurations (see below) |
+| `max_concurrent` | Integer | No | 10 | Maximum concurrent executions |
+| `aggregate` | Boolean | No | true | Aggregate results into summary |
+| `fail_fast` | Boolean | No | false | Stop on first task failure |
+
+#### Task Object Schema
+
+Each task in the `tasks` array must have:
+
+```typescript
+{
+  name: string;           // Subagent name (must be registered)
+  directive: string;      // Clear task instruction
+  model?: string;         // Optional: Override model
+  disallowedTools?: string; // Optional: Comma-separated tool blacklist
+}
+```
+
+#### Return Value
+
+**Aggregated Mode (`aggregate=true`):**
+```markdown
+## Parallel Subagent Execution Results
+
+**Summary:** 3/3 tasks succeeded (Total execution time: 5.23s)
+
+---
+
+### ✅ Task 1: analyzer1
+**Status:** success (took 1.8s)
+
+**Result:**
+```
+[Analysis results...]
+```
+
+---
+
+### ✅ Task 2: analyzer2
+...
+```
+
+**Structured Mode (`aggregate=false`):**
+```json
+{
+  "summary": {
+    "total_tasks": 3,
+    "success_count": 3,
+    "failed_count": 0,
+    "total_elapsed": 5.23
+  },
+  "tasks": [
+    {
+      "name": "analyzer1",
+      "status": "success",
+      "result": "...",
+      "elapsed": 1.8
+    },
+    ...
+  ]
+}
+```
+
+---
+
+## Usage Patterns
+
+### Pattern 1: Data Processing Pipeline
+
+**Scenario:** Process multiple datasets in parallel.
+
+```python
+coordinator = Agent(
+    name="data_coordinator",
+    system_prompt="""Process datasets A, B, C in parallel.
+
+Use spawn_parallel:
+tasks=[
+    {"name": "processor", "directive": "Process dataset A"},
+    {"name": "processor", "directive": "Process dataset B"},
+    {"name": "processor", "directive": "Process dataset C"}
+]
+""",
+    enable_subagent=True
+)
+
+processor = Agent(name="processor", desc="Data processing agent")
+
+swarm = TeamSwarm(coordinator, processor)
+```
+
+**Expected Behavior:**
+- 3 tasks execute concurrently
+- Total time ≈ max(task_time), not sum(task_times)
+- Results aggregated into summary
+
+---
+
+### Pattern 2: Code Review Workflow
+
+**Scenario:** Analyze code quality, documentation, and tests simultaneously.
+
+```python
+reviewer = Agent(
+    name="code_reviewer",
+    system_prompt="""Review codebase comprehensively.
+
+Spawn parallel tasks:
+tasks=[
+    {
+        "name": "quality_checker",
+        "directive": "Analyze code quality metrics",
+        "disallowedTools": "write_file"  # Read-only
+    },
+    {
+        "name": "doc_checker",
+        "directive": "Verify documentation completeness"
+    },
+    {
+        "name": "test_runner",
+        "directive": "Run test suite and report coverage"
+    }
+]
+""",
+    enable_subagent=True
+)
+
+swarm = TeamSwarm(
+    reviewer,
+    quality_checker,
+    doc_checker,
+    test_runner
+)
+```
+
+**Best Practices:**
+- Use `disallowedTools` for security (prevent write access)
+- Set appropriate `max_concurrent` (3-5 for code review)
+- Enable `aggregate=True` for human-readable reports
+
+---
+
+### Pattern 3: Deployment Validation
+
+**Scenario:** Run pre-deployment checks, stop on first failure.
+
+```python
+validator = Agent(
+    system_prompt="""Validate deployment readiness.
+
+Use fail_fast=True to stop on first error:
+tasks=[
+    {"name": "db_validator", "directive": "Validate database migrations"},
+    {"name": "api_validator", "directive": "Check API endpoint health"},
+    {"name": "security_validator", "directive": "Verify security configs"}
+],
+fail_fast=True
+""",
+    enable_subagent=True
+)
+```
+
+**When to Use `fail_fast`:**
+- ✅ Pre-deployment checks (critical validations)
+- ✅ Dependency chains (later tasks depend on earlier)
+- ❌ Comprehensive reports (need all results)
+- ❌ Non-critical analysis (want full picture)
+
+---
+
+## Performance Tuning
+
+### Choosing `max_concurrent`
+
+| Task Type | Recommended | Reason |
+|-----------|-------------|--------|
+| CPU-bound | 4-8 | Match CPU cores |
+| I/O-bound | 10-20 | High concurrency OK |
+| API calls | 2-5 | Respect rate limits |
+| LLM inference | 5-10 | Balance throughput/cost |
+
+### Benchmarks
+
+**Scenario:** 10 tasks, each taking 5 seconds
+
+| `max_concurrent` | Total Time | Speedup |
+|------------------|------------|---------|
+| 1 (sequential) | 50s | 1x |
+| 3 | 20s | 2.5x |
+| 5 | 10s | 5x |
+| 10 | 5s | 10x |
+
+**Formula:**
+```
+total_time ≈ (num_tasks / max_concurrent) * avg_task_time
+```
+
+---
+
+## Error Handling
+
+### Default Behavior (`fail_fast=false`)
+
+All tasks complete regardless of failures:
+
+```python
+tasks=[
+    {"name": "task1", "directive": "..."},  # ✅ Succeeds
+    {"name": "task2", "directive": "..."},  # ❌ Fails
+    {"name": "task3", "directive": "..."}   # ✅ Succeeds (still runs)
+]
+```
+
+**Result:**
+- `success_count`: 2
+- `failed_count`: 1
+- `reward`: 0.67 (2/3)
+
+**Use When:**
+- Need comprehensive error report
+- Failures are non-critical
+- Want to see all results
+
+---
+
+### Fail-Fast Mode (`fail_fast=true`)
+
+Stops on first failure, cancels remaining:
+
+```python
+tasks=[
+    {"name": "critical", "directive": "..."},  # ❌ Fails first
+    {"name": "task2", "directive": "..."},     # 🚫 Cancelled
+    {"name": "task3", "directive": "..."}      # 🚫 Cancelled
+]
+```
+
+**Result:**
+- Minimal tasks completed
+- Fast failure detection
+- Lower token/API cost
+
+**Use When:**
+- Failures are blocking (deployment gates)
+- Later tasks depend on earlier success
+- Cost optimization (stop early)
+
+---
+
+## Advanced Usage
+
+### Pattern: Dynamic Task Generation
+
+```python
+# Generate tasks based on runtime data
+files = ["module1.py", "module2.py", "module3.py"]
+
+tasks = [
+    {
+        "name": "code_analyzer",
+        "directive": f"Analyze {file} for security vulnerabilities"
+    }
+    for file in files
+]
+
+spawn_subagent(
+    action="spawn_parallel",
+    tasks=tasks,
+    max_concurrent=5
+)
+```
+
+---
+
+### Pattern: Heterogeneous Subagents
+
+```python
+# Use different subagent types
+tasks=[
+    {"name": "python_analyzer", "directive": "Analyze Python code"},
+    {"name": "js_analyzer", "directive": "Analyze JavaScript code"},
+    {"name": "rust_analyzer", "directive": "Analyze Rust code"}
+]
+```
+
+**Tip:** Each subagent can have specialized tools and prompts.
+
+---
+
+### Pattern: Tool Access Control
+
+```python
+# Restrict dangerous operations
+tasks=[
+    {
+        "name": "file_scanner",
+        "directive": "Scan codebase for secrets",
+        "disallowedTools": "terminal,write_file,git_commit"
+    },
+    {
+        "name": "reporter",
+        "directive": "Generate report",
+        "disallowedTools": "terminal"  # Only prevent terminal access
+    }
+]
+```
+
+**Security Best Practice:**
+- Always use least-privilege principle
+- Blacklist dangerous tools for read-only tasks
+- Audit tool usage in logs
+
+---
+
+## System Prompt Integration
+
+Add guidance to parent agent's system prompt:
+
+```markdown
+## Available Subagents
+
+You can delegate subtasks using spawn_subagent tool:
+
+### Single Task
+spawn_subagent(name="analyzer", directive="...")
+
+### Parallel Tasks (Faster!)
+spawn_subagent(
+    action="spawn_parallel",
+    tasks=[
+        {"name": "analyzer1", "directive": "..."},
+        {"name": "analyzer2", "directive": "..."}
+    ],
+    max_concurrent=5
+)
+
+**When to Use Parallel:**
+- ✅ Multiple independent subtasks
+- ✅ I/O-bound operations (API calls, file reads)
+- ✅ Data processing on separate datasets
+- ❌ Tasks with dependencies (use sequential spawn)
+- ❌ Single complex task (use regular spawn)
+
+**Parameters:**
+- max_concurrent: 3-5 for API-heavy, 10+ for I/O-bound
+- aggregate: true for human summary, false for JSON
+- fail_fast: true for deployment gates, false for reports
+```
+
+---
+
+## Comparison: Sequential vs Parallel
+
+### Sequential Spawning (Original)
+
+```python
+# Call spawn_subagent multiple times
+result1 = spawn_subagent(name="task1", directive="...")
+result2 = spawn_subagent(name="task2", directive="...")
+result3 = spawn_subagent(name="task3", directive="...")
+
+# Total time: T1 + T2 + T3
+```
+
+**Pros:**
+- Simpler for dependent tasks
+- Lower memory usage
+
+**Cons:**
+- Slower for independent tasks
+- Blocks on each task
+
+---
+
+### Parallel Spawning (New)
+
+```python
+# Single call with task array
+results = spawn_subagent(
+    action="spawn_parallel",
+    tasks=[
+        {"name": "task1", "directive": "..."},
+        {"name": "task2", "directive": "..."},
+        {"name": "task3", "directive": "..."}
+    ]
+)
+
+# Total time: max(T1, T2, T3)
+```
+
+**Pros:**
+- **Much faster** for independent tasks
+- Efficient resource usage
+- Built-in error aggregation
+
+**Cons:**
+- Higher memory/API concurrency
+- Not suitable for dependent tasks
+
+---
+
+## Troubleshooting
+
+### Issue: "No SubagentManager available"
+
+**Cause:** Parent agent doesn't have `enable_subagent=True`
+
+**Fix:**
+```python
+agent = Agent(
+    name="parent",
+    enable_subagent=True,  # Add this
+    ...
+)
+```
+
+---
+
+### Issue: "Subagent 'X' not found"
+
+**Cause:** Subagent not registered (not in TeamSwarm or agent.md missing)
+
+**Fix:**
+```python
+# Option 1: Add to TeamSwarm
+swarm = TeamSwarm(parent, subagent_x, ...)
+
+# Option 2: Create agent.md
+# File: .aworld/agents/subagent_x.md
+# ---
+# name: subagent_x
+# description: Does X
+# tool_names: [tool1, tool2]
+# ---
+```
+
+---
+
+### Issue: Tasks completing slowly
+
+**Diagnosis:**
+1. Check `max_concurrent` (too low?)
+2. Verify tasks are truly independent
+3. Monitor API rate limits
+
+**Optimization:**
+```python
+# Increase concurrency for I/O-bound tasks
+max_concurrent=20  # Up from default 10
+
+# Profile task execution time
+# (check elapsed field in results)
+```
+
+---
+
+### Issue: High API costs
+
+**Cause:** Too many concurrent LLM calls
+
+**Fix:**
+```python
+# Reduce concurrency
+max_concurrent=3  # Lower for cost control
+
+# Use fail_fast to stop early
+fail_fast=True
+
+# Optimize subagent prompts (shorter system prompts)
+```
+
+---
+
+## Implementation Details
+
+### Architecture
+
+```
+Parent Agent
+    └─ spawn_subagent tool
+        └─ SpawnSubagentTool.do_step()
+            ├─ action="spawn" → _spawn_single()
+            └─ action="spawn_parallel" → _spawn_parallel()
+                 └─ _execute_tasks_parallel()
+                      ├─ asyncio.Semaphore (concurrency control)
+                      ├─ asyncio.gather() (parallel execution)
+                      └─ SubagentManager.spawn() (per task)
+```
+
+### Concurrency Control
+
+Uses `asyncio.Semaphore` for throttling:
+
+```python
+semaphore = asyncio.Semaphore(max_concurrent)
+
+async def spawn_with_limit(task):
+    async with semaphore:  # Acquire slot
+        result = await subagent_manager.spawn(...)
+    return result  # Release slot
+
+# Only max_concurrent tasks run at once
+```
+
+### Context Isolation
+
+Each spawned subagent gets isolated context:
+
+```python
+# Per-task isolation
+sub_context = await parent_context.build_sub_context(...)
+result = await subagent.execute(sub_context)
+parent_context.merge_sub_context(sub_context)  # Merge back
+```
+
+**Isolated State:**
+- Token usage tracking
+- KV store
+- Event manager
+
+**Shared State:**
+- Workspace directory
+- Configuration
+- Tool registry
+
+---
+
+## Best Practices
+
+### ✅ Do
+
+- Use parallel spawning for independent tasks
+- Set appropriate `max_concurrent` for task type
+- Use `disallowedTools` for security
+- Monitor token/API usage
+- Add clear directives to each task
+- Use `aggregate=True` for human review
+- Use `aggregate=False` for programmatic processing
+
+### ❌ Don't
+
+- Don't use parallel for dependent tasks (use sequential)
+- Don't set `max_concurrent` too high (resource exhaustion)
+- Don't ignore error handling (check failed_count)
+- Don't use for single tasks (overhead not worth it)
+- Don't skip security controls (always whitelist/blacklist tools)
+
+---
+
+## Future Enhancements
+
+**Planned Features:**
+1. Task prioritization (high-priority tasks first)
+2. Dynamic concurrency adjustment (adaptive throttling)
+3. Task dependencies graph (auto-sequencing)
+4. Retry policies (auto-retry failed tasks)
+5. Progress callbacks (real-time status updates)
+
+**Under Consideration:**
+- Task timeout per subagent
+- Resource quotas (token/time limits per task)
+- Result caching (skip duplicate tasks)
+
+---
+
+## Related Documentation
+
+- [Subagent Architecture](../design/subagent-architecture.md)
+- [SubagentManager API](../api/subagent-manager.md)
+- [TeamSwarm Guide](../guides/team-swarm.md)
+- [Tool Access Control](../security/tool-access-control.md)
+
+---
+
+## Changelog
+
+### v1.0 (2026-04-07)
+- Initial release
+- Added `spawn_parallel` action to `spawn_subagent` tool
+- Implemented concurrency control with `asyncio.Semaphore`
+- Added aggregated and structured output modes
+- Added fail-fast mode for early termination
+- Comprehensive test coverage
+
+---
+
+---
+
+## Background Execution
+
+### Overview
+
+**Background execution** enables **non-blocking subagent spawning**, allowing the orchestrator to continue working while subagents execute independently. This implements the **Fire-and-Forget** pattern with full lifecycle management.
+
+**Key Differences from Parallel Execution:**
+
+| Feature | `spawn_parallel` | `spawn_background` |
+|---------|------------------|---------------------|
+| **Blocking** | Yes (waits for all) | No (returns immediately) |
+| **Use Case** | Need all results before proceeding | Orchestrator continues independently |
+| **Overhead** | Lower (one-shot wait) | Higher (task tracking) |
+| **Flexibility** | Lower (all-or-nothing) | Higher (selective waiting) |
+
+### When to Use Background Execution
+
+**✅ Use background when:**
+- Orchestrator has independent work to do while tasks run
+- Tasks are long-running (minutes, not seconds)
+- Results are not immediately needed
+- Need selective waiting (wait for specific tasks)
+
+**❌ Use parallel instead when:**
+- Need all results before proceeding
+- Tasks are fast (< 10 seconds)
+- Simpler all-or-nothing pattern suffices
+
+---
+
+### Background Actions
+
+#### 1. `spawn_background` - Start Background Task
+
+Spawns a subagent and returns immediately.
+
+**Parameters:**
+```typescript
+{
+  name: string;              // Subagent name (required)
+  directive: string;         // Task description (required)
+  model?: string;            // Optional model override
+  disallowedTools?: string;  // Comma-separated tool blacklist
+  task_id?: string;          // Custom ID (auto-generated if omitted)
+}
+```
+
+**Returns:**
+- Immediate return with task_id
+- `info['task_id']`: Task identifier for tracking
+- `info['action']`: 'spawn_background'
+
+**Example:**
+```python
+spawn_subagent(
+    action="spawn_background",
+    name="Deep_Researcher",
+    directive="Research quantum computing trends",
+    task_id="research_quantum"  # Optional custom ID
+)
+# Returns immediately, agent runs in background
+```
+
+---
+
+#### 2. `check_task` - Query Task Status
+
+Check status of one or all background tasks (non-blocking).
+
+**Parameters:**
+```typescript
+{
+  task_id: string;           // Task ID or 'all' (required)
+  include_result?: boolean;  // Include result if completed (default: true)
+}
+```
+
+**Returns:**
+- `info['status']`: 'running', 'completed', 'error', or 'cancelled'
+- `info['elapsed']`: Elapsed time in seconds
+- `info['result']`: Task result (if completed)
+- `info['error']`: Error message (if status='error')
+
+**Example:**
+```python
+# Check specific task
+spawn_subagent(
+    action="check_task",
+    task_id="research_quantum",
+    include_result=True
+)
+
+# Check all tasks (summary)
+spawn_subagent(
+    action="check_task",
+    task_id="all"
+)
+# Returns: total_tasks, running, completed, failed counts
+```
+
+---
+
+#### 3. `wait_task` - Wait for Completion
+
+Block until specified tasks complete or timeout.
+
+**Parameters:**
+```typescript
+{
+  task_ids: string;  // Comma-separated IDs, 'any', or 'all' (required)
+  timeout?: number;  // Timeout in seconds (default: 300)
+}
+```
+
+**Returns:**
+- `info['completed']`: Number of tasks completed
+- `info['pending']`: Number still running
+- `info['timed_out']`: Boolean (timeout occurred)
+- `info['already_completed']`: Boolean (all were already done)
+
+**Example:**
+```python
+# Wait for specific tasks
+spawn_subagent(
+    action="wait_task",
+    task_ids="task1,task2,task3",
+    timeout=120
+)
+
+# Wait for any one task
+spawn_subagent(
+    action="wait_task",
+    task_ids="any",
+    timeout=60
+)
+
+# Wait for all background tasks
+spawn_subagent(
+    action="wait_task",
+    task_ids="all",
+    timeout=300
+)
+```
+
+---
+
+#### 4. `cancel_task` - Cancel Running Task
+
+Cancel one or all background tasks.
+
+**Parameters:**
+```typescript
+{
+  task_id: string;  // Task ID or 'all' (required)
+}
+```
+
+**Returns:**
+- `info['cancelled']`: Boolean (success for single task)
+- `info['cancelled_count']`: Number cancelled (for 'all')
+
+**Example:**
+```python
+# Cancel specific task
+spawn_subagent(
+    action="cancel_task",
+    task_id="research_quantum"
+)
+
+# Cancel all background tasks
+spawn_subagent(
+    action="cancel_task",
+    task_id="all"
+)
+```
+
+---
+
+### Background Execution Patterns
+
+#### Pattern 1: Spawn and Forget
+
+Fire off tasks without tracking:
+
+```python
+coordinator = Agent(
+    system_prompt="""You are a research orchestrator.
+
+Start background research tasks:
+spawn_subagent(action="spawn_background", name="researcher", directive="Research AI trends")
+spawn_subagent(action="spawn_background", name="researcher", directive="Research quantum computing")
+
+Then continue your analysis work without waiting.
+""",
+    enable_subagent=True
+)
+```
+
+**Use Case:** Fire-and-forget logging, notifications, data collection
+
+---
+
+#### Pattern 2: Spawn, Work, Then Collect
+
+Start tasks, do other work, then collect results:
+
+```python
+coordinator = Agent(
+    system_prompt="""Research orchestrator workflow:
+
+1. Start background research tasks:
+   spawn_subagent(action="spawn_background", name="deep_researcher", directive="...", task_id="research_1")
+   spawn_subagent(action="spawn_background", name="deep_researcher", directive="...", task_id="research_2")
+
+2. Continue with other work (analyze previous data, plan next steps, etc.)
+
+3. Wait for research to complete:
+   spawn_subagent(action="wait_task", task_ids="research_1,research_2", timeout=300)
+
+4. Retrieve and process results:
+   spawn_subagent(action="check_task", task_id="research_1", include_result=True)
+   spawn_subagent(action="check_task", task_id="research_2", include_result=True)
+""",
+    enable_subagent=True
+)
+```
+
+**Use Case:** Orchestrator with independent work while long tasks run
+
+---
+
+#### Pattern 3: Mixed Foreground/Background
+
+Combine blocking and non-blocking execution:
+
+```python
+coordinator = Agent(
+    system_prompt="""Execute mixed workflow:
+
+# Start slow background task
+spawn_subagent(
+    action="spawn_background",
+    name="deep_analyzer",
+    directive="Comprehensive analysis (takes 5 minutes)",
+    task_id="deep_analysis"
+)
+
+# Execute quick foreground tasks (blocks)
+result = spawn_subagent(
+    name="quick_validator",
+    directive="Quick validation check"
+)
+
+# Check background status
+spawn_subagent(action="check_task", task_id="deep_analysis")
+
+# Wait if needed
+if task_still_running:
+    spawn_subagent(action="wait_task", task_ids="deep_analysis", timeout=300)
+""",
+    enable_subagent=True
+)
+```
+
+**Use Case:** Critical path optimization (fast tasks first, wait for slow)
+
+---
+
+#### Pattern 4: Adaptive Waiting
+
+Wait for any task to complete first (early exit):
+
+```python
+# Start multiple research tasks
+for topic in ['AI', 'Quantum', 'Blockchain']:
+    spawn_subagent(
+        action="spawn_background",
+        name="researcher",
+        directive=f"Quick scan: {topic}",
+        task_id=f"scan_{topic}"
+    )
+
+# Wait for any one to complete (first-wins)
+spawn_subagent(
+    action="wait_task",
+    task_ids="any",  # Returns when first task completes
+    timeout=60
+)
+
+# Cancel the rest
+spawn_subagent(action="cancel_task", task_id="all")
+```
+
+**Use Case:** Racing algorithms, redundant research (first-to-finish)
+
+---
+
+### Performance Characteristics
+
+**Benchmark Results** (3 tasks @ 500ms each):
+
+| Mode | Spawn Time | Total Time | Speedup |
+|------|------------|------------|---------|
+| Sequential | N/A | 1500ms | 1x |
+| `spawn_parallel` | N/A | 500ms + overhead | 3x |
+| `spawn_background` | <10ms (non-blocking!) | 500ms (with overlap) | 3x |
+
+**Key Advantage:**
+- **Background**: Orchestrator can do 100ms of work *during* subagent execution
+- **Parallel**: Orchestrator blocks for full execution time
+
+**Formula:**
+```
+Without background: T_orchestrator + T_subagents (sequential)
+With background:    max(T_orchestrator, T_subagents) (overlapped)
+```
+
+---
+
+### Best Practices
+
+**1. Task ID Management:**
+```python
+# ✅ Good: Descriptive custom IDs
+task_id="research_quantum_computing_2026"
+
+# ❌ Bad: Auto-generated only (hard to track in logs)
+# Let task_id auto-generate
+```
+
+**2. Timeout Strategy:**
+```python
+# ✅ Set reasonable timeouts
+spawn_subagent(action="wait_task", task_ids="...", timeout=300)  # 5 minutes
+
+# ❌ No timeout (can hang forever)
+spawn_subagent(action="wait_task", task_ids="...")
+```
+
+**3. Error Handling:**
+```python
+# ✅ Always check status
+result = spawn_subagent(action="check_task", task_id="task1")
+if result['status'] == 'error':
+    handle_error(result['error'])
+
+# ❌ Assume success
+result = spawn_subagent(action="check_task", task_id="task1")
+process(result['result'])  # May not exist!
+```
+
+**4. Resource Management:**
+```python
+# ✅ Limit concurrent background tasks
+MAX_BACKGROUND = 5
+if len(active_tasks) < MAX_BACKGROUND:
+    spawn_subagent(action="spawn_background", ...)
+
+# ❌ Spawn unlimited tasks (resource exhaustion)
+for i in range(1000):
+    spawn_subagent(action="spawn_background", ...)
+```
+
+---
+
+### Comparison: Parallel vs Background
+
+| Aspect | `spawn_parallel` | `spawn_background` |
+|--------|------------------|---------------------|
+| **Orchestrator Blocking** | Yes | No |
+| **Task Tracking** | Automatic | Manual (via task_id) |
+| **Result Collection** | Automatic aggregation | Manual retrieval |
+| **Use Complexity** | Low (one call) | Medium (spawn + wait + check) |
+| **Flexibility** | Low (all-or-nothing) | High (selective waiting) |
+| **Performance** | Good (if no orchestrator work) | Better (if orchestrator has work) |
+| **Memory Overhead** | Lower | Higher (task registry) |
+
+**Decision Tree:**
+
+```
+Do you need all results before proceeding?
+├─ Yes → Use spawn_parallel
+└─ No → Does orchestrator have independent work?
+    ├─ Yes → Use spawn_background
+    └─ No → Use spawn_parallel (simpler)
+```
+
+---
+
+### Implementation Details
+
+**Task Registry:**
+```python
+_background_tasks: Dict[str, Dict[str, Any]] = {
+    'task_id': {
+        'task': asyncio.Task,        # Running task
+        'name': str,                 # Subagent name
+        'directive': str,            # Task description
+        'start_time': float,         # Start timestamp
+        'status': str,               # 'running', 'completed', 'error', 'cancelled'
+        'result': Optional[str],     # Task result
+        'error': Optional[str]       # Error message
+    }
+}
+```
+
+**Thread Safety:**
+```python
+# All registry access protected by lock
+self._bg_lock = asyncio.Lock()
+
+async with self._bg_lock:
+    self._background_tasks[task_id] = {...}
+```
+
+**Task Lifecycle:**
+```
+Created ──> Running ──┬──> Completed
+                      ├──> Error
+                      └──> Cancelled
+```
+
+---
+
+### Testing
+
+**Unit Tests:** `tests/core/tool/test_spawn_background.py`
+- 18 comprehensive test cases
+- Coverage: spawn, check, wait, cancel, error handling
+- Validation: thread safety, status transitions, timeout behavior
+
+**Integration Tests:** `examples/subagent_integration/test_background_spawn.py`
+- Real-world orchestrator scenarios
+- Performance validation (3x speedup)
+- Mixed foreground/background patterns
+
+**Run Tests:**
+```bash
+# Unit tests
+pytest tests/core/tool/test_spawn_background.py -v
+
+# Integration tests
+python examples/subagent_integration/test_background_spawn.py
+```
+
+---
+
+## Support
+
+**Questions?** Open an issue on GitHub  
+**Feature Requests?** Submit a proposal via discussions  
+**Bugs?** File a bug report with reproduction steps

--- a/docs/superpowers/specs/2026-07-01-aworld-cli-resume-design.md
+++ b/docs/superpowers/specs/2026-07-01-aworld-cli-resume-design.md
@@ -1,0 +1,603 @@
+# AWorld CLI Resume Design
+
+## Date
+2026-07-01
+
+## Status
+Implemented
+
+## Goal
+
+Add a first-class `aworld-cli resume` capability that can reopen a previous AWorld CLI session by session id, rebuild the effective conversation context that existed when the session ended, and continue chatting as if the process had not exited.
+
+The core success criterion is continuity: after `aworld-cli resume <session-id>`, the next user turn should have access to the same relevant session history, memory summaries, agent identity, cwd, and runtime metadata that an uninterrupted multi-turn conversation would have had.
+
+The target user experience is intentionally similar to:
+
+```bash
+codex resume 019f1d05-4529-7201-9733-4e6bdb5cc768
+```
+
+For AWorld CLI, the equivalent should be:
+
+```bash
+aworld-cli resume <session-id>
+aworld-cli resume <session-id> "continue the previous task"
+aworld-cli resume --last
+```
+
+## Scope
+
+Included:
+
+- local `aworld-cli` session discovery and resumption
+- a top-level `resume` command
+- interactive resume by explicit session id
+- interactive resume of the latest session
+- optional immediate prompt after resume
+- cwd-scoped session selection by default
+- explicit `--all` cross-cwd lookup
+- explicit inclusion of direct-run sessions
+- session metadata persistence needed for reliable resume
+- in-chat `/restore <session-id>` and `/sessions` improvements that share the same underlying session store
+- a shared restore core used by both top-level `resume` and in-chat `/restore`
+- tests for session store, command parsing, cwd filtering, and resume handoff into runtime/executor creation
+
+Excluded from this change:
+
+- Codex-compatible storage format
+- cloud task resume
+- remote backend session replay guarantees beyond passing the selected session id to `RemoteAgentExecutor`
+- archive/delete/unarchive/fork commands
+- transcript viewer UI beyond enough CLI-visible transcript replay to make a resumed terminal look like the session at exit
+- full migration of every historical `~/.aworld/cli_history.jsonl` record into rich session records
+- changing AWorld framework memory semantics outside what is needed to select the correct `session_id`
+
+## Problem
+
+AWorld CLI already has several session-related pieces, but they do not form a reliable resume feature:
+
+- `BaseAgentExecutor` creates and records session ids in `.aworld/workspaces/.session_history.json`, but the record only contains `session_id`, `created_at`, and `last_used_at`.
+- `restore_session()` changes `self.session_id`, but it does not validate agent availability, cwd ownership, mode, source metadata, or transcript presence.
+- direct run mode accepts `--session-id`, but interactive mode has no top-level way to start inside an existing session.
+- `/restore` restores only the latest session and does not parse an explicit id.
+- `/sessions` is currently a debug dump rather than a user-facing session picker/list.
+- `JSONLHistory` stores command-style prompt history and token stats, but it is not a session index and should not become the sole source of truth for resume.
+
+The missing product contract is: “A session is a durable resumable object with enough metadata to find it, validate it, select the right agent, and continue with the same `session_id`.”
+
+## Product Decisions
+
+### 1. Resume must rebuild effective context, not only reuse an id
+
+The MVP resumes by reusing the selected `session_id` in the existing AWorld context/memory pipeline, but that is not sufficient by itself. Resume must prove that the next task can reconstruct the effective context from the previous session end.
+
+Effective context means the agent can see the same relevant prior dialogue and summarized/session memory it would have seen if the user had kept the original process open and sent one more message.
+
+This does not require mechanically replaying every old event into a new process. It does require a durable context-reconstruction path backed by session-scoped memory/history. If the current AWorld context/memory pipeline cannot fully reconstruct the session-end context from `session_id`, this change must add the missing durable session transcript or summary material needed to make resume behavior equivalent to uninterrupted multi-turn chat.
+
+### 2. A session store becomes the source of truth for discovery, not context alone
+
+Add a dedicated AWorld CLI session store for resumable session metadata. Existing history files may remain useful, but resume selection should not depend on scanning `~/.aworld/cli_history.jsonl`.
+
+The store should live under the workspace by default:
+
+```text
+.aworld/sessions/index.json
+```
+
+The store owns:
+
+- durable session metadata
+- latest-session selection
+- cwd filtering
+- agent/source metadata needed to reopen the right runtime
+- archived/deleted-ready fields, even if commands for those fields are out of scope
+
+The session store is not the complete conversation context store. It should point to, or be updated alongside, the durable session history/memory artifacts that allow context reconstruction.
+
+### 3. Existing session ids remain valid
+
+Do not require UUID-style ids. AWorld currently creates ids like:
+
+```text
+session_YYYYMMDDHHMMSS_<8-hex>
+```
+
+The resume command must accept existing AWorld session ids. If future ids become UUIDs, the store should support them without requiring this change to redesign the command.
+
+### 4. Default lookup is current workspace scoped
+
+`aworld-cli resume` should default to sessions whose stored `cwd` matches the current working directory after path resolution.
+
+`--all` disables cwd filtering and shows/accepts sessions from all known cwd values in the store.
+
+### 5. Direct-run sessions are recorded but hidden by default
+
+Direct runs using `aworld-cli run --task ...` should be recorded in the session store with `mode=direct`.
+
+Default resume selection should target interactive sessions. `--include-non-interactive` includes direct-run sessions in `--last` selection and session listing.
+
+Explicit `aworld-cli resume <session-id>` may resume a direct-run session even without `--include-non-interactive`, because an explicit id is a stronger user intent than the default filter.
+
+### 6. Resume and restore share one core implementation
+
+`aworld-cli resume <session-id>` and `/restore <session-id>` are different user entry points for the same underlying operation: recover a known session into a live executor/runtime so the next turn continues under that session id and its reconstructed context.
+
+The two entry points must not maintain separate restore semantics. Their only differences are lifecycle concerns:
+
+- `aworld-cli resume` starts from a cold process, bootstraps runtime, loads or selects the agent, creates an executor, then applies the shared restore operation.
+- `/restore` runs inside an existing interactive process and applies the same shared restore operation to the current executor.
+- `aworld-cli resume <session-id> <prompt>` applies the same restore operation first, then submits `<prompt>` as the next user turn in the restored session.
+
+Any behavior that defines whether a session can be restored, how the executor is updated, how HUD/tool logging is reset, how the session store is touched, and how limited-context warnings are produced belongs in the shared restore core, not in either entry point.
+
+## User-Facing CLI Contract
+
+### Top-level command
+
+Add:
+
+```bash
+aworld-cli resume [OPTIONS] [SESSION_ID] [PROMPT]
+```
+
+Arguments:
+
+- `SESSION_ID`: optional session id or session name/alias when names are introduced later
+- `PROMPT`: optional follow-up prompt to execute immediately after resume
+
+Options:
+
+- `--last`: resume the latest matching session without showing an interactive picker
+- `--all`: disable cwd filtering
+- `--include-non-interactive`: include direct-run sessions in picker and `--last`
+- `--agent <name>`: override stored agent name when the original agent is unavailable or the user intentionally wants a different agent
+- existing runtime setup options should remain available where they matter:
+  - `--skill`
+  - `--env-file`
+  - `--remote-backend`
+  - `--agent-dir`
+  - `--agent-file`
+  - `--skill-path`
+
+Initial MVP behavior:
+
+- if `SESSION_ID` is provided, resume that session directly
+- if `--last` is provided and no `SESSION_ID` is provided, resume the latest matching session
+- if neither `SESSION_ID` nor `--last` is provided, print a compact numbered list and ask the user to choose when running in a terminal
+- if no terminal is available and no `SESSION_ID`/`--last` is provided, fail with a clear message
+
+### Examples
+
+```bash
+aworld-cli resume session_20260701121000_ab12cd34
+aworld-cli resume session_20260701121000_ab12cd34 "continue from the last result"
+aworld-cli resume --last
+aworld-cli resume --all --last
+aworld-cli resume --include-non-interactive --last
+aworld-cli resume --agent Aworld session_20260701121000_ab12cd34
+```
+
+### Interactive slash commands
+
+Improve in-chat commands to use the same session store:
+
+```text
+/sessions
+/sessions list
+/sessions show <session-id>
+/restore <session-id>
+/latest
+```
+
+Rules:
+
+- `/restore <session-id>` switches the current executor to the selected session after validation.
+- `/restore` without an id behaves like `/latest`.
+- `/latest` uses the same current-cwd and interactive-session default filters as `aworld-cli resume --last`.
+- `/sessions` and `/sessions list` show a compact table, not executor debug attributes.
+- `/sessions show <session-id>` shows stored metadata and recent prompt summary if available.
+
+## Session Store Model
+
+### Record shape
+
+Use a dataclass-backed model with explicit JSON serialization.
+
+Recommended fields:
+
+```python
+@dataclass
+class CliSessionRecord:
+    session_id: str
+    created_at: str
+    updated_at: str
+    cwd: str
+    agent_name: str
+    mode: str  # "interactive" or "direct"
+    source_type: str | None = None
+    source_location: str | None = None
+    title: str | None = None
+    last_prompt: str | None = None
+    last_task_id: str | None = None
+    turn_count: int = 0
+    archived: bool = False
+    deleted_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+### Store API
+
+Recommended API:
+
+```python
+class CliSessionStore:
+    def __init__(self, root: Path | None = None): ...
+
+    def upsert_session(self, record: CliSessionRecord) -> CliSessionRecord: ...
+
+    def record_turn(
+        self,
+        *,
+        session_id: str,
+        cwd: str,
+        agent_name: str,
+        mode: str,
+        prompt: str,
+        task_id: str | None,
+        source_type: str | None,
+        source_location: str | None,
+    ) -> CliSessionRecord: ...
+
+    def get(self, session_id: str) -> CliSessionRecord | None: ...
+
+    def list(
+        self,
+        *,
+        cwd: str | None,
+        include_all_cwds: bool = False,
+        include_non_interactive: bool = False,
+        include_archived: bool = False,
+    ) -> list[CliSessionRecord]: ...
+
+    def latest(
+        self,
+        *,
+        cwd: str | None,
+        include_all_cwds: bool = False,
+        include_non_interactive: bool = False,
+    ) -> CliSessionRecord | None: ...
+```
+
+## Shared Restore Core
+
+Add a core module owned by AWorld CLI session management:
+
+```text
+aworld_cli.core.session_restore
+```
+
+Recommended API:
+
+```python
+@dataclass
+class SessionRestoreResult:
+    record: CliSessionRecord
+    message: str
+    warning: str | None = None
+
+
+def resolve_session_record(
+    *,
+    session_store: CliSessionStore,
+    session_id: str | None,
+    cwd: str,
+    use_latest: bool = False,
+    include_all_cwds: bool = False,
+    include_non_interactive: bool = False,
+) -> CliSessionRecord | None: ...
+
+
+def restore_session_to_executor(
+    *,
+    record: CliSessionRecord,
+    executor_instance: Any,
+    session_store: CliSessionStore,
+    current_agent_name: str | None = None,
+    require_same_agent: bool = True,
+) -> SessionRestoreResult: ...
+```
+
+Responsibilities:
+
+- validate that an executor exists
+- reject agent mismatch when `require_same_agent=True`
+- set `executor_instance.session_id = record.session_id`
+- restart tool logging when the executor supports it
+- reset HUD session state when the runtime supports it
+- touch the session store record
+- return any limited-context warning from `CliSessionStore.context_warning(record)`
+
+Entry-point responsibilities:
+
+- `resume` resolves agent/runtime options, creates the executor/runtime, then invokes the shared restore core before accepting the next user turn.
+- `/restore` parses the slash command and delegates to the shared restore core.
+- neither entry point should call legacy `BaseAgentExecutor.restore_session()` for explicit resume ids, because that legacy method creates a new session when the id is missing.
+
+### Migration and compatibility
+
+On first use, the session store should import lightweight records from the existing workspace `.aworld/workspaces/.session_history.json` when the new index does not exist.
+
+Imported records should:
+
+- preserve `session_id`, `created_at`, and `last_used_at`
+- set `updated_at` from `last_used_at`
+- set `cwd` to the current workspace path where the legacy file was found
+- set `agent_name` to the current/default agent only when the old record does not know the agent
+- set `mode` to `interactive`
+- mark `metadata["imported_from"] = ".aworld/workspaces/.session_history.json"`
+
+This import is best-effort. It should not block normal CLI startup if the legacy file is malformed.
+
+## Runtime Integration
+
+### Recording sessions
+
+Every interactive and direct run should update the session store.
+
+Interactive path:
+
+- when an executor is created, ensure the session has a store record
+- before or after each successful task start, record the prompt and task id
+- update `updated_at` when a session is restored or used
+
+Direct run path:
+
+- when `_run_direct_mode()` creates an executor, ensure a record with `mode=direct`
+- record the direct prompt and task id when available
+
+The existing `JSONLHistory` writes should remain. The session store does not replace token/cost history.
+
+### Context reconstruction
+
+Resume must restore enough durable context that the next turn behaves like an uninterrupted follow-up turn.
+
+Before executing any resumed prompt or entering the resumed interactive loop, the runtime must ensure:
+
+- the selected `session_id` is passed into executor creation and task construction
+- the selected agent id/name is the same one used to resolve session-scoped memory, unless explicitly overridden
+- the AWorld context/memory layer can load prior session messages, summaries, or equivalent durable state for that `session_id`
+- any CLI-owned transcript or summary artifact required for context reconstruction is available and well-formed
+- if required context artifacts are missing, the user receives a warning that resume will continue with limited context rather than silently claiming full continuity
+
+Implementation planning must verify the current AWorld memory path. If existing session-scoped memory already provides complete continuity, tests should lock that in. If it does not, this change must add a minimal durable session transcript/summary writer and loader before `resume` is considered complete.
+
+### Resuming into runtime
+
+Top-level `resume` should:
+
+1. load and validate the target session record
+2. resolve the agent name:
+   - use `--agent` when provided
+   - otherwise use `record.agent_name`
+   - otherwise fall back to `Aworld` with a warning for imported legacy records
+3. bootstrap runtime with the usual env/skill/plugin options
+4. create `CliRuntime(..., session_id=record.session_id)`
+5. create the executor for the selected agent
+6. apply the shared restore core to the executor/runtime
+7. start interactive mode using that restored session id
+8. rebuild the effective session context for `record.session_id`
+9. if a prompt argument exists, execute it once in the resumed session before returning to the interactive prompt or exiting according to the selected mode
+
+MVP behavior for prompt-after-resume:
+
+- `aworld-cli resume <id> "prompt"` means: first restore session `<id>`, then submit `"prompt"` as the next user turn inside that restored session, with the rebuilt prior context available to the agent.
+- The prompt must not start a new unrelated session.
+- The prompt must be recorded as a new turn for the restored session.
+- After that turn completes, the CLI should enter interactive mode in the same restored session.
+- A later implementation may add `--non-interactive` for resume, but it is not part of this MVP.
+
+### Restore inside an existing chat
+
+`/restore <session-id>` should:
+
+- validate the record in the store through the shared restore core
+- update `executor_instance.session_id` through the shared restore core
+- restart tool logging for the restored session through the shared restore core
+- reset HUD session state for the new session id through the shared restore core
+- update session store `updated_at` through the shared restore core
+- not rebuild the agent unless the current agent differs from the stored agent
+
+If the stored agent differs from the current agent:
+
+- default behavior: warn and require `/switch <agent>` or top-level `aworld-cli resume --agent ...`
+- do not silently switch agents inside `/restore`
+
+## Error Handling
+
+### Missing session
+
+For explicit session id:
+
+```text
+Session not found: <session-id>
+Use `aworld-cli resume --all` to include sessions from other workspaces, or `/sessions list`.
+```
+
+Do not create a new session when an explicit resume id is missing. This differs from current `restore_session()` behavior and is important for user trust.
+
+### No latest session
+
+For `--last` with no match:
+
+```text
+No resumable sessions found for <cwd>.
+Start a session with `aworld-cli interactive`, or use `--all` to search all workspaces.
+```
+
+### Agent unavailable
+
+When a stored agent cannot be loaded:
+
+```text
+Session <id> was created with agent <agent>, but that agent is not available.
+Pass `--agent <name>` to resume with a different agent.
+```
+
+### CWD mismatch
+
+Explicit id with different cwd should succeed only with a warning:
+
+```text
+Session <id> belongs to <stored-cwd>; current cwd is <cwd>.
+Continuing because the session id was explicit.
+```
+
+List and `--last` should keep cwd filtering unless `--all` is provided.
+
+## Security and Privacy
+
+The session index should not persist full assistant transcripts or tool outputs.
+
+The CLI may persist a separate session transcript artifact for terminal replay because the
+updated resume goal requires `aworld-cli resume <session-id>` to repaint the visible
+conversation before showing the next prompt. This transcript should contain only the
+CLI-visible user input, assistant final answer, agent name, task id, and timestamps needed
+to reconstruct the terminal view. It should not live in the session index.
+
+The same shared restore core also prepares bounded OpenAI-compatible `user`/`assistant`
+messages by merging the dedicated transcript artifact with legacy session history/memory,
+then removing exact duplicate events. The restored messages are consumed once into
+`TaskInput.messages` by the next task under the restored session. The current
+`task_content` remains the user's new prompt, while the LLM request receives prior turns as
+separate chat messages instead of a transcript pasted into one user message. Terminal
+replay and model-context restoration are separate consumers of the same session
+reconstruction module.
+
+Allowed metadata:
+
+- session id
+- timestamps
+- cwd
+- agent/source metadata
+- last prompt preview
+- task id
+- token/cost summary references
+- CLI-visible user/assistant transcript events in the dedicated transcript artifact
+
+Prompt previews should be truncated for display and storage. The full prompt remains in existing history/memory systems, which already carry their own privacy expectations.
+
+Do not store environment variables, API keys, raw tool outputs, or file contents in the session index or transcript artifact.
+
+## Testing Strategy
+
+### Unit tests
+
+Add focused tests for:
+
+- creating a new session store index
+- upserting records
+- listing by cwd
+- `--all` behavior
+- `--include-non-interactive` behavior
+- latest-session selection by `updated_at`
+- explicit id lookup bypassing default cwd/mode filters
+- malformed legacy `.session_history.json` import does not crash
+- explicit missing id does not create a new session
+
+Recommended location:
+
+```text
+tests/core/test_cli_session_store.py
+```
+
+### Command parser tests
+
+Add tests for:
+
+- `aworld-cli resume <id>`
+- `aworld-cli resume <id> <prompt>`
+- `aworld-cli resume --last`
+- `aworld-cli resume --all --last`
+- runtime setup options are accepted
+
+Recommended locations:
+
+```text
+tests/test_cli_help.py
+tests/test_plugin_cli_entrypoint.py
+tests/core/test_top_level_invocation.py
+```
+
+### Runtime integration tests
+
+Add tests with fake runtime/executor boundaries for:
+
+- shared restore core updates executor session id, restarts tool logging, resets HUD, touches the store, and returns context warnings
+- top-level `resume` delegates executor restore behavior to the shared restore core rather than duplicating it
+- resume command creates `CliRuntime(..., session_id=<id>)`
+- prompt-after-resume calls the executor with the provided prompt under the restored session id
+- resumed prompts see prior session context through the same context/memory path used by uninterrupted multi-turn chat
+- missing context artifacts produce an explicit limited-context warning rather than silently claiming full continuity
+- `aworld-cli resume <session-id>` replays the CLI-visible transcript before showing the next interactive prompt
+- `/restore <session-id>` updates executor session id and store `updated_at`
+- `/sessions list` renders user-facing records rather than debug attributes
+
+Recommended locations:
+
+```text
+tests/test_slash_commands.py
+tests/test_interactive_steering.py
+tests/core/test_top_level_invocation.py
+```
+
+## Acceptance Criteria
+
+1. `aworld-cli resume <session-id>` starts an interactive session using the selected session id, replays the CLI-visible transcript, and restores the effective context from the previous session end.
+2. A resumed session's next turn has access to prior session dialogue/memory/summaries equivalent to an uninterrupted multi-turn conversation.
+3. `aworld-cli resume <session-id> "prompt"` first resumes `<session-id>`, then executes `"prompt"` as the next user turn under that resumed session id and rebuilt context, then enters the interactive prompt.
+4. prompt-after-resume records the prompt as a new turn on the restored session, not as a new unrelated session.
+5. `aworld-cli resume --last` resumes the latest non-archived interactive session for the current cwd.
+6. `aworld-cli resume --all --last` can resume a latest session from another cwd.
+7. direct-run sessions are recorded with `mode=direct` but excluded from default `--last`.
+8. `--include-non-interactive` includes direct-run sessions in latest/list selection.
+9. explicit missing session ids fail clearly and do not create new sessions.
+10. stored agent metadata is used to select the default agent for resume.
+11. missing stored agents fail clearly unless `--agent` overrides the agent.
+12. missing or incomplete context artifacts produce an explicit limited-context warning.
+13. `/restore <session-id>` restores a specific known session in the current chat.
+14. `/sessions list` displays resumable sessions with id, agent, mode, cwd indicator, updated time, and last prompt preview.
+15. existing `--session-id` direct run behavior remains compatible.
+16. existing `JSONLHistory` cost and prompt history behavior remains compatible.
+17. `aworld-cli resume <session-id>` and `/restore <session-id>` use the same shared restore core for executor/runtime mutation.
+18. focused tests cover the new session store, context reconstruction, top-level command parsing, and restore/resume runtime handoff.
+19. future completed turns are recorded to a dedicated transcript artifact so a later resume can repaint the terminal without relying on lossy legacy history.
+
+## Rejected Alternatives
+
+### Use only `~/.aworld/cli_history.jsonl`
+
+Rejected because `JSONLHistory` is optimized for prompt history and cost accounting, not session discovery. It lacks reliable agent/source metadata and would require expensive scans for common resume operations.
+
+### Make `restore_session()` create missing sessions for resume
+
+Rejected because `resume <id>` should be trustworthy. A typo should fail; it should not silently create a new session and make the user believe previous context was restored.
+
+### Implement archive/delete/fork in the same change
+
+Rejected for MVP scope. The session model should reserve fields for these lifecycle commands, but the first implementation should deliver reliable resume/list/restore before expanding lifecycle management.
+
+### Blindly replay raw transcripts to rebuild context
+
+Rejected as the primary MVP mechanism because AWorld already has session-scoped memory/context machinery. Blind transcript replay would introduce ordering, tool-output, and security risks.
+
+This rejection does not remove the requirement to rebuild effective context. If the existing memory path is insufficient, the implementation should add a minimal durable session transcript or summary path designed for context reconstruction, not replay arbitrary raw terminal output.
+
+## Implementation Decisions
+
+The implemented MVP uses these choices:
+
+1. use a numbered text prompt first
+2. always enter interactive mode after the immediate prompt
+3. use workspace-local index first and defer a global index until a later change

--- a/tests/agents/test_llm_output_parser.py
+++ b/tests/agents/test_llm_output_parser.py
@@ -1,0 +1,48 @@
+import pytest
+
+from aworld.agents.llm_agent import LlmOutputParser
+from aworld.models.model_response import Function, ModelResponse, ToolCall
+
+
+@pytest.mark.asyncio
+async def test_parser_ignores_malformed_tool_call_when_response_has_content():
+    response = ModelResponse(
+        id="resp_1",
+        model="test-model",
+        content="final answer",
+        tool_calls=[
+            ToolCall(
+                id="call_1",
+                function=Function(name="bash", arguments=None),
+            )
+        ],
+    )
+
+    result = await LlmOutputParser().parse(response, agent_id="Aworld")
+
+    assert result.is_call_tool is False
+    assert len(result.actions) == 1
+    assert result.actions[0].policy_info == "final answer"
+    assert result.actions[0].tool_name is None
+
+
+@pytest.mark.asyncio
+async def test_parser_keeps_valid_tool_call():
+    response = ModelResponse(
+        id="resp_1",
+        model="test-model",
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="call_1",
+                function=Function(name="bash", arguments='{"command": "pwd"}'),
+            )
+        ],
+    )
+
+    result = await LlmOutputParser().parse(response, agent_id="Aworld")
+
+    assert result.is_call_tool is True
+    assert len(result.actions) == 1
+    assert result.actions[0].tool_name == "bash"
+    assert result.actions[0].params == {"command": "pwd"}

--- a/tests/core/test_cli_session_restore.py
+++ b/tests/core/test_cli_session_restore.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_restore_session_to_executor_updates_runtime_and_store(tmp_path: Path) -> None:
+    from aworld_cli.core.session_restore import restore_session_to_executor
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_restore_core",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+            metadata={"context_artifact": ".aworld/missing-context.jsonl"},
+        )
+    )
+
+    class FakeRuntime:
+        def __init__(self):
+            self.reset_session = None
+
+        def reset_hud_session(self, session_id):
+            self.reset_session = session_id
+
+    class FakeExecutor:
+        def __init__(self):
+            self.session_id = "old_session"
+            self._base_runtime = FakeRuntime()
+            self.tool_logging_restarted = False
+
+        def _start_tool_logging(self):
+            self.tool_logging_restarted = True
+
+    executor = FakeExecutor()
+
+    result = restore_session_to_executor(
+        record=record,
+        executor_instance=executor,
+        session_store=store,
+        current_agent_name="Aworld",
+    )
+
+    assert executor.session_id == "session_restore_core"
+    assert executor.tool_logging_restarted is True
+    assert executor._base_runtime.reset_session == "session_restore_core"
+    assert store.get("session_restore_core").updated_at != "2026-01-01T00:00:00+00:00"
+    assert result.warning is not None
+    assert "limited context" in result.warning
+
+
+def test_restore_session_to_executor_warns_for_explicit_cwd_mismatch(tmp_path: Path) -> None:
+    from aworld_cli.core.session_restore import restore_session_to_executor
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_other_cwd",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=str((tmp_path / "other").resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+    executor = type("Executor", (), {"session_id": "old"})()
+
+    result = restore_session_to_executor(
+        record=record,
+        executor_instance=executor,
+        session_store=store,
+        current_agent_name="Aworld",
+        current_cwd=str((tmp_path / "current").resolve()),
+    )
+
+    assert executor.session_id == "session_other_cwd"
+    assert result.warning is not None
+    assert "belongs to" in result.warning
+
+
+def test_resolve_session_record_uses_latest_filters(tmp_path: Path) -> None:
+    from aworld_cli.core.session_restore import resolve_session_record
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    current_cwd = str((tmp_path / "current").resolve())
+    other_cwd = str((tmp_path / "other").resolve())
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="session_current",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=current_cwd,
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="session_other_latest",
+            created_at="2026-01-02T00:00:00+00:00",
+            updated_at="2026-01-02T00:00:00+00:00",
+            cwd=other_cwd,
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+
+    assert (
+        resolve_session_record(
+            session_store=store,
+            session_id=None,
+            cwd=current_cwd,
+            use_latest=True,
+        ).session_id
+        == "session_current"
+    )
+    assert (
+        resolve_session_record(
+            session_store=store,
+            session_id=None,
+            cwd=current_cwd,
+            use_latest=True,
+            include_all_cwds=True,
+        ).session_id
+        == "session_other_latest"
+    )
+
+
+def test_cli_runtime_restores_executor_with_shared_core(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+    from aworld_cli.runtime.cli import CliRuntime
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_runtime_restore",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+
+    calls = {}
+
+    def fake_restore_session_to_executor(**kwargs):
+        calls.update(kwargs)
+        kwargs["executor_instance"].session_id = kwargs["record"].session_id
+        return type(
+            "Result",
+            (),
+            {
+                "record": record,
+                "message": "Restored to session: session_runtime_restore",
+                "warning": None,
+            },
+        )()
+
+    monkeypatch.setattr(
+        "aworld_cli.runtime.cli.restore_session_to_executor",
+        fake_restore_session_to_executor,
+    )
+
+    executor = type("Executor", (), {"session_id": "old_session"})()
+    runtime = CliRuntime(
+        agent_name="Aworld",
+        session_id=record.session_id,
+        resume_record=record,
+        session_store=store,
+    )
+
+    runtime._restore_executor_session(executor, current_agent_name="Aworld")
+
+    assert executor.session_id == "session_runtime_restore"
+    assert calls["record"] is record
+    assert calls["executor_instance"] is executor
+    assert calls["session_store"] is store
+
+
+def test_cli_runtime_can_allow_agent_override_for_resume(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+    from aworld_cli.runtime.cli import CliRuntime
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_agent_override",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Original",
+            mode="interactive",
+        )
+    )
+    calls = {}
+
+    def fake_restore_session_to_executor(**kwargs):
+        calls.update(kwargs)
+        return type("Result", (), {"record": record, "message": "ok", "warning": None})()
+
+    monkeypatch.setattr(
+        "aworld_cli.runtime.cli.restore_session_to_executor",
+        fake_restore_session_to_executor,
+    )
+
+    runtime = CliRuntime(
+        agent_name="Override",
+        session_id=record.session_id,
+        resume_record=record,
+        session_store=store,
+        require_same_resume_agent=False,
+        resume_cwd=str(tmp_path.resolve()),
+    )
+
+    runtime._restore_executor_session(type("Executor", (), {"session_id": "old"})(), current_agent_name="Override")
+
+    assert calls["require_same_agent"] is False
+    assert calls["current_cwd"] == str(tmp_path.resolve())
+
+
+def test_cli_runtime_annotates_executor_source_metadata() -> None:
+    from aworld_cli.runtime.cli import CliRuntime
+
+    runtime = CliRuntime(agent_name="Aworld")
+    executor = type("Executor", (), {})()
+
+    runtime._annotate_executor_source(
+        executor,
+        {"type": "local", "location": "/agents"},
+    )
+
+    assert executor._session_source_type == "local"
+    assert executor._session_source_location == "/agents"
+
+
+def test_cli_runtime_ensures_session_record_for_new_executor(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+    from aworld_cli.runtime.cli import CliRuntime
+
+    monkeypatch.setenv("AWORLD_CLI_SESSION_STORE_ROOT", str(tmp_path))
+    executor = type(
+        "Executor",
+        (),
+        {
+            "session_id": "session_new_executor",
+            "_session_mode": "interactive",
+            "_session_source_type": "local",
+            "_session_source_location": "/agents",
+        },
+    )()
+    runtime = CliRuntime(agent_name="Aworld")
+
+    runtime._restore_executor_session(executor, current_agent_name="Aworld")
+
+    record = CliSessionStore(root=tmp_path).get("session_new_executor")
+    assert record is not None
+    assert record.agent_name == "Aworld"
+    assert record.source_type == "local"
+    assert record.source_location == "/agents"
+
+
+@pytest.mark.asyncio
+async def test_cli_runtime_fails_resume_when_stored_agent_unavailable(capsys) -> None:
+    from aworld_cli.models import AgentInfo
+    from aworld_cli.runtime.cli import CliRuntime
+
+    runtime = CliRuntime(agent_name="MissingAgent", fail_on_missing_agent=True)
+
+    selected = await runtime._select_agent(
+        [AgentInfo(name="Aworld", desc="", source_type="local", source_location=".")]
+    )
+
+    output = capsys.readouterr().out
+    assert selected is None
+    assert "MissingAgent" in output
+    assert "--agent" in output
+
+
+@pytest.mark.asyncio
+async def test_resume_context_uses_same_session_memory_path(monkeypatch, tmp_path: Path) -> None:
+    from aworld.core.memory import MemoryConfig
+    from aworld.memory.db.filesystem import FileSystemMemoryStore
+    from aworld.memory.main import AworldMemory
+    from aworld.memory.models import MemoryHumanMessage, MessageMetadata
+    from aworld_cli.core.session_restore import restore_session_to_executor
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    memory_root = tmp_path / "runtime-memory"
+    monkeypatch.setenv("AWORLD_MEMORY_ROOT", str(memory_root))
+
+    memory = AworldMemory(
+        memory_store=FileSystemMemoryStore(memory_root=str(memory_root)),
+        config=MemoryConfig(provider="aworld"),
+    )
+    await memory.add(
+        MemoryHumanMessage(
+            content="previous turn content",
+            metadata=MessageMetadata(
+                agent_id="Aworld",
+                agent_name="Aworld",
+                session_id="session_continuity",
+                task_id="task-1",
+                user_id="user",
+            ),
+        )
+    )
+
+    store = CliSessionStore(root=tmp_path / "workspace")
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_continuity",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            cwd=str((tmp_path / "workspace").resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+            turn_count=1,
+        )
+    )
+    executor = type("Executor", (), {"session_id": "old"})()
+
+    result = restore_session_to_executor(
+        record=record,
+        executor_instance=executor,
+        session_store=store,
+        current_agent_name="Aworld",
+    )
+
+    items = memory.get_last_n(10, filters={"session_id": "session_continuity"})
+    assert result.warning is None
+    assert executor.session_id == "session_continuity"
+    assert [item.content for item in items] == ["previous turn content"]

--- a/tests/core/test_cli_session_store.py
+++ b/tests/core/test_cli_session_store.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_session_store_records_and_lists_by_cwd(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    store.record_turn(
+        session_id="session_a",
+        cwd=str(tmp_path / "workspace-a"),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="first prompt",
+        task_id="task-1",
+        source_type="local",
+        source_location="/agents",
+    )
+    store.record_turn(
+        session_id="session_b",
+        cwd=str(tmp_path / "workspace-b"),
+        agent_name="Other",
+        mode="interactive",
+        prompt="other prompt",
+        task_id="task-2",
+        source_type="local",
+        source_location="/agents",
+    )
+
+    cwd_a = str((tmp_path / "workspace-a").resolve())
+    records = store.list(cwd=cwd_a)
+
+    assert [record.session_id for record in records] == ["session_a"]
+    assert records[0].last_prompt == "first prompt"
+    assert records[0].turn_count == 1
+    assert records[0].cwd == cwd_a
+
+
+def test_session_store_filters_direct_sessions_unless_requested(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    cwd = str(tmp_path.resolve())
+    store.record_turn(
+        session_id="session_interactive",
+        cwd=cwd,
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="interactive",
+        task_id=None,
+        source_type=None,
+        source_location=None,
+    )
+    store.record_turn(
+        session_id="session_direct",
+        cwd=cwd,
+        agent_name="Aworld",
+        mode="direct",
+        prompt="direct",
+        task_id=None,
+        source_type=None,
+        source_location=None,
+    )
+
+    default_records = store.list(cwd=cwd)
+    all_records = store.list(cwd=cwd, include_non_interactive=True)
+
+    assert [record.session_id for record in default_records] == ["session_interactive"]
+    assert {record.session_id for record in all_records} == {
+        "session_interactive",
+        "session_direct",
+    }
+
+
+def test_session_store_latest_respects_cwd_and_all_flag(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="old",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            cwd=str((tmp_path / "a").resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="new-other-cwd",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-02T00:00:00",
+            cwd=str((tmp_path / "b").resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+
+    assert store.latest(cwd=str((tmp_path / "a").resolve())).session_id == "old"
+    assert (
+        store.latest(cwd=str((tmp_path / "a").resolve()), include_all_cwds=True).session_id
+        == "new-other-cwd"
+    )
+
+
+def test_session_store_preserves_records_created_by_another_instance(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    first = CliSessionStore(root=tmp_path)
+    second = CliSessionStore(root=tmp_path)
+
+    first.record_turn(
+        session_id="session_a",
+        cwd=str(tmp_path.resolve()),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="first prompt",
+        task_id="task-a",
+        source_type="local",
+        source_location="/agents",
+    )
+    second.record_turn(
+        session_id="session_b",
+        cwd=str(tmp_path.resolve()),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="second prompt",
+        task_id="task-b",
+        source_type="local",
+        source_location="/agents",
+    )
+
+    reloaded = CliSessionStore(root=tmp_path)
+
+    assert {record.session_id for record in reloaded.list(cwd=str(tmp_path.resolve()))} == {
+        "session_a",
+        "session_b",
+    }
+
+
+def test_session_store_imports_legacy_history_when_index_missing(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    legacy_dir = tmp_path / ".aworld" / "workspaces"
+    legacy_dir.mkdir(parents=True)
+    legacy_file = legacy_dir / ".session_history.json"
+    legacy_file.write_text(
+        json.dumps(
+            {
+                "session_legacy": {
+                    "session_id": "session_legacy",
+                    "created_at": "2026-01-01T00:00:00",
+                    "last_used_at": "2026-01-01T01:00:00",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.get("session_legacy")
+
+    assert record is not None
+    assert record.session_id == "session_legacy"
+    assert record.mode == "interactive"
+    assert record.metadata["imported_from"] == ".aworld/workspaces/.session_history.json"
+
+
+def test_session_store_warns_when_context_artifacts_missing(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.upsert_session(
+        CliSessionRecord(
+            session_id="session_missing_context",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+            metadata={"context_artifact": ".aworld/missing.jsonl"},
+        )
+    )
+
+    warning = store.context_warning(record)
+
+    assert warning is not None
+    assert "limited context" in warning
+
+
+def test_session_store_warns_when_recorded_turns_have_no_memory_artifact(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.record_turn(
+        session_id="session_no_memory",
+        cwd=str(tmp_path.resolve()),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="remember this",
+        task_id="task-1",
+        source_type="local",
+        source_location="/agents",
+    )
+
+    warning = store.context_warning(record)
+
+    assert warning is not None
+    assert "limited context" in warning
+    assert "session_no_memory" in warning
+
+
+def test_session_store_accepts_existing_memory_artifact_for_context(tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    memory_file = tmp_path / ".aworld" / "memory" / "sessions" / "session_with_memory.jsonl"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text('{"memory_type":"message"}\n', encoding="utf-8")
+
+    store = CliSessionStore(root=tmp_path)
+    record = store.record_turn(
+        session_id="session_with_memory",
+        cwd=str(tmp_path.resolve()),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="remember this",
+        task_id="task-1",
+        source_type="local",
+        source_location="/agents",
+    )
+
+    assert store.context_warning(record) is None
+
+
+def test_session_store_accepts_runtime_memory_root_artifact(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionStore
+
+    runtime_memory = tmp_path / "runtime-memory"
+    memory_file = runtime_memory / "sessions" / "session_runtime_memory.jsonl"
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text('{"memory_type":"message"}\n', encoding="utf-8")
+    monkeypatch.setenv("AWORLD_MEMORY_ROOT", str(runtime_memory))
+
+    store = CliSessionStore(root=tmp_path / "workspace")
+    record = store.record_turn(
+        session_id="session_runtime_memory",
+        cwd=str((tmp_path / "workspace").resolve()),
+        agent_name="Aworld",
+        mode="interactive",
+        prompt="remember this",
+        task_id="task-1",
+        source_type="local",
+        source_location="/agents",
+    )
+
+    assert store.context_warning(record) is None

--- a/tests/core/test_skill_cli.py
+++ b/tests/core/test_skill_cli.py
@@ -20,6 +20,7 @@ from aworld_cli.core.skill_activation_resolver import (
     SkillResolverRequest,
 )
 from aworld_cli.core.top_level_command_system import TopLevelCommandRegistry
+from aworld_cli.executors.continuous import ContinuousExecutor
 from aworld_cli.models import AgentInfo
 from aworld_cli.plugin_capabilities.commands import register_plugin_commands
 from aworld_cli.plugin_capabilities.state import PluginStateStore
@@ -396,6 +397,9 @@ async def test_run_direct_mode_passes_requested_skill_names(
         async def _create_executor(self, _agent):
             return SimpleNamespace(console=None)
 
+        def _restore_executor_session(self, executor, current_agent_name=None):
+            return None
+
     class DummyContinuousExecutor:
         def __init__(self, agent_executor, console=None) -> None:
             self.agent_executor = agent_executor
@@ -444,6 +448,9 @@ async def test_run_direct_mode_binds_runtime_to_executor(
             captured["executor"] = executor
             return executor
 
+        def _restore_executor_session(self, executor, current_agent_name=None):
+            return None
+
     class DummyContinuousExecutor:
         def __init__(self, agent_executor, console=None) -> None:
             self.agent_executor = agent_executor
@@ -465,6 +472,91 @@ async def test_run_direct_mode_binds_runtime_to_executor(
     )
 
     assert captured["runtime_on_executor"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_direct_mode_prints_restored_transcript_before_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = StringIO()
+    test_console = Console(file=output, force_terminal=False, width=120)
+    captured: dict[str, object] = {}
+
+    class DummyExecutor(SimpleNamespace):
+        pass
+
+    class DummyRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            self._scheduler = None
+
+        async def _load_agents(self):
+            return [SimpleNamespace(name="Aworld")]
+
+        def _bind_scheduler_default_agent(self, agent_name: str) -> None:
+            captured["bound_agent"] = agent_name
+
+        async def _create_executor(self, _agent):
+            return DummyExecutor(console=None)
+
+        def _restore_executor_session(self, executor, current_agent_name=None):
+            executor._aworld_cli_restored_transcript = SimpleNamespace(
+                rendered_text="── Previous session transcript ──\nYou: old prompt\n\nAworld:\nold answer"
+            )
+
+    class DummyContinuousExecutor:
+        def __init__(self, agent_executor, console=None) -> None:
+            self.agent_executor = agent_executor
+            self.console = console
+
+        async def run_continuous(self, **kwargs) -> None:
+            captured["output_before_run"] = output.getvalue()
+
+    monkeypatch.setattr("aworld_cli._globals.console", test_console)
+    monkeypatch.setattr(main_module, "CliRuntime", DummyRuntime)
+    monkeypatch.setattr(main_module, "ContinuousExecutor", DummyContinuousExecutor)
+    monkeypatch.setattr(
+        "aworld.core.scheduler.get_scheduler",
+        lambda: SimpleNamespace(),
+    )
+
+    await main_module._run_direct_mode(
+        prompt="new prompt",
+        agent_name="Aworld",
+        session_id="session_test",
+        session_mode="interactive",
+        resume_record=SimpleNamespace(session_id="session_test"),
+        session_store=SimpleNamespace(),
+    )
+
+    assert "Previous session transcript" in captured["output_before_run"]
+    assert "You: old prompt" in captured["output_before_run"]
+    assert "old answer" in captured["output_before_run"]
+
+
+@pytest.mark.asyncio
+async def test_continuous_executor_can_render_prompt_as_terminal_turn() -> None:
+    output = StringIO()
+    test_console = Console(file=output, force_terminal=False, width=120)
+
+    class DummyAgentExecutor(SimpleNamespace):
+        async def chat(self, prompt, **kwargs):
+            return "done"
+
+    executor = ContinuousExecutor(DummyAgentExecutor(session_id="session_test"), console=test_console)
+
+    await executor.run_continuous(
+        prompt="next prompt",
+        agent_name="Aworld",
+        max_runs=1,
+        show_start_banner=False,
+        show_iteration_header=False,
+        echo_prompt_as_turn=True,
+    )
+
+    rendered = output.getvalue()
+    assert "You: next prompt" in rendered
+    assert "Starting" not in rendered
+    assert "Continuous Execution" not in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_top_level_invocation.py
+++ b/tests/core/test_top_level_invocation.py
@@ -2,6 +2,8 @@ import argparse
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "aworld-cli" / "src"))
 
 
@@ -34,3 +36,248 @@ def test_find_command_index_ignores_option_values() -> None:
 
     assert index is None
 
+
+def test_resume_parser_accepts_session_id_and_prompt() -> None:
+    from aworld_cli.top_level_commands.resume_cmd import _parse_resume_invocation_args
+
+    args = _parse_resume_invocation_args(
+        ["aworld-cli", "resume", "session_123", "continue this work"]
+    )
+
+    assert args.session_id == "session_123"
+    assert args.prompt == "continue this work"
+    assert args.last is False
+
+
+def test_resume_parser_accepts_options_after_session_id_before_prompt() -> None:
+    from aworld_cli.top_level_commands.resume_cmd import _parse_resume_invocation_args
+
+    args = _parse_resume_invocation_args(
+        ["aworld-cli", "resume", "session_123", "--agent", "Other", "continue", "work"]
+    )
+
+    assert args.session_id == "session_123"
+    assert args.agent == "Other"
+    assert args.prompt == "continue work"
+
+
+def test_resume_last_parser_treats_remaining_args_as_prompt() -> None:
+    from aworld_cli.top_level_commands.resume_cmd import _parse_resume_invocation_args
+
+    args = _parse_resume_invocation_args(
+        ["aworld-cli", "resume", "--last", "continue", "this", "work"]
+    )
+
+    assert args.session_id is None
+    assert args.prompt == "continue this work"
+    assert args.last is True
+
+
+def test_resume_parser_accepts_lookup_and_runtime_options() -> None:
+    from aworld_cli.top_level_commands.resume_cmd import _parse_resume_invocation_args
+
+    args = _parse_resume_invocation_args(
+        [
+            "aworld-cli",
+            "--env-file",
+            "custom.env",
+            "resume",
+            "--all",
+            "--include-non-interactive",
+            "--last",
+            "--skill",
+            "code-review",
+            "--remote-backend",
+            "http://localhost:8000",
+            "--agent-dir",
+            "./agents",
+            "--agent-file",
+            "./agent.py",
+            "--skill-path",
+            "./skills",
+        ]
+    )
+
+    assert args.last is True
+    assert args.all is True
+    assert args.include_non_interactive is True
+    assert args.env_file == "custom.env"
+    assert args.skill == ["code-review"]
+    assert args.remote_backend == ["http://localhost:8000"]
+    assert args.agent_dir == ["./agents"]
+    assert args.agent_file == ["./agent.py"]
+    assert args.skill_path == ["./skills"]
+
+
+def test_resume_command_registered_as_builtin() -> None:
+    from aworld_cli.core.top_level_command_system import TopLevelCommandRegistry
+    from aworld_cli.top_level_commands import register_builtin_top_level_commands
+
+    registry = TopLevelCommandRegistry()
+    register_builtin_top_level_commands(registry)
+
+    assert registry.get("resume") is not None
+
+
+def test_resume_command_runs_prompt_after_resuming(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+    from aworld_cli.top_level_commands.resume_cmd import ResumeTopLevelCommand
+
+    store = CliSessionStore(root=tmp_path)
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="session_resume",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+
+    calls = {}
+
+    async def fake_resume_mode(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setenv("AWORLD_CLI_SESSION_STORE_ROOT", str(tmp_path))
+    monkeypatch.setattr("aworld_cli.top_level_commands.resume_cmd._run_resume_mode", fake_resume_mode)
+
+    command = ResumeTopLevelCommand()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    command.register_parser(subparsers)
+    args = parser.parse_args(["resume", "session_resume", "next prompt"])
+
+    exit_code = command.run(
+        args,
+        type("Context", (), {"cwd": str(tmp_path), "argv": ("aworld-cli", "resume", "session_resume", "next prompt")})(),
+    )
+
+    assert exit_code == 0
+    assert calls["session_id"] == "session_resume"
+    assert calls["agent_name"] == "Aworld"
+    assert calls["initial_prompt"] == "next prompt"
+
+
+@pytest.mark.asyncio
+async def test_resume_mode_displays_initial_prompt_as_terminal_turn(monkeypatch) -> None:
+    from aworld_cli.top_level_commands.resume_cmd import _run_resume_mode
+
+    calls = {}
+
+    async def fake_direct_mode(**kwargs):
+        calls["direct"] = kwargs
+
+    async def fake_interactive_mode(**kwargs):
+        calls["interactive"] = kwargs
+
+    monkeypatch.setattr("aworld_cli.main._run_direct_mode", fake_direct_mode)
+    monkeypatch.setattr("aworld_cli.main._run_interactive_mode", fake_interactive_mode)
+
+    await _run_resume_mode(
+        session_id="session_resume",
+        agent_name="Aworld",
+        requested_skill_names=None,
+        initial_prompt="next prompt",
+        remote_backends=None,
+        local_dirs=None,
+        agent_files=None,
+        resume_record=object(),
+        session_store=object(),
+        require_same_resume_agent=True,
+        resume_cwd="/workspace",
+        fail_on_missing_agent=True,
+    )
+
+    assert calls["direct"]["show_start_banner"] is False
+    assert calls["direct"]["show_iteration_header"] is False
+    assert calls["direct"]["echo_prompt_as_turn"] is True
+    assert calls["direct"]["max_runs"] == 1
+    assert calls["interactive"]["session_id"] == "session_resume"
+
+
+def test_resume_command_prompts_for_session_when_no_id_or_last(monkeypatch, tmp_path: Path) -> None:
+    from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+    from aworld_cli.top_level_commands.resume_cmd import ResumeTopLevelCommand
+
+    store = CliSessionStore(root=tmp_path)
+    store.upsert_session(
+        CliSessionRecord(
+            session_id="session_pick",
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            cwd=str(tmp_path.resolve()),
+            agent_name="Aworld",
+            mode="interactive",
+        )
+    )
+
+    calls = {}
+
+    async def fake_resume_mode(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setenv("AWORLD_CLI_SESSION_STORE_ROOT", str(tmp_path))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    monkeypatch.setattr("aworld_cli.top_level_commands.resume_cmd._run_resume_mode", fake_resume_mode)
+
+    command = ResumeTopLevelCommand()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    command.register_parser(subparsers)
+    args = parser.parse_args(["resume"])
+
+    exit_code = command.run(
+        args,
+        type("Context", (), {"cwd": str(tmp_path), "argv": ("aworld-cli", "resume")})(),
+    )
+
+    assert exit_code == 0
+    assert calls["session_id"] == "session_pick"
+
+
+def test_resume_missing_explicit_session_message_mentions_all_and_sessions(monkeypatch, tmp_path: Path, capsys) -> None:
+    from aworld_cli.top_level_commands.resume_cmd import ResumeTopLevelCommand
+
+    monkeypatch.setenv("AWORLD_CLI_SESSION_STORE_ROOT", str(tmp_path))
+
+    command = ResumeTopLevelCommand()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    command.register_parser(subparsers)
+    args = parser.parse_args(["resume", "missing_session"])
+
+    exit_code = command.run(
+        args,
+        type("Context", (), {"cwd": str(tmp_path), "argv": ("aworld-cli", "resume", "missing_session")})(),
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Session not found: missing_session" in output
+    assert "--all" in output
+    assert "/sessions list" in output
+
+
+def test_resume_last_without_match_message_mentions_cwd_and_all(monkeypatch, tmp_path: Path, capsys) -> None:
+    from aworld_cli.top_level_commands.resume_cmd import ResumeTopLevelCommand
+
+    monkeypatch.setenv("AWORLD_CLI_SESSION_STORE_ROOT", str(tmp_path))
+
+    command = ResumeTopLevelCommand()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    command.register_parser(subparsers)
+    args = parser.parse_args(["resume", "--last"])
+
+    exit_code = command.run(
+        args,
+        type("Context", (), {"cwd": str(tmp_path), "argv": ("aworld-cli", "resume", "--last")})(),
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert f"No resumable sessions found for {tmp_path}" in output
+    assert "--all" in output

--- a/tests/test_prompt_logger_observability.py
+++ b/tests/test_prompt_logger_observability.py
@@ -1,0 +1,36 @@
+from aworld.logs import prompt_log
+from aworld.logs.prompt_log import PromptLogger
+
+
+class _FakePromptLogger:
+    def __init__(self):
+        self.info_messages = []
+        self.debug_messages = []
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def debug(self, message):
+        self.debug_messages.append(message)
+
+
+def test_log_messages_includes_truncated_assistant_content_at_info_level(monkeypatch):
+    fake_logger = _FakePromptLogger()
+    monkeypatch.setattr(prompt_log, "prompt_logger", fake_logger)
+
+    long_assistant_content = "assistant-history-" + ("x" * 200)
+
+    PromptLogger._log_messages(
+        [
+            {"role": "user", "content": "first prompt"},
+            {"role": "assistant", "content": long_assistant_content},
+            {"role": "user", "content": "next prompt"},
+        ]
+    )
+
+    info_output = "\n".join(fake_logger.info_messages)
+
+    assert "ASSISTANT" in info_output
+    assert "assistant-history-" in info_output
+    assert "..." in info_output
+    assert long_assistant_content not in info_output

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -991,5 +991,124 @@ class TestCommandContext:
         assert context.agent_config is None
 
 
+class TestSessionRestoreCommands:
+    def test_format_sessions_list_uses_session_store_records(self, tmp_path):
+        from aworld_cli.console import AWorldCLI
+        from aworld_cli.core.session_store import CliSessionRecord
+
+        cli = AWorldCLI()
+        output = cli._format_sessions_list(
+            [
+                CliSessionRecord(
+                    session_id="session_1",
+                    created_at="2026-01-01T00:00:00",
+                    updated_at="2026-01-01T01:00:00",
+                    cwd=str(tmp_path),
+                    agent_name="Aworld",
+                    mode="interactive",
+                    last_prompt="continue the work",
+                )
+            ],
+            current_cwd=str(tmp_path),
+        )
+
+        assert "session_1" in output
+        assert "Aworld" in output
+        assert "continue the work" in output
+        assert "Session Info" not in output
+
+    def test_restore_known_session_delegates_to_shared_core(self, monkeypatch, tmp_path):
+        from aworld_cli.console import AWorldCLI
+        from aworld_cli.core.session_store import CliSessionRecord, CliSessionStore
+
+        store = CliSessionStore(root=tmp_path)
+        record = store.upsert_session(
+            CliSessionRecord(
+                session_id="session_restore",
+                created_at="2026-01-01T00:00:00",
+                updated_at="2026-01-01T00:00:00",
+                cwd=str(tmp_path.resolve()),
+                agent_name="Aworld",
+                mode="interactive",
+            )
+        )
+
+        class FakeExecutor:
+            def __init__(self):
+                self.session_id = "old_session"
+
+        calls = {}
+
+        def fake_restore_session_to_executor(**kwargs):
+            calls.update(kwargs)
+            kwargs["executor_instance"].session_id = kwargs["record"].session_id
+            return type(
+                "Result",
+                (),
+                {
+                    "record": record,
+                    "message": "Restored to session: session_restore",
+                    "warning": None,
+                },
+            )()
+
+        monkeypatch.setattr(
+            "aworld_cli.console.restore_session_to_executor",
+            fake_restore_session_to_executor,
+        )
+
+        executor = FakeExecutor()
+        cli = AWorldCLI()
+
+        message = cli._restore_cli_session(
+            "session_restore",
+            executor_instance=executor,
+            current_agent_name="Aworld",
+            session_store=store,
+        )
+
+        assert executor.session_id == "session_restore"
+        assert calls["record"].session_id == "session_restore"
+        assert calls["executor_instance"] is executor
+        assert calls["session_store"] is store
+        assert "Restored to session" in message
+
+    def test_format_session_show_renders_record_metadata(self, tmp_path):
+        from aworld_cli.console import AWorldCLI
+        from aworld_cli.core.session_store import CliSessionRecord
+
+        cli = AWorldCLI()
+        output = cli._format_session_show(
+            CliSessionRecord(
+                session_id="session_show",
+                created_at="2026-01-01T00:00:00",
+                updated_at="2026-01-01T01:00:00",
+                cwd=str(tmp_path),
+                agent_name="Aworld",
+                mode="interactive",
+                source_type="local",
+                source_location="/agents",
+                last_prompt="continue this",
+                last_task_id="task-1",
+                turn_count=2,
+            )
+        )
+
+        assert "session_show" in output
+        assert "Aworld" in output
+        assert "/agents" in output
+        assert "continue this" in output
+
+    def test_format_resume_command_hint_uses_current_session(self):
+        from aworld_cli.console import AWorldCLI
+
+        cli = AWorldCLI()
+        executor = type("Executor", (), {"session_id": "session_hint"})()
+
+        output = cli._format_resume_command_hint(executor)
+
+        assert "aworld-cli resume session_hint" in output
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary
- add aworld-cli session store, transcript replay, restore/resume core, and top-level `resume` command
- rebuild resumed session context through standard OpenAI message history and render restored terminal transcript before continuing
- harden resume prompt execution to run as a single chat turn and avoid repeat loops from malformed tool calls

## Test Plan
- pytest tests/agents/test_llm_output_parser.py tests/core/test_top_level_invocation.py tests/core/test_cli_session_restore.py tests/core/test_cli_session_store.py tests/test_prompt_logger_observability.py tests/executors/test_continuous.py tests/core/test_skill_cli.py::test_continuous_executor_can_render_prompt_as_terminal_turn -q