### PR TITLE
Document the self-evolve verification flow

### DIFF
--- a/docs/AWorld CLI/Commands/Optimize.md
+++ b/docs/AWorld CLI/Commands/Optimize.md
@@ -30,13 +30,14 @@ Verified apply for an allowlisted skill target:
 
 ```bash
 aworld-cli optimize \
-  --target skill:login \
-  --from-trajectory trajectory.log \
+  --from-trajectory ~/Documents/trajectory1.log \
   --apply auto_verified \
-  --judge-agent judges/login_quality.md \
-  --judge-model-profile judge \
-  --replay-timeout 900
+  --judge-agent ~/Documents/agent.md \
+  --judge-timeout 600 \
+  --judge-model-profile gpt-5.5
 ```
+
+`--judge-model-profile` is the name of a configured CLI model profile. It does not directly set a provider model id. Add `--target skill:<name>` when you want to bypass target inference.
 
 Drain pending post-run jobs:
 
@@ -61,7 +62,7 @@ Exactly one evaluation source is normally provided:
 - `--batch-config <path>`: batch config for a larger request.
 - `--from-run <run_id>`: previous run artifacts, usually with `--rerun-evaluator`.
 
-When `--target` is omitted, the CLI sets `infer_target=True` and the framework performs credit assignment. Low-confidence inferred targets are blocked for `auto_verified` apply.
+When `--target` is omitted, the CLI sets `infer_target=True` and the framework performs credit assignment. The inference inventory is filtered to target types with a registered CLI adapter before scoring. Phase 1 registers the `skill` adapter only, so automatic inference cannot select an unsupported `prompt-section`, `tool-description`, `config`, or `workspace-artifact` target. Low-confidence inferred targets are blocked for `auto_verified` apply.
 
 ## Replay Adaptation and Portability
 
@@ -89,11 +90,27 @@ inspection, but an evaluator-resume that could authorize verified apply requires
 replay provenance. Rerun the full optimize flow for legacy artifacts; they are not reused
 as a new strict baseline.
 
+## Candidate Generation, Repair, and Preflight
+
+The CLI builds a typed, bounded `EvolutionContext` and runs each candidate-generation slot as an isolated AWorld task. The context contains only trainable cases, bounded trace evidence, reusable lessons, capability requirements, prior validation feedback, and acceptance constraints. Candidate output must match the framework JSON package contract; a skill candidate may contain `SKILL.md`, a bounded patch intent, and candidate-owned replay files such as `replay/capability.json`, a compiler, and a runtime.
+
+The framework ranks the generated population and validates repair candidates before an expensive task rollout:
+
+1. `candidate_repair_conformance` first proves that the candidate materially changed the failed source branch and that the request operation participates in the response data flow.
+2. The candidate-owned replay capability is compiled and frozen with immutable fixture and package fingerprints. Recorded operation responses are exposed through `AWORLD_REPLAY_RESPONSE_INDEX`.
+3. Compiled probe declarations must cover the observed operation and assert a non-empty value derived from the recorded response payload.
+4. The frozen runtime is started in the replay subprocess sandbox and every declared HTTP/TCP/WebSocket readiness and protocol probe is executed. Required WebSocket probes validate handshake, ping/text exchange, operation correlation, non-empty result, and recorded-response binding.
+5. Only a candidate that passes conformance proceeds to representative screening and then the authoritative paired baseline/candidate rollout.
+
+This sequence is generic: contracts are compiled from observed operations, protocol traces, fixture provenance, and the candidate package. There is no target-specific repair adapter for one trajectory case. A source-conformant candidate can still fail at runtime preflight; that result is intentionally reported before the longer task rollout and fed into the next focused repair iteration.
+
+Candidate repair gate diagnostics are summarized in `report.json`. When execution preflight is reached, bounded service/probe artifacts are stored under `.aworld/self_evolve/<run_id>/repair_conformance/<candidate_id>/`. Increasing `--replay-timeout` affects task rollouts but does not weaken or bypass exact repair probes.
+
 ## Options
 
 - `--agent`: agent name or id used by replay/evaluator request context.
 - `--task`: task text used by framework target inference and dataset context.
-- `--target`: explicit target reference. Phase 1 CLI runs support `skill:<name>` end to end. Other target forms are framework-level roadmap types until their CLI adapters are implemented.
+- `--target`: explicit target reference. Phase 1 CLI runs support `skill:<name>` end to end. Automatic inference uses the same adapter registry and therefore considers skills only. Other target forms remain framework/SDK types until general CLI adapters are implemented.
 - `--iterations`: maximum candidate optimization iterations.
 - `--apply`: `proposal` or `auto_verified`. The default is `proposal`.
 - `--judge-agent`: markdown judge agent path.
@@ -121,7 +138,9 @@ When `--apply auto_verified` is used and the caller does not override values, th
 - `--judge-timeout 120`
 - `--baseline-replay-repetitions 2`
 - `--candidate-replay-repetitions 3`
-- `--iterations 1`
+- `--iterations 10`
+
+Proposal runs default to one iteration. `auto_verified` uses the larger budget because each verified runtime repair can expose a new protocol frontier. The runner stops early when verification succeeds or progress stalls, and it may grant up to six bounded extension iterations only for newly observed repairable failure families. Duplicate candidates and repeated failure families do not consume unbounded retries.
 
 The CLI also enables framework replay for `auto_verified`. Skill candidates must have candidate replay evidence, evaluator evidence, deterministic or objective verification signals, passing gates, and a post-apply runtime-loader check before they can remain applied.
 
@@ -147,6 +166,8 @@ Resume evaluator: aworld-cli optimize --from-run <run_id> --rerun-evaluator
 
 If replay repetitions are missing, rerun full optimize with a larger `--replay-timeout`; evaluator-only resume cannot add new replay rollouts.
 
+For an `auto_verified` release, treat the run as successful only when `report.json` has `status: "succeeded"`, no blocking failed gate, a selected candidate, and `post_apply.status: "accepted"` with `release_state: "verified"`. `status: "rejected"`, `post_apply.status: "rolled_back"`, or a missing post-apply record is not a successful verified release even if candidate generation or source conformance passed.
+
 ## Report Files
 
 Open `.aworld/self_evolve/<run_id>/report.json` for the release-facing result:
@@ -157,6 +178,7 @@ Open `.aworld/self_evolve/<run_id>/report.json` for the release-facing result:
 - `gate_results`: low-level gate decisions.
 - `release_checklist`: grouped release checks derived from gates.
 - `content_quality_diagnostics`: non-blocking publication/content quality diagnostics when evaluator metrics provide them.
+- `population`: generated candidates, representative screening attempts, selection reason, focused repair telemetry, concurrency, and candidate-generation token usage.
 - `optimizer_lineage`: candidate lineage artifact links, including content, semantic, and lesson-set fingerprints when available.
 - `lessons`: normalized lesson artifact links and counts.
 - `harness_diagnostics`: advisory framework diagnostic artifact links and counts.
@@ -165,8 +187,11 @@ Open `.aworld/self_evolve/<run_id>/report.json` for the release-facing result:
 - `replay.adaptation`: adaptation readiness plus workspace, environment, task, dataset, and current-skill fingerprints for completed paired replay.
 - `evaluator_report_paths`: evaluator output artifacts.
 - `post_apply`: accepted or rolled-back apply details, backup path, journal path, runtime activation, and registry refresh status.
+- `artifact_retention`: merged startup/terminal cleanup result, including policy, protected runs, skipped runs, and removed paths.
 
-Candidate files and diffs live under `.aworld/self_evolve/<run_id>/candidates/`. For skill candidates, proposal content is marked with `self_evolve.release_state: candidate`; verified content is marked with `self_evolve.release_state: verified` only after post-apply checks pass. Candidate JSON records are durable. After a run leaves the complete-artifact retention window, redundant Markdown, diff, and expanded package copies for unselected candidates may be reclaimed while selected, applied, and lineage-parent candidates remain intact.
+Candidate files and diffs live under `.aworld/self_evolve/<run_id>/candidates/`. For skill candidates, proposal content is marked with `self_evolve.release_state: candidate`; verified content is marked with `self_evolve.release_state: verified` only after post-apply checks pass. `<candidate_id>.json` is the durable normalized record; `<candidate_id>/` is the expanded multi-file materialization. After a run leaves the complete-artifact retention window, redundant Markdown, diff, and expanded package copies for unselected candidates may be reclaimed while selected, applied, and lineage-parent candidates remain intact.
+
+Repair preflight artifacts live under `.aworld/self_evolve/<run_id>/repair_conformance/<candidate_id>/`. They contain bounded frozen-capability and service/probe diagnostics for failures that occurred before task rollout.
 
 Replay adaptation artifacts live under
 `.aworld/self_evolve/<run_id>/replay_adaptation/<dataset_fingerprint>/`. The directory
@@ -178,6 +203,8 @@ Artifact GC runs at optimize startup and terminal completion. It preserves the t
 newest runs, lineage and apply recovery dependencies, and runs with a live process
 lease. Raw replay, replay-adaptation, repair-conformance, evaluator, overlay, and
 temporary-workspace artifacts from older eligible runs are reclaimed.
+
+The default store is `<workspace>/.aworld/self_evolve`. The framework does not create or manage a top-level `self_evolve_artifacts/` directory.
 
 ## Runtime Skill Management
 
@@ -196,7 +223,7 @@ aworld-cli skill remove <skill-name>
 
 ## Boundaries
 
-The CLI does not infer targets itself. `--task` without `--target` delegates target selection to framework credit assignment. If inference selects a target type without a phase-1 CLI adapter, the request is persisted as an unsupported-target result rather than applied.
+The CLI does not score targets itself. `--task` without `--target` delegates target selection to framework credit assignment after the framework filters the inventory through the CLI adapter registry. This prevents an unsupported target type from winning inference. An explicitly requested unsupported target is rejected; adding a general tested adapter is the extension path, not adding a trajectory-specific exception.
 
 The CLI also does not own scheduler behavior, evaluator behavior, optimizer semantics, durable job formats, or agent opt-in configuration. Configure opt-in with `AgentConfig.self_evolve_config`, then use this command as a manual/debug entrypoint for the same framework APIs.
 

--- a/docs/Agents/Self Evolve.md
+++ b/docs/Agents/Self Evolve.md
@@ -1,6 +1,6 @@
 # Self Evolve
 
-Self-evolve is a framework-owned capability for improving agent-facing harness artifacts from observed task trajectories. Phase 1 is intentionally narrow: it proposes and verifies changes to harness text and configuration surfaces, especially skills. It does not mutate AWorld framework code, runtime code, CLI code, dependency manifests, secrets, or repository product logic.
+Self-evolve is a framework-owned capability for improving agent-facing harness artifacts from observed task trajectories. Phase 1 is intentionally narrow: it proposes and verifies changes to skills and other harness surfaces. A skill candidate may be a multi-file package containing `SKILL.md` plus skill-owned replay compiler/runtime files, but self-evolve does not mutate AWorld framework/runtime/CLI product code, dependency manifests, secrets, or unrelated repository logic.
 
 The capability is disabled by default. Agents opt in through `AgentConfig.self_evolve_config`, `aworld-cli --evolve` can enable it for the current CLI runtime session, and `aworld-cli optimize` provides an explicit manual/debug entrypoint for release operators and developers.
 
@@ -8,11 +8,12 @@ The capability is disabled by default. Agents opt in through `AgentConfig.self_e
 
 Self-evolve works on target references rather than arbitrary files. A target records the artifact type, id, optional path, and provenance used by the framework gates.
 
-Phase 1 target support:
+The framework target model represents several artifact types, but target representation and CLI execution support are separate:
 
 - `skill:<name>`: available end to end for proposal runs and verified apply when the target is allowlisted.
-- `workspace-artifact:<path>`: available for proposal preservation when the path is outside protected product roots.
-- `prompt-section:<id>`, `tool-description:<id>`, and `config:<id>`: represented as target types, but treated as skeleton/roadmap targets until adapters are implemented and covered by tests.
+- `workspace-artifact:<path>`, `prompt-section:<id>`, `tool-description:<id>`, and `config:<id>`: available as framework/SDK target types, but do not currently have phase-1 `aworld-cli optimize` adapters.
+
+Automatic CLI target inference is adapter-aware. Before credit assignment, the framework filters the target inventory to target types with a registered CLI adapter. With the phase-1 registry, inference considers skill targets only; it cannot select an unsupported target such as `prompt-section:result-validation-anchor-policy`. This is a capability-level rule rather than a special case for one trajectory. An explicitly requested unsupported CLI target is rejected instead of being silently rewritten to another type.
 
 Protected areas include AWorld framework/runtime/CLI code, dependency files, package metadata, and protected built-in skills such as `app_evaluator` and `self_evolve`.
 
@@ -20,16 +21,75 @@ Protected areas include AWorld framework/runtime/CLI code, dependency files, pac
 
 Self-evolve follows a proposal-first pipeline:
 
+<pre class="mermaid">
+flowchart TD
+    A["Trajectory / Evaluation Evidence"] --> B["Dataset Recipe&lt;br/&gt;Trainable + Held-out"]
+    B --> C["Adapter-aware Target Selection"]
+    C --> D["Bounded EvolutionContext"]
+    D --> E["CandidateGenerationAgent&lt;br/&gt;Candidate Population"]
+
+    E --> F["Shape / Package / Provenance Gates"]
+    F -->|Repairable candidate failure| R["Focused Candidate Repair"]
+    F -->|Non-repairable rejection| P["Preserve Proposal and Diagnostics"]
+    R --> E
+
+    F -->|Pass| G["Replay Adaptation"]
+    G -->|Unresolved dependency| P
+    G -->|Ready| H["Source Conformance"]
+    H -->|Fail| R
+    H -->|Pass| I["Compile and Freeze Capability"]
+    I -->|Fail| R
+    I -->|Pass| J["Exact Protocol Preflight&lt;br/&gt;HTTP / TCP / WebSocket"]
+    J -->|Fail| R
+
+    J -->|Pass| K["Representative Screening"]
+    K --> L["Authoritative Paired Replay&lt;br/&gt;Baseline vs Candidate"]
+    L --> M["Judge / Held-out / Regression Gates"]
+    M -->|Repairable candidate failure| R
+    M -->|Rejected| P
+    M -->|Pass| N{"Apply Policy"}
+
+    N -->|proposal| P
+    N -->|auto_verified| O["Backup and Apply"]
+    O --> Q["Runtime-loader Verification"]
+    Q -->|Fail| S["Rollback"]
+    Q -->|Pass| T["Verified Release&lt;br/&gt;status: succeeded"]
+</pre>
+
+The loop makes three boundaries visible: target selection is limited by registered adapters, inexpensive candidate/protocol checks run before authoritative rollout, and only a fully verified `auto_verified` candidate can modify the target. Proposal preservation and rollback remain valid terminal outcomes rather than being treated as successful releases.
+
 1. Collect trajectory or evaluation evidence from a current run, trajectory log, session, JSONL dataset, or batch config.
 2. Build a dataset recipe with trainable and held-out cases. Candidate optimizers see trainable evidence only.
-3. Select a target explicitly from `--target` or infer one through framework credit assignment.
-4. Generate one or more candidate variants through a `CandidateOptimizer`.
-5. Preserve candidates and diffs under `.aworld/self_evolve/<run_id>/`.
-6. Run shape, provenance, budget, evidence, replay, evaluator, and regression gates.
-7. Keep the result as a proposal, or, for `auto_verified`, apply only after verification passes.
-8. Re-evaluate the applied artifact through the runtime loader and roll back if post-apply verification fails.
+3. Select a target explicitly from `--target` or infer one through adapter-filtered framework credit assignment.
+4. Build a typed, bounded `EvolutionContext` containing target state, trainable evidence, reusable lessons, capability requirements, prior validation feedback, and acceptance constraints.
+5. Generate and normalize a population of candidate variants with an AWorld-native `CandidateGenerationAgent`; skill candidates may use a bounded patch intent or a multi-file package.
+6. Preserve candidate JSON, materialized content, diffs, lineage, and diagnostics under `.aworld/self_evolve/<run_id>/`.
+7. Run candidate shape, source conformance, provenance, budget, replay adaptation, protocol preflight, paired replay, evaluator, and regression gates.
+8. Feed machine-readable candidate failures back into a focused repair iteration without treating the model rationale as proof of a fix.
+9. Keep the result as a proposal, or, for `auto_verified`, apply only after verification passes.
+10. Re-evaluate the applied artifact through the runtime loader and roll back if post-apply verification fails.
 
 This keeps the self-evolve loop outside the task response path. Post-run scheduling is best effort: a failed enqueue is logged and does not change the completed `TaskResponse`.
+
+### Candidate Generation and Focused Repair
+
+Each candidate-generation slot runs as an isolated AWorld task with one model call, no tools, model-aware input/output budgeting, and a typed JSON output contract. Candidate packages are normalized before they enter the population. Malformed but repairable model output receives one bounded representation-repair attempt; provider/runtime failures remain infrastructure failures and are not misclassified as bad candidates.
+
+The default proposal budget is one optimizer iteration. `auto_verified` defaults to ten iterations because runtime-backed repairs often expose the next protocol boundary only after the previous one is corrected. The runner stops when it has a verified candidate or no new progress is possible. It may grant a bounded extension for a newly observed repairable failure family, up to six extension iterations, rather than looping on duplicate candidates or the same failed branch.
+
+Once a concrete candidate has failed, the next repair prompt switches to `focused_candidate_delta` mode. It includes the failed candidate package, bounded machine-readable diagnostics, the relevant source branches, and the repair acceptance contract. Broad trajectory, lesson, and current-target payloads are omitted from that repair prompt so the model edits the observed failure frontier instead of regenerating the whole skill.
+
+### Layered Repair Conformance
+
+For a repairable skill-owned replay failure, the framework validates a candidate in layers before paying for an authoritative task rollout:
+
+1. **Source conformance** requires a material change to the failed compiler/runtime branch. It rejects rationale-only changes, deleted handlers, global fixture fallbacks, request-independent responses, response-index metadata traversal, and compiler/runtime selector drift.
+2. **Compile and freeze** rebuilds the candidate-owned replay capability, verifies fixture provenance and immutable package fingerprints, and constructs an operation-indexed recorded response map exposed to the runtime as `AWORLD_REPLAY_RESPONSE_INDEX`.
+3. **Probe conformance** requires the declared HTTP/TCP/WebSocket probe to cover the observed operation and to assert a non-empty scalar derived from the recorded response payload, not a mapping key, request token, placeholder, hash, or control-plane handshake.
+4. **Execution preflight** starts the frozen service in the replay subprocess sandbox and executes every declared readiness/protocol probe. WebSocket probes validate the upgrade, ping/text exchange, operation correlation, non-empty result, and recorded-response binding when required.
+5. **Representative screening** runs one bounded baseline/candidate pair only after conformance passes. Screening is a cost filter, not acceptance evidence; an inconclusive baseline preserves the ranked population for authoritative replay.
+
+Failures in the first four layers are reported through the `candidate_repair_conformance` gate. When execution preflight is reached, bounded service/probe artifacts are stored under `repair_conformance/<candidate_id>/`. The failure becomes generic repair feedback for the next iteration and does not enter the full task rollout. The contracts are derived from observed operations, package structure, fixture provenance, and protocol traces; they do not contain target-specific fixes for a particular training case.
 
 ### Three-Trajectory Replay Model
 
@@ -178,14 +238,14 @@ Run verified apply for an allowlisted skill target:
 
 ```bash
 aworld-cli optimize \
-  --target skill:login \
-  --from-trajectory ./trajectory.log \
+  --from-trajectory ~/Documents/trajectory1.log \
   --apply auto_verified \
-  --judge-agent ./judges/login_quality.md \
-  --replay-timeout 900 \
-  --baseline-replay-repetitions 2 \
-  --candidate-replay-repetitions 3
+  --judge-agent ~/Documents/agent.md \
+  --judge-timeout 600 \
+  --judge-model-profile gpt-5.5
 ```
+
+`--judge-model-profile` names a model profile from the CLI configuration; it does not bypass profile resolution or directly set a provider model id. Add `--target skill:<name>` when target selection must be explicit. Without it, adapter-aware credit assignment selects only an eligible CLI target.
 
 Drain pending post-run jobs from `shadow` or `online` mode:
 
@@ -317,7 +377,9 @@ Each run writes durable artifacts under `.aworld/self_evolve/<run_id>/`:
 - `target_selection.json`: credit-assignment decision, confidence, and target inference signals.
 - `target_provenance.json`: provenance for the selected target when available.
 - `candidates/<candidate_id>.md`: runtime-only candidate content. Skill candidates are marked with `self_evolve.release_state: candidate`; task ids, evidence ids, gate names, scores, and prior feedback remain in lineage and lesson artifacts.
+- `candidates/<candidate_id>.json`: durable normalized candidate record. This is the canonical fallback for audit, `--from-run`, and historical repair after redundant materializations are reclaimed.
 - `candidates/<candidate_id>.diff`: unified diff against the current target, when the target adapter supports diffs.
+- `candidates/<candidate_id>/`: expanded multi-file candidate skill package, including candidate-owned replay files when present.
 - `optimizer_lineage/<candidate_id>.json`: optimizer name/version, parents, trainable cases, content fingerprint, semantic fingerprint, lesson-set fingerprint, addressed lesson ids, and rationale.
 - `lessons/lessons.jsonl`: normalized failure memories, success memories, and required runtime behavior records extracted from evaluation feedback.
 - `diagnostics/harness_diagnostics.jsonl`: advisory framework diagnostics for replay, evidence, evaluator, memory, permission-boundary, and artifact-lifecycle issues. These records are intentionally separate from runtime skill instructions.
@@ -328,6 +390,9 @@ Each run writes durable artifacts under `.aworld/self_evolve/<run_id>/`:
 - `replay_adaptation/<dataset_fingerprint>/workspace_seed/`: filtered immutable replay seed verified before every rollout copy.
 - `replay_adaptation/<dataset_fingerprint>/workspace_manifest.json`: relative paths, modes, sizes, and SHA-256 digests for seed files.
 - `replay_adaptation/<dataset_fingerprint>/environment_snapshot.json`: bounded non-secret runtime, locale, platform, and observed tool metadata used in the adaptation fingerprint.
+- `repair_conformance/<candidate_id>/`: bounded service stdout/stderr, probe traces, and frozen-capability diagnostics produced by pre-rollout repair validation.
+- `population` in `report.json`: candidate generation, screening attempts, selection reason, repair telemetry, and token/concurrency usage.
+- `artifact_retention` in `report.json`: cleanup policy, protected runs, skipped runs, and removed paths from startup and terminal cleanup.
 
 Artifact retention runs both when a self-evolve run starts and when it reaches a
 terminal report. The two newest runs, lineage-referenced runs, interrupted apply
@@ -337,6 +402,8 @@ overlay, and temporary-workspace data. Candidate JSON records remain durable so
 `--from-run` and audit tooling can reconstruct a candidate; only redundant Markdown,
 diff, and expanded package copies for unselected candidates are pruned. A non-terminal
 run without a live lease becomes eligible only after the stale-run retention window.
+
+The default store is always rooted at `<workspace>/.aworld/self_evolve`; it does not create a top-level `self_evolve_artifacts/` directory. A pre-existing directory with that name is not managed or deleted by framework GC.
 
 Trajectory-set runs may also include framework-owned trajectory-set and population artifacts:
 
@@ -371,7 +438,7 @@ Best candidate: cand-1
 
 Checklist groups:
 
-- Candidate shape: no-op, malformed markdown, protected path, provenance, token limit, target type, and external code-evolution checks.
+- Candidate shape: no-op, malformed markdown, candidate package protocol, protected path, provenance, token limit, target type, external code-evolution, and focused repair-conformance checks.
 - Quality improvement: score improvement, replay stability, and replay confidence.
 - Cost and latency: replay/evaluator cost and budget regression checks.
 - Evidence integrity: evidence quality, candidate replay, and judge-only signal checks.
@@ -416,6 +483,9 @@ Domain-specific learned skills, such as a grounding or media-comprehension skill
 - `auto_verified apply policy requires a candidate`: the optimizer produced no non-noop candidate, so replay/evaluation/apply were skipped.
 - `auto_verified self-evolve requires an evaluation backend`: pass `--judge-agent`, `--judge-agent-name`, `--judge-backend-ref`, or use a framework evaluator backend.
 - `auto_verified skill apply requires candidate replay backend`: verified apply requires replay evidence for skill candidates.
+- Target inference selected no target: inspect `target_selection.json`. Phase-1 CLI inference considers only registered adapters, currently `skill`; add an explicit `skill:<name>` target or install/implement a general adapter rather than adding a trajectory-specific target exception.
+- `candidate_repair_conformance` failed: inspect the gate `code`, `repair_conformance` contract, and `repair_conformance/<candidate_id>/` diagnostics. A passing source check is not sufficient when the compiled runtime fails its exact protocol probe.
+- `repair_probe_execution_failed`: the frozen candidate service failed readiness, handshake, request/response correlation, non-empty-result, or recorded-response validation before task rollout. Repair the candidate-owned runtime or compiler; increasing `--replay-timeout` does not fix this preflight contract.
 - Judge timeout after replay completed: rerun `aworld-cli optimize --from-run <run_id> --rerun-evaluator`.
 - Missing replay repetitions or replay timeout: rerun full optimize with a higher `--replay-timeout`; evaluator-only resume cannot create new replay evidence.
 - `replay_adaptation requires unavailable context or dependencies`: inspect the gate details and `replay_adaptation/.../bundle.json`; provide a bounded fixture/adapter or keep the result proposal-only.

--- a/docs/css/aworld.css
+++ b/docs/css/aworld.css
@@ -1711,6 +1711,19 @@ body {
   border: 1px solid var(--aw-border);
 }
 
+/* Mermaid diagrams */
+.md-typeset .mermaid {
+  overflow-x: auto;
+  padding: 1rem 0;
+  background: transparent;
+  text-align: center;
+}
+
+.md-typeset .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
 /* ============================================
    Accessibility Enhancements
    ============================================ */

--- a/docs/js/mermaid.js
+++ b/docs/js/mermaid.js
@@ -1,0 +1,60 @@
+(function () {
+  const mermaidSource =
+    "https://unpkg.com/mermaid@11.16.0/dist/mermaid.min.js";
+  let initialized = false;
+  let mermaidPromise;
+
+  const loadMermaid = () => {
+    if (window.mermaid) {
+      return Promise.resolve(window.mermaid);
+    }
+    if (mermaidPromise) {
+      return mermaidPromise;
+    }
+
+    mermaidPromise = new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = mermaidSource;
+      script.async = true;
+      script.addEventListener("load", () => resolve(window.mermaid));
+      script.addEventListener("error", () => {
+        mermaidPromise = undefined;
+        reject(new Error("Unable to load Mermaid"));
+      });
+      document.head.appendChild(script);
+    });
+    return mermaidPromise;
+  };
+
+  const renderMermaid = () => {
+    if (!document.querySelector(".mermaid:not([data-processed])")) {
+      return;
+    }
+
+    loadMermaid()
+      .then((mermaid) => {
+        if (!mermaid) {
+          throw new Error("Mermaid loaded without exposing its API");
+        }
+        if (!initialized) {
+          mermaid.initialize({
+            startOnLoad: false,
+            securityLevel: "strict",
+          });
+          initialized = true;
+        }
+        return mermaid.run({
+          querySelector: ".mermaid:not([data-processed])",
+        });
+      })
+      .catch((error) => console.error("Unable to render Mermaid diagram", error));
+  };
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(renderMermaid);
+  } else if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderMermaid);
+  } else {
+    renderMermaid();
+  }
+})();

--- a/docs/outline.py
+++ b/docs/outline.py
@@ -164,6 +164,7 @@ if __name__ == '__main__':
         "copyright": "\u00A9 Copyright 2025 inclusionAI AWorld Team.",
         "extra_css": ["css/aworld.css"],
         "extra_javascript": [
+            "js/mermaid.js",
             "js/hide-home-edit.js",
             "js/aworld-enhancements.js",
             "js/github-stars.js",


### PR DESCRIPTION
## Summary

- refresh the public Self Evolve and Optimize documentation to match the current adapter-aware target inference, candidate generation, focused repair, replay preflight, artifact retention, and verified-apply behavior
- add a core execution-loop diagram covering candidate repair, exact protocol probes, authoritative paired replay, proposal preservation, apply, and rollback
- add responsive Mermaid styling and a lazy, pinned Mermaid loader that runs only on pages containing diagrams and supports Material instant navigation

## Why

The existing documentation no longer fully described the latest self-evolve execution model. In particular, it did not make clear that CLI target inference is filtered by registered adapters, that source conformance alone does not satisfy runtime protocol probes, or that expensive task rollout is preceded by layered repair validation. The end-to-end control flow was also difficult to understand from prose alone.

## Impact

Readers can now distinguish candidate generation, focused repair, protocol preflight, paired replay, judge gates, verified apply, and rollback at a glance. The docs also record the current `auto_verified` defaults, report success criteria, `.aworld/self_evolve` artifact layout, and safe cleanup semantics. Mermaid is loaded on demand so pages without diagrams do not incur the dependency cost.

## Validation

- `node --check docs/js/mermaid.js`
- regenerated docs navigation with `conda run -n aworld_env python docs/outline.py`
- parsed generated `mkdocs.yml` and verified Mermaid loader ordering
- validated the diagram source and pinned Mermaid 11.16.0 CDN endpoint
- `git diff --check`
- related Optimize CLI, lifecycle, and repair-conformance tests: 78 passed